### PR TITLE
Pass escape sequence through to CQL. Fixes UIIN-55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Adding `<Notes>`. Fixes UIIN-10. 
 * Adding search by Location. Refs UIIN-3.
 * Sort lookup tables server side because it's the right thing to do. 
+* Pass escape sequences on to CQL. Fixes UIIN-55.  
 
 ## [1.0.0](https://github.com/folio-org/ui-instances/tree/v1.0.0) (2017-09-08)
 [Full Changelog](https://github.com/folio-org/ui-items/compare/v0.0.1...v1.0.0)

--- a/Instances.js
+++ b/Instances.js
@@ -85,7 +85,7 @@ class Instances extends React.Component {
               Contributors: 'contributors',
             };
 
-            let cql = `(title="${resourceData.query.query}*" or contributors adj "name": "${resourceData.query.query}*" or identifiers adj "value": "${resourceData.query.query}*")`;
+            let cql = `(title="${resourceData.query.query}*" or contributors adj "\\"name\\": \\"${resourceData.query.query}*\\"" or identifiers adj "\\"value\\": \\"${resourceData.query.query}*\\"")`;
             const filterCql = filters2cql(filterConfig, resourceData.query.filters);
             if (filterCql) {
               if (cql) {


### PR DESCRIPTION
In a CQL join clause, the entire clause must be quoted and the pieces of each clause should be quoted and escaped. Because the query is generated in JavaScript, we need to pass through the literal escape string, i.e. backslash-quote, to CQL. 