### PR TITLE
UIIN-98 & UIIN-99: Show metadata for holdings and items

### DIFF
--- a/ViewHoldingsRecord.js
+++ b/ViewHoldingsRecord.js
@@ -16,6 +16,7 @@ import AppIcon from '@folio/stripes-components/lib/AppIcon';
 import craftLayerUrl from '@folio/stripes-components/util/craftLayerUrl';
 
 import HoldingsForm from './edit/holdings/HoldingsForm';
+import ViewMetaData from './ViewMetaData';
 
 class ViewHoldingsRecord extends React.Component {
   static manifest = Object.freeze({
@@ -51,6 +52,7 @@ class ViewHoldingsRecord extends React.Component {
       },
     };
     this.craftLayerUrl = craftLayerUrl.bind(this);
+    this.cViewMetaData = props.stripes.connect(ViewMetaData);
   }
 
   // Edit Holdings records handlers
@@ -177,6 +179,9 @@ class ViewHoldingsRecord extends React.Component {
                 </Col>
               </Row>
               <br />
+              { (holdingsRecord.metadata && holdingsRecord.metadata.createdDate) &&
+                <this.cViewMetaData metadata={holdingsRecord.metadata} />
+              }
               <Row>
                 <Col sm={12}>
                   <Headline size="medium" margin="medium">
@@ -240,6 +245,9 @@ class ViewHoldingsRecord extends React.Component {
 }
 
 ViewHoldingsRecord.propTypes = {
+  stripes: PropTypes.shape({
+    connect: PropTypes.func.isRequired,
+  }).isRequired,
   resources: PropTypes.shape({
     instances1: PropTypes.shape({
       records: PropTypes.arrayOf(PropTypes.object),

--- a/ViewItem.js
+++ b/ViewItem.js
@@ -16,6 +16,7 @@ import AppIcon from '@folio/stripes-components/lib/AppIcon';
 import craftLayerUrl from '@folio/stripes-components/util/craftLayerUrl';
 
 import ItemForm from './edit/items/ItemForm';
+import ViewMetaData from './ViewMetaData';
 
 class ViewItem extends React.Component {
   static manifest = Object.freeze({
@@ -61,6 +62,7 @@ class ViewItem extends React.Component {
     };
 
     this.craftLayerUrl = craftLayerUrl.bind(this);
+    this.cViewMetaData = props.stripes.connect(ViewMetaData);
   }
 
   onClickEditItem = (e) => {
@@ -190,6 +192,9 @@ class ViewItem extends React.Component {
                 </Col>
               </Row>
               <br />
+              { (item.metadata && item.metadata.createdDate) &&
+                <this.cViewMetaData metadata={item.metadata} />
+              }
               { (item.barcode) &&
                 <Row>
                   <Col sm={12}>
@@ -296,6 +301,9 @@ class ViewItem extends React.Component {
 }
 
 ViewItem.propTypes = {
+  stripes: PropTypes.shape({
+    connect: PropTypes.func.isRequired,
+  }).isRequired,
   resources: PropTypes.shape({
     instances1: PropTypes.shape({
       records: PropTypes.arrayOf(PropTypes.object),


### PR DESCRIPTION
Adds the `<ViewMetadata>` component to Holding and Item views, in order to show info about when the record was created and last updated.

https://issues.folio.org/browse/UIIN-98
https://issues.folio.org/browse/UIIN-99