### PR TITLE
Correctly close 'Add holdings' pane. Fixes UIIN-54.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Adding search by Location. Refs UIIN-3.
 * Sort lookup tables server side because it's the right thing to do. 
 * Pass escape sequences on to CQL. Fixes UIIN-55.  
+* Close "Add holdings" pane correctly. Fixes UIIN-54.
 
 ## [1.0.0](https://github.com/folio-org/ui-instances/tree/v1.0.0) (2017-09-08)
 [Full Changelog](https://github.com/folio-org/ui-items/compare/v0.0.1...v1.0.0)

--- a/edit/holdings/HoldingsForm.js
+++ b/edit/holdings/HoldingsForm.js
@@ -57,7 +57,7 @@ function HoldingsForm(props) {
   return (
     <form>
       <Paneset isRoot>
-        <Pane defaultWidth="100%" dismissible onClick={onCancel} lastMenu={initialValues.id ? editHoldingsLastMenu : addHoldingsLastMenu} paneTitle={initialValues.title ? 'Edit Holdings' : 'New Holdings Record'}>
+        <Pane defaultWidth="100%" dismissible onClose={onCancel} lastMenu={initialValues.id ? editHoldingsLastMenu : addHoldingsLastMenu} paneTitle={initialValues.title ? 'Edit Holdings' : 'New Holdings Record'}>
           <Row>
             <Col sm={5} smOffset={1}>
               <h2>Holdings Record</h2>


### PR DESCRIPTION
Bug fix for [UIIN-54](https://issues.folio.org/browse/UIIN-54).  A `<Pane>` uses the attribute `onClose`, not `onClick`, to accept its on-close callback. 