### PR TITLE
item double history push. Refs UIIN-122 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 * Fix holding and item forms. Fixes UIIN-174.
 * Try harder to derive an item's status-date. Refs UIIN-110.
 * Enable opening item view and holdings view in new tab. UIIN-147, UIIN-148.
+* Prevent event propagation, which prevents pushing onto history twice. Fixes UIIN-122.
 
 ## [1.0.0](https://github.com/folio-org/ui-instances/tree/v1.0.0) (2017-09-08)
 [Full Changelog](https://github.com/folio-org/ui-items/compare/v0.0.1...v1.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 * Fix holding and item forms. Fixes UIIN-174.
 * Try harder to derive an item's status-date. Refs UIIN-110.
 * Enable opening item view and holdings view in new tab. UIIN-147, UIIN-148.
-* Prevent event propagation, which prevents pushing onto history twice. Fixes UIIN-122.
+* Use a single handler for managing row-level links in MCL. Refs UIIN-122.
 
 ## [1.0.0](https://github.com/folio-org/ui-instances/tree/v1.0.0) (2017-09-08)
 [Full Changelog](https://github.com/folio-org/ui-items/compare/v0.0.1...v1.0.0)

--- a/Items.js
+++ b/Items.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
+import Link from 'react-router-dom/Link';
 
 import MultiColumnList from '@folio/stripes-components/lib/MultiColumnList';
 
@@ -23,28 +24,15 @@ class Items extends React.Component {
     this.editItemModeThisLayer = false;
   }
 
-  openItem = (e, selectedItem) => {
-    if (e) {
-      e.preventDefault();
-      e.stopPropagation();
-    }
-    const itemId = selectedItem.id;
-
-    this.props.parentMutator.query.update({
-      _path: `/inventory/view/${this.props.instance.id}/${this.props.holdingsRecord.id}/${itemId}`,
-    });
-  }
-
   anchoredRowFormatter = (row) => (
     <div role="listitem" key={`row-${row.rowIndex}`}>
-      <a
-        href={`/inventory/view/${this.props.instance.id}/${this.props.holdingsRecord.id}/${row.rowData.id}`}
+      <Link to={`/inventory/view/${this.props.instance.id}/${this.props.holdingsRecord.id}/${row.rowData.id}`}
         aria-label={row.labelStrings && row.labelStrings.join('...')}
         className={row.rowClass}
         {...row.rowProps}
       >
         {row.cells}
-      </a>
+      </Link>
     </div>
   );
 
@@ -64,7 +52,6 @@ class Items extends React.Component {
           contentData={itemRecords}
           rowMetadata={['id', 'holdingsRecordId']}
           formatter={itemsFormatter}
-          onRowClick={this.openItem}
           visibleColumns={['Item: barcode', 'status', 'Material Type']}
           ariaLabel="Items"
           containerRef={(ref) => { this.resultsList = ref; }}

--- a/Items.js
+++ b/Items.js
@@ -26,7 +26,8 @@ class Items extends React.Component {
 
   anchoredRowFormatter = (row) => (
     <div role="listitem" key={`row-${row.rowIndex}`}>
-      <Link to={`/inventory/view/${this.props.instance.id}/${this.props.holdingsRecord.id}/${row.rowData.id}`}
+      <Link
+        to={`/inventory/view/${this.props.instance.id}/${this.props.holdingsRecord.id}/${row.rowData.id}`}
         aria-label={row.labelStrings && row.labelStrings.join('...')}
         className={row.rowClass}
         {...row.rowProps}

--- a/Items.js
+++ b/Items.js
@@ -24,7 +24,10 @@ class Items extends React.Component {
   }
 
   openItem = (e, selectedItem) => {
-    if (e) e.preventDefault();
+    if (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
     const itemId = selectedItem.id;
 
     this.props.parentMutator.query.update({


### PR DESCRIPTION
Briefly, I thought I could knock out [UIIN-148](https://issues.folio.org/browse/UIIN-148) (open item details in new tab) and [UIIN-122](https://issues.folio.org/browse/UIIN-122) (history is pushed twice when viewing item details from an external link), but alas that's not the case. 

This PR gets us down to a single handler for row-clicks, however, so that's something. 