### PR TITLE
don't manipulate history object directly

### DIFF
--- a/Holdings.js
+++ b/Holdings.js
@@ -5,6 +5,7 @@ import ItemsPerHoldingsRecord from './ItemsPerHoldingsRecord';
 
 class Holdings extends React.Component {
   static manifest = Object.freeze({
+    query: {},
     holdings: {
       type: 'okapi',
       records: 'holdingsRecords',

--- a/Items.js
+++ b/Items.js
@@ -18,14 +18,13 @@ class Items extends React.Component {
     this.editItemModeThisLayer = false;
   }
 
-  onSelectRow = (e, meta) => {
-    if (e) e.stopPropagation();
-    this.openItem(meta);
-  }
-
-  openItem(selectedItem) {
+  openItem = (e, selectedItem) => {
+    if (e) e.preventDefault();
     const itemId = selectedItem.id;
-    this.props.history.push(`/inventory/view/${this.props.instance.id}/${this.props.holdingsRecord.id}/${itemId}${this.props.location.search}`);
+
+    this.props.parentMutator.query.update({
+      _path: `/inventory/view/${this.props.instance.id}/${this.props.holdingsRecord.id}/${itemId}`
+    });
   }
 
   render() {
@@ -43,7 +42,7 @@ class Items extends React.Component {
           id="list-items"
           contentData={itemRecords}
           rowMetadata={['id', 'holdingsRecordId']}
-          onRowClick={this.onSelectRow}
+          onRowClick={this.openItem}
           formatter={itemsFormatter}
           visibleColumns={['Item: barcode', 'status', 'Material Type']}
           ariaLabel="Items"
@@ -58,11 +57,9 @@ Items.propTypes = {
     items: PropTypes.shape({
       records: PropTypes.arrayOf(PropTypes.object),
     }),
+    query: PropTypes.object,
   }),
-  history: PropTypes.object,
-  location: PropTypes.shape({
-    search: PropTypes.string,
-  }),
+  parentMutator: PropTypes.object.isRequired,
   instance: PropTypes.object,
   holdingsRecord: PropTypes.object.isRequired,
 };

--- a/ItemsPerHoldingsRecord.js
+++ b/ItemsPerHoldingsRecord.js
@@ -13,6 +13,7 @@ import ItemForm from './edit/items/ItemForm';
 
 class ItemsPerHoldingsRecord extends React.Component {
   static manifest = Object.freeze({
+    query: {},
     addItemMode: { initialValue: { mode: false } },
     materialTypes: {
       type: 'okapi',
@@ -65,12 +66,14 @@ class ItemsPerHoldingsRecord extends React.Component {
   }
 
   viewHoldingsRecord = () => {
-    this.props.history.push(`/inventory/view/${this.props.instance.id}/${this.props.holdingsRecord.id}${this.props.location.search}`);
+    this.props.mutator.query.update({
+      _path: `/inventory/view/${this.props.instance.id}/${this.props.holdingsRecord.id}`,
+    });
   }
 
 
   render() {
-    const { okapi, resources: { addItemMode, materialTypes, loanTypes }, instance, holdingsRecord, location, accordionToggle, accordionStates } = this.props;
+    const { okapi, resources: { addItemMode, materialTypes, loanTypes }, instance, holdingsRecord, accordionToggle, accordionStates } = this.props;
 
     const materialtypes = (materialTypes || {}).records || [];
     const loantypes = (loanTypes || {}).records || [];
@@ -109,7 +112,7 @@ class ItemsPerHoldingsRecord extends React.Component {
         </Row>
         <Row>
           <Col sm={12}>
-            <this.cItems holdingsRecord={holdingsRecord} referenceTables={referenceTables} okapi={okapi} instance={instance} location={location} history={this.props.history} match={this.props.match} />
+            <this.cItems holdingsRecord={holdingsRecord} instance={instance} parentMutator={this.props.mutator} />
           </Col>
         </Row>
         <br />
@@ -144,6 +147,7 @@ ItemsPerHoldingsRecord.propTypes = {
     addItemMode: PropTypes.shape({
       replace: PropTypes.func,
     }),
+    query: PropTypes.object.isRequired,
   }),
   resources: PropTypes.shape({
     materialTypes: PropTypes.shape({
@@ -161,15 +165,7 @@ ItemsPerHoldingsRecord.propTypes = {
     connect: PropTypes.func.isRequired,
     locale: PropTypes.string.isRequired,
   }).isRequired,
-  match: PropTypes.shape({
-    params: PropTypes.object,
-  }),
-  history: PropTypes.object,
   okapi: PropTypes.object,
-  location: PropTypes.shape({
-    pathname: PropTypes.string.isRequired,
-    search: PropTypes.string,
-  }),
   accordionToggle: PropTypes.func.isRequired,
   accordionStates: PropTypes.object.isRequired,
 };

--- a/ViewHoldingsRecord.js
+++ b/ViewHoldingsRecord.js
@@ -19,6 +19,7 @@ import HoldingsForm from './edit/holdings/HoldingsForm';
 
 class ViewHoldingsRecord extends React.Component {
   static manifest = Object.freeze({
+    query: {},
     holdingsRecords: {
       type: 'okapi',
       path: 'holdings-storage/holdings/:{holdingsrecordid}',
@@ -73,12 +74,14 @@ class ViewHoldingsRecord extends React.Component {
   }
 
   copyHoldingsRecord = (holdingsRecord) => {
-    const { location, history, resources: { instances1 } } = this.props;
+    const { resources: { instances1 } } = this.props;
     const instance = instances1.records[0];
 
     this.props.mutator.holdingsRecords.POST(holdingsRecord).then((data) => {
-      history.push(`/inventory/view/${instance.id}/${data.id}${location.search}`);
-      setTimeout(() => this.removeQueryParam({ layer: null }));
+      this.props.mutator.query.update({
+        _path: `/inventory/view/${instance.id}/${data.id}`,
+        layer: null,
+      });
     });
   }
 
@@ -253,7 +256,6 @@ ViewHoldingsRecord.propTypes = {
   }).isRequired,
   okapi: PropTypes.object,
   location: PropTypes.object,
-  history: PropTypes.object,
   paneWidth: PropTypes.string,
   referenceTables: PropTypes.object.isRequired,
   mutator: PropTypes.shape({

--- a/ViewInstance.js
+++ b/ViewInstance.js
@@ -96,12 +96,12 @@ class ViewInstance extends React.Component {
 
   closeViewItem = (e) => {
     if (e) e.preventDefault();
-    this.props.history.push(`/inventory/view/${this.props.match.params.id}${this.props.location.search}`);
+    this.props.mutator.query.update({ _path: `/inventory/view/${this.props.match.params.id}` });
   }
 
   closeViewHoldingsRecord = (e) => {
     if (e) e.preventDefault();
-    this.props.history.push(`/inventory/view/${this.props.match.params.id}${this.props.location.search}`);
+    this.props.mutator.query.update({ _path: `/inventory/view/${this.props.match.params.id}` });
   }
 
   createHoldingsRecord = (holdingsRecord) => {
@@ -348,7 +348,6 @@ class ViewInstance extends React.Component {
             match={this.props.match}
             stripes={stripes}
             location={location}
-            history={this.props.history}
           />
           : null
         }
@@ -410,7 +409,6 @@ ViewInstance.propTypes = {
     pathname: PropTypes.string.isRequired,
     search: PropTypes.string,
   }).isRequired,
-  history: PropTypes.object,
   referenceTables: PropTypes.object.isRequired,
   mutator: PropTypes.shape({
     selectedInstance: PropTypes.shape({

--- a/ViewItem.js
+++ b/ViewItem.js
@@ -78,13 +78,15 @@ class ViewItem extends React.Component {
   }
 
   copyItem = (item) => {
-    const { location, history, resources: { holdingsRecords, instances1 } } = this.props;
+    const { resources: { holdingsRecords, instances1 } } = this.props;
     const holdingsRecord = holdingsRecords.records[0];
     const instance = instances1.records[0];
 
     this.props.mutator.items.POST(item).then((data) => {
-      history.push(`/inventory/view/${instance.id}/${holdingsRecord.id}/${data.id}${location.search}`);
-      setTimeout(() => this.props.mutator.query.update({ layer: null }));
+      this.props.mutator.query.update({
+        _path: `/inventory/view/${instance.id}/${holdingsRecord.id}/${data.id}`,
+        layer: null,
+      });
     });
   }
 
@@ -141,7 +143,11 @@ class ViewItem extends React.Component {
       </PaneMenu>
     );
 
-    const labelLocation = holdingsRecord.permanentLocationId ? referenceTables.shelfLocations.find(loc => holdingsRecord.permanentLocationId === loc.id).name : '';
+    let labelLocation = '';
+    if (holdingsRecord.permanentLocationId) {
+      const shelfLocation = referenceTables.shelfLocations.find(loc => holdingsRecord.permanentLocationId === loc.id);
+      labelLocation = _.get(shelfLocation, ['name'], '');
+    }
     const labelCallNumber = holdingsRecord.callNumber || '';
 
     return (
@@ -303,7 +309,6 @@ ViewItem.propTypes = {
   }).isRequired,
   okapi: PropTypes.object,
   location: PropTypes.object,
-  history: PropTypes.object,
   paneWidth: PropTypes.string,
   referenceTables: PropTypes.object.isRequired,
   mutator: PropTypes.shape({


### PR DESCRIPTION
Don't manully push onto props.history; use the anointed resource to read
and write URL state.

Refs [UIIN-122](https://issues.folio.org/browse/UIIN-122) but sadly does not actually fix it; it still takes two clicks on the backbutton to return to the previous page after viewing an item-detail page. 

Fixes [UIIN-123](https://issues.folio.org/browse/UIIN-123) item-detail should be a bookmarkable URL, [UIIN-124](https://issues.folio.org/browse/UIIN-124) holdings-detail should be a bookmarkable URL, [UIIN-128](https://issues.folio.org/browse/UIIN-128) holdings-edit regression.