### PR TITLE
UIIN-68 Correctly apply `addButtonId` prop

### DIFF
--- a/edit/alternativeTitles.js
+++ b/edit/alternativeTitles.js
@@ -7,7 +7,7 @@ const AlternativeTitles = () => (
     name="alternativeTitles"
     label="Alternative titles"
     addLabel="+ Add alternative title"
-    addId="clickable-add-alt-title"
+    addButtonId="clickable-add-alternativeTitle"
     template={[{
       label: 'Alternative title',
       component: TextField,

--- a/edit/classificationFields.js
+++ b/edit/classificationFields.js
@@ -16,7 +16,7 @@ const ClassificationFields = ({ classificationTypes }) => {
       name="classifications"
       label="Classifications"
       addLabel="+ Add classification"
-      addId="clickable-add-classification"
+      addButtonId="clickable-add-classification"
       addDefaultItem={false}
       template={[
         {

--- a/edit/contributorFields.js
+++ b/edit/contributorFields.js
@@ -16,7 +16,7 @@ const ContributorFields = ({ contributorNameTypes }) => {
       name="contributors"
       label="Contributors"
       addLabel="+ Add contributor"
-      addId="clickable-add-contributor"
+      addButtonId="clickable-add-contributor"
       template={[
         {
           label: 'Name',

--- a/edit/descriptionFields.js
+++ b/edit/descriptionFields.js
@@ -7,7 +7,7 @@ const DescriptionFields = () => (
     name="physicalDescriptions"
     label="Descriptions"
     addLabel="+ Add description"
-    addId="clickable-add-description"
+    addButtonId="clickable-add-description"
     template={[{
       label: 'Description',
       component: TextField,

--- a/edit/identifierFields.js
+++ b/edit/identifierFields.js
@@ -15,7 +15,7 @@ const IdentifierFields = ({ identifierTypes }) => {
       name="identifiers"
       label="Identifiers"
       addLabel="+ Add identifier"
-      addId="clickable-add-identifier"
+      addButtonId="clickable-add-identifier"
       template={[
         {
           name: 'value',

--- a/edit/languageFields.js
+++ b/edit/languageFields.js
@@ -27,7 +27,7 @@ const LanguageFields = () => (
     name="languages"
     label="Languages"
     addLabel="+ Add language"
-    addId="clickable-add-language"
+    addButtonId="clickable-add-language"
     template={[{
       render: renderLanguageField,
     }]}

--- a/edit/noteFields.js
+++ b/edit/noteFields.js
@@ -7,7 +7,7 @@ const NoteFields = () => (
     name="notes"
     label="Notes"
     addLabel="+ Add note"
-    addId="clickable-add-note"
+    addButtonId="clickable-add-notes"
     template={[{
       label: 'Note',
       component: TextField,

--- a/edit/publicationFields.js
+++ b/edit/publicationFields.js
@@ -7,7 +7,7 @@ const PublicationFields = () => (
     name="publication"
     label="Publications"
     addLabel="+ Add publication"
-    addId="clickable-add-publication"
+    addButtonId="clickable-add-publication"
     template={[
       {
         name: 'publisher',

--- a/edit/seriesFields.js
+++ b/edit/seriesFields.js
@@ -7,7 +7,7 @@ const SeriesFields = () => (
     name="series"
     label="Series statements"
     addLabel="+ Add series"
-    addId="clickable-add-series"
+    addButtonId="clickable-add-series"
     template={[{
       component: TextField,
     }]}

--- a/edit/subjectFields.js
+++ b/edit/subjectFields.js
@@ -7,7 +7,7 @@ const SubjectFields = () => (
     name="subjects"
     label="Subjects"
     addLabel="+ Add subject"
-    addId="clickable-add-subject"
+    addButtonId="clickable-add-subject"
     template={[{
       component: TextField,
     }]}

--- a/edit/urlFields.js
+++ b/edit/urlFields.js
@@ -7,7 +7,7 @@ const URLFields = () => (
     name="urls"
     label="URLs"
     addLabel="+ Add URL"
-    addId="clickable-add-url"
+    addButtonId="clickable-add-url"
     template={[{
       label: 'URL',
       component: TextField,


### PR DESCRIPTION
Tests failed after https://github.com/folio-org/ui-inventory/pull/73 due to improperly id'd 'add' buttons. This PR resolves the issue by applying the id properly within the `<RepeatableField>` instances.