### PR TITLE
correct fieldname for language filter. Refs UIIN-32

### DIFF
--- a/Instances.js
+++ b/Instances.js
@@ -52,7 +52,7 @@ const filterConfig = [
   {
     label: 'Language',
     name: 'language',
-    cql: 'languages.code',
+    cql: 'languages',
     values: languages.map(rec => ({ name: rec.name, cql: rec.code })),
   },
   {


### PR DESCRIPTION
use "languages", not "languages.code" for the CQL. See
https://github.com/folio-org/cql2pgjson-java. I'm not entirely sure why
the "code" attribute isn't required since that's how the field is
defined in the results, but perhaps the fieldname is pushed all through
to the joined table? Dunno, but this works, so here we are.