### PR TITLE
restore show-single-result functionality.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Sort contributor-type lookup table by name. Fixes UIIN-63.
 * Update stripes-connect, redux-form dependencies. Refs STRIPES-501.
 * Use stripes-components' Row and Col so that react-flexbox-grid remains a transitive dependency. Refs STRIPES-490.
+* Restore show-single-record. Refs UIIN-58, STSMACOM-52.
 
 ## [1.0.0](https://github.com/folio-org/ui-instances/tree/v1.0.0) (2017-09-08)
 [Full Changelog](https://github.com/folio-org/ui-items/compare/v0.0.1...v1.0.0)

--- a/Instances.js
+++ b/Instances.js
@@ -337,6 +337,7 @@ class Instances extends React.Component {
       parentMutator={this.props.mutator}
       detailProps={{ referenceTables, onCopy: this.copyInstance }}
       path={`${this.props.match.path}/view/:id/:holdingsrecordid?/:itemid?`}
+      showSingleResult={true}
     />);
   }
 }

--- a/Instances.js
+++ b/Instances.js
@@ -337,7 +337,7 @@ class Instances extends React.Component {
       parentMutator={this.props.mutator}
       detailProps={{ referenceTables, onCopy: this.copyInstance }}
       path={`${this.props.match.path}/view/:id/:holdingsrecordid?/:itemid?`}
-      showSingleResult={true}
+      showSingleResult
     />);
   }
 }


### PR DESCRIPTION
UIIN-58 introduced show-single-result functionality, but that broke
some things, so it was made optional and off by default in STSMACOM-52.
This turns that option on.

Refs [UIIN-58](https://issues.folio.org/browse/UIIN-58), [STSMACOM-52](https://issues.folio.org/browse/STSMACOM-52).