### PR TITLE
Sort contributor types correctly. Refs UIIN-32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Sort lookup tables server side because it's the right thing to do. 
 * Pass escape sequences on to CQL. Fixes UIIN-55.  
 * Close "Add holdings" pane correctly. Fixes UIIN-54.
+* Sort contributor-types correctly. Refs UIIN-32. 
 
 ## [1.0.0](https://github.com/folio-org/ui-instances/tree/v1.0.0) (2017-09-08)
 [Full Changelog](https://github.com/folio-org/ui-items/compare/v0.0.1...v1.0.0)

--- a/Instances.js
+++ b/Instances.js
@@ -128,7 +128,7 @@ class Instances extends React.Component {
     contributorTypes: {
       type: 'okapi',
       records: 'contributorTypes',
-      path: 'contributor-types?limit=100&query=cql.allRecords=1sortby name',
+      path: 'contributor-types?limit=100&query=cql.allRecords=1 sortby name',
     },
     contributorNameTypes: {
       type: 'okapi',


### PR DESCRIPTION
Bug fix for [UIIN-32](https://issues.folio.org/browse/UIIN-32). This was otherwise handled in #53; this fixes the typo on line 131. 