### PR TITLE
add missing translation key. Refs UIIN-100

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -1,4 +1,5 @@
 {
+  "resultCount": "{count, number} {count, plural, one {Record found} other {Records found}}",
   "item.availability": "Availability",
   "item.availability.itemStatus": "Item status",
   "item.availability.itemStatusDate": "Item status date",


### PR DESCRIPTION
`<SearchAndSort>` relies on the translation key `resultCount`, which was not present. 

Refs [UIIN-100](https://issues.folio.org/browse/UIIN-100)