### PR TITLE
Revert "rm creator. Fixes UIIN-30"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 * Dependency on inventory: 3.0
 * Use PropTypes, not React.PropTypes. STRIPES-427.
 * Validation. Fixes UIIN-19.
-* Remove creator; use contributor exclusively. UIIN-30.
 
 ## [1.0.0](https://github.com/folio-org/ui-instances/tree/v1.0.0) (2017-09-08)
 [Full Changelog](https://github.com/folio-org/ui-items/compare/v0.0.1...v1.0.0)

--- a/Instances.js
+++ b/Instances.js
@@ -53,6 +53,11 @@ class Instances extends React.Component {
       records: 'identifierTypes',
       path: 'identifier-types?limit=100',
     },
+    creatorTypes: {
+      type: 'okapi',
+      records: 'creatorTypes',
+      path: 'creator-types?limit=100',
+    },
     contributorTypes: {
       type: 'okapi',
       records: 'contributorTypes',
@@ -169,6 +174,7 @@ class Instances extends React.Component {
   render() {
     const { stripes, okapi, match, resources, location } = this.props;
     const instances = (resources.instances || emptyObj).records || emptyArr;
+    const creatorTypes = (resources.creatorTypes || emptyObj).records || emptyArr;
     const contributorTypes = (resources.contributorTypes || emptyObj).records || emptyArr;
     const identifierTypes = (resources.identifierTypes || emptyObj).records || emptyArr;
     const classificationTypes = (resources.classificationTypes || emptyObj).records || emptyArr;
@@ -182,7 +188,7 @@ class Instances extends React.Component {
     const resultsFormatter = {
       identifiers: r => utils.identifiersFormatter(r, identifierTypes),
       publishers: r => r.publication.map(p => p.publisher).join(', '),
-      contributors: r => utils.contributorsFormatter(r, contributorTypes),
+      creators: r => utils.creatorsFormatter(r, creatorTypes),
       'publication date': r => r.publication.map(p => p.dateOfPublication).join(', '),
     };
     const maybeTerm = this.state.searchTerm ? ` for "${this.state.searchTerm}"` : '';
@@ -213,7 +219,7 @@ class Instances extends React.Component {
             onRowClick={this.onSelectRow}
             onHeaderClick={this.onSort}
             onNeedMoreData={this.onNeedMore}
-            visibleColumns={['title', 'contributors', 'identifiers', 'publishers', 'publication date']}
+            visibleColumns={['title', 'creators', 'identifiers', 'publishers', 'publication date']}
             sortOrder={this.state.sortOrder.replace(/^-/, '').replace(/,.*/, '')}
             sortDirection={this.state.sortOrder.startsWith('-') ? 'descending' : 'ascending'}
             isEmptyMessage={`No results found${maybeTerm}. Please check your ${maybeSpelling}filters.`}
@@ -235,6 +241,7 @@ class Instances extends React.Component {
             onSubmit={(record) => { this.createInstance(record); }}
             onCancel={this.closeNewInstance}
             okapi={okapi}
+            creatorTypes={creatorTypes}
             contributorTypes={contributorTypes}
             identifierTypes={identifierTypes}
             classificationTypes={classificationTypes}

--- a/ViewInstance.js
+++ b/ViewInstance.js
@@ -33,6 +33,11 @@ class ViewInstance extends React.Component {
       records: 'identifierTypes',
       path: 'identifier-types?limit=100',
     },
+    creatorTypes: {
+      type: 'okapi',
+      records: 'creatorTypes',
+      path: 'creator-types?limit=100',
+    },
     contributorTypes: {
       type: 'okapi',
       records: 'contributorTypes',
@@ -98,6 +103,7 @@ class ViewInstance extends React.Component {
     if (!selectedInstance || !instanceid) return <div />;
     const instance = selectedInstance.find(i => i.id === instanceid);
     const identifierTypes = (resources.identifierTypes || emptyObj).records || emptyArr;
+    const creatorTypes = (resources.creatorTypes || emptyObj).records || emptyArr;
     const contributorTypes = (resources.contributorTypes || emptyObj).records || emptyArr;
     const instanceFormats = (resources.instanceFormats || emptyObj).records || emptyArr;
     const instanceTypes = (resources.instanceTypes || emptyObj).records || emptyArr;
@@ -135,6 +141,11 @@ class ViewInstance extends React.Component {
         <Row>
           <Col xs={12}>
             <KeyValue label="Identifiers" value={utils.identifiersFormatter(instance, identifierTypes)} />
+          </Col>
+        </Row>
+        <Row>
+          <Col xs={12}>
+            <KeyValue label="Creators" value={utils.creatorsFormatter(instance, creatorTypes)} />
           </Col>
         </Row>
         <Row>
@@ -193,6 +204,7 @@ class ViewInstance extends React.Component {
             onSubmit={(record) => { this.update(record); }}
             initialValues={instance}
             onCancel={this.closeEditInstance}
+            creatorTypes={creatorTypes}
             contributorTypes={contributorTypes}
             identifierTypes={identifierTypes}
             classificationTypes={classificationTypes}

--- a/edit/InstanceForm.js
+++ b/edit/InstanceForm.js
@@ -12,6 +12,7 @@ import Select from '@folio/stripes-components/lib/Select';
 
 import renderAlternativeTitles from './alternativeTitles';
 import renderSeries from './seriesFields';
+import renderCreators from './creatorFields';
 import renderContributors from './contributorFields';
 import renderSubjects from './subjectFields';
 import renderIdentifiers from './identifierFields';
@@ -86,6 +87,7 @@ function InstanceForm(props) {
     onCancel,
     initialValues,
     identifierTypes,
+    creatorTypes,
     contributorTypes,
     classificationTypes,
     instanceTypes,
@@ -130,6 +132,7 @@ function InstanceForm(props) {
           <FieldArray name="series" component={renderSeries} />
 
           <FieldArray name="identifiers" component={renderIdentifiers} identifierTypes={identifierTypes} />
+          <FieldArray name="creators" component={renderCreators} creatorTypes={creatorTypes} />
           <FieldArray name="contributors" component={renderContributors} contributorTypes={contributorTypes} />
           <FieldArray name="subjects" component={renderSubjects} />
           <FieldArray name="classifications" component={renderClassifications} classificationTypes={classificationTypes} />
@@ -175,6 +178,7 @@ InstanceForm.propTypes = {
   submitting: PropTypes.bool,
   onCancel: PropTypes.func,
   initialValues: PropTypes.object,
+  creatorTypes: PropTypes.arrayOf(PropTypes.object),
   contributorTypes: PropTypes.arrayOf(PropTypes.object),
   identifierTypes: PropTypes.arrayOf(PropTypes.object),
   classificationTypes: PropTypes.arrayOf(PropTypes.object),

--- a/edit/creatorFields.js
+++ b/edit/creatorFields.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Row, Col } from 'react-flexbox-grid';
+import Button from '@folio/stripes-components/lib/Button';
+import TextField from '@folio/stripes-components/lib/TextField';
+import Select from '@folio/stripes-components/lib/Select';
+import { Field } from 'redux-form';
+
+const renderCreators = ({ fields, meta: { touched, error, submitFailed }, creatorTypes }) => (
+  <div>
+    <Row>
+      <Col sm={2} smOffset={4}>
+        <Button type="button" buttonStyle="fullWidth secondary" id="clickable-add-creator" onClick={() => fields.push()}>Add Creator *</Button>
+        {(touched || submitFailed) && error && <span>{error}</span>}
+      </Col>
+    </Row>
+    {fields.map((creator, index) => {
+      const creatorTypeOptions = creatorTypes.map(
+                                        it => ({
+                                          label: it.name,
+                                          value: it.id,
+                                          selected: it.id === creator.creatorTypeId,
+                                        }));
+      return (
+        <Row key={index}>
+          <Col sm={2} smOffset={1}>
+            <Field
+              name={`${creator}.name`}
+              id={`input_creator_name_${index}`}
+              type="text"
+              component={TextField}
+              label={index === 0 ? 'Creator *' : null}
+            />
+          </Col>
+          <Col sm={1}>
+            <Field
+              name={`${creator}.creatorTypeId`}
+              id={`select_creator_type_${index}`}
+              type="text"
+              component={Select}
+              label={index === 0 ? 'Type of name *' : null}
+              dataOptions={[{ label: 'Select creator name type', value: '' }, ...creatorTypeOptions]}
+            />
+          </Col>
+          <Col sm={1} smOffset={1}>
+            { index === 0 ? <br /> : null }
+            <Button
+              buttonStyle="fullWidth secondary"
+              type="button"
+              title={`Remove Creator ${index + 1}`}
+              onClick={() => fields.remove(index)}
+            >Delete creator</Button>
+          </Col>
+        </Row>
+      );
+    })}
+  </div>
+);
+renderCreators.propTypes = { fields: PropTypes.object, meta: PropTypes.object, creatorTypes: PropTypes.arrayOf(PropTypes.object) };
+
+export default renderCreators;

--- a/test/ui-testing/new_title.js
+++ b/test/ui-testing/new_title.js
@@ -50,8 +50,12 @@ module.exports.test = function(uiTestCtx) {
 	.wait(55)
 	.insert('input[name="identifiers[1].value', isbn)
 	.type('select[name="identifiers[1].identifierTypeId', 'ii')
+        .click('#clickable-add-creator')
+	.wait(55)
+        .insert('#input_creator_name_0', author)
+        .type('#select_creator_type_0', 'P')
+        .type('#select_instance_type', 'B')
 	.click('#clickable-add-contributor')
-  .wait(55)
 	.insert('input[name="contributors[0].name"', contrib)
 	.type('select[name="contributors[0].contributorTypeId"]', 'r')
         .click('#clickable-add-subject')
@@ -92,7 +96,7 @@ module.exports.test = function(uiTestCtx) {
 	.wait(2222)
         .then(result => { done() } )
 	.catch(done)
-      })
+      }) 
       it('should find new title in list ', done => {
         nightmare
         .wait('#list-instances')
@@ -110,3 +114,4 @@ module.exports.test = function(uiTestCtx) {
     })
   })
 }
+

--- a/utils.js
+++ b/utils.js
@@ -21,6 +21,20 @@ export default {
     return formatted;
   },
 
+  creatorsFormatter: (r, creatorTypes) => {
+    let formatted = '';
+    if (r.creators && r.creators.length) {
+      for (let i = 0; i < r.creators.length; i += 1) {
+        const creator = r.creators[i];
+        const type = creatorTypes.find(ct => ct.id === creator.creatorTypeId);
+        formatted += (i > 0 ? ', ' : '') +
+                     creator.name +
+                     (type ? ` (${type.name})` : '');
+      }
+    }
+    return formatted;
+  },
+
   contributorsFormatter: (r, contributorTypes) => {
     let formatted = '';
     if (r.contributors && r.contributors.length) {


### PR DESCRIPTION
Reverts folio-org/ui-inventory#16

We do _eventually_ want to remove the `creator` field list, but currently it's still required by the backend. Jumped the gun a bit. 