### PR TITLE
Limit sorting to single-column at a time

### DIFF
--- a/Instances.js
+++ b/Instances.js
@@ -317,6 +317,7 @@ class Instances extends React.Component {
       objectName="inventory"
       baseRoute={packageInfo.stripes.route}
       initialPath={initialPath}
+      maxSortKeys={1}
       filterConfig={filterConfig}
       initialResultCount={INITIAL_RESULT_COUNT}
       resultCountIncrement={RESULT_COUNT_INCREMENT}


### PR DESCRIPTION
By passing in the new `maxSortKeys={1}` property: see STSMACOM-45.

Fixes UIIN-66.