### PR TITLE
UIIN-149, UIIN-150, UIIN-151, UIIN-152: Added code and source fields to Settings pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 * Enable opening item view and holdings view in new tab. UIIN-147, UIIN-148.
 * Use a single handler for managing row-level links in MCL. Refs UIIN-122.
 * Replace shelf location references with locations. Fixes UIIN-182.
+* Added `code` and `source` fields to several settings pages. Fixes UIIN-149, UIIN-150, UIIN-151, UIIN-152,
 
 ## [1.0.0](https://github.com/folio-org/ui-instances/tree/v1.0.0) (2017-09-08)
 [Full Changelog](https://github.com/folio-org/ui-items/compare/v0.0.1...v1.0.0)

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
   "dependencies": {
     "@folio/stripes-components": "^2.0.0",
     "@folio/stripes-form": "^0.8.1",
-    "@folio/stripes-smart-components": "^1.4.7",
+    "@folio/stripes-smart-components": "^1.4.14",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
     "query-string": "^5.0.0",

--- a/settings/ContributorTypesSettings.js
+++ b/settings/ContributorTypesSettings.js
@@ -28,6 +28,8 @@ class FormatTypesSettings extends React.Component {
         label={formatMessage({ id: 'ui-inventory.contributorTypes' })}
         labelSingular={formatMessage({ id: 'ui-inventory.contributorType' })}
         objectLabel={formatMessage({ id: 'ui-inventory.contributors' })}
+        visibleFields={['name', 'code', 'source']}
+        readOnlyFields={['source']}
         hiddenFields={['description', 'numberOfObjects']}
         nameKey="name"
         id="contributor-types"

--- a/settings/FormatsSettings.js
+++ b/settings/FormatsSettings.js
@@ -28,6 +28,8 @@ class FormatTypesSettings extends React.Component {
         label={formatMessage({ id: 'ui-inventory.formats' })}
         labelSingular={formatMessage({ id: 'ui-inventory.format' })}
         objectLabel={formatMessage({ id: 'ui-inventory.instances' })}
+        visibleFields={['name', 'code', 'source']}
+        readOnlyFields={['source']}
         hiddenFields={['description', 'numberOfObjects']}
         nameKey="name"
         id="formats"

--- a/settings/MaterialTypesSettings.js
+++ b/settings/MaterialTypesSettings.js
@@ -28,6 +28,8 @@ class MaterialTypesSettings extends React.Component {
         label={formatMessage({ id: 'ui-inventory.materialTypes' })}
         labelSingular={formatMessage({ id: 'ui-inventory.materialType' })}
         objectLabel={formatMessage({ id: 'ui-inventory.items' })}
+        visibleFields={['name', 'source']}
+        readOnlyFields={['source']}
         hiddenFields={['description', 'numberOfObjects']}
         nameKey="name"
         id="materialtypes"

--- a/settings/ResourceTypesSettings.js
+++ b/settings/ResourceTypesSettings.js
@@ -28,6 +28,8 @@ class FormatTypesSettings extends React.Component {
         label={formatMessage({ id: 'ui-inventory.resourceTypes' })}
         labelSingular={formatMessage({ id: 'ui-inventory.resourceType' })}
         objectLabel={formatMessage({ id: 'ui-inventory.instances' })}
+        visibleFields={['name', 'code', 'source']}
+        readOnlyFields={['source']}
         hiddenFields={['description', 'numberOfObjects']}
         nameKey="name"
         id="instance-types"

--- a/settings/index.js
+++ b/settings/index.js
@@ -22,37 +22,47 @@ class InventorySettings extends React.Component {
 
     const { formatMessage } = this.props.stripes.intl;
 
-    this.pages = [
+    this.sections = [
       {
-        route: 'materialtypes',
-        label: formatMessage({ id: 'ui-inventory.materialTypes' }),
-        component: MaterialTypesSettings,
-        perm: 'ui-inventory.settings.materialtypes',
+        label: formatMessage({ id: 'ui-inventory.items' }),
+        pages: [
+          {
+            route: 'loantypes',
+            label: formatMessage({ id: 'ui-inventory.loanTypes' }),
+            component: LoanTypesSettings,
+            perm: 'ui-inventory.settings.loantypes',
+          },
+          {
+            route: 'materialtypes',
+            label: formatMessage({ id: 'ui-inventory.materialTypes' }),
+            component: MaterialTypesSettings,
+            perm: 'ui-inventory.settings.materialtypes',
+          },
+        ]
       },
       {
-        route: 'loantypes',
-        label: formatMessage({ id: 'ui-inventory.loanTypes' }),
-        component: LoanTypesSettings,
-        perm: 'ui-inventory.settings.loantypes',
-      },
-      {
-        route: 'formats',
-        label: formatMessage({ id: 'ui-inventory.formats' }),
-        component: FormatsSettings,
-        perm: 'ui-inventory.settings.instance-formats',
-      },
-      {
-        route: 'resourcetypes',
-        label: formatMessage({ id: 'ui-inventory.resourceTypes' }),
-        component: ResourceTypesSettings,
-        perm: 'ui-inventory.settings.instance-types',
-      },
-      {
-        route: 'contributortypes',
-        label: formatMessage({ id: 'ui-inventory.contributorTypes' }),
-        component: ContributorTypesSettings,
-        perm: 'ui-inventory.settings.contributor-types',
-      },
+        label: formatMessage({ id: 'ui-inventory.instances' }),
+        pages: [
+          {
+            route: 'contributortypes',
+            label: formatMessage({ id: 'ui-inventory.contributorTypes' }),
+            component: ContributorTypesSettings,
+            perm: 'ui-inventory.settings.contributor-types',
+          },
+          {
+            route: 'formats',
+            label: formatMessage({ id: 'ui-inventory.formats' }),
+            component: FormatsSettings,
+            perm: 'ui-inventory.settings.instance-formats',
+          },
+          {
+            route: 'resourcetypes',
+            label: formatMessage({ id: 'ui-inventory.resourceTypes' }),
+            component: ResourceTypesSettings,
+            perm: 'ui-inventory.settings.instance-types',
+          },
+        ]
+      }
     ];
   }
 
@@ -60,8 +70,8 @@ class InventorySettings extends React.Component {
     return (
       <Settings
         {...this.props}
-        pages={_.sortBy(this.pages, ['label'])}
-        paneTitle="Inventory"
+        sections={this.sections}
+        paneTitle={this.props.stripes.intl.formatMessage({ id: 'ui-inventory.inventory.label' })}
       />
     );
   }

--- a/settings/index.js
+++ b/settings/index.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Settings from '@folio/stripes-components/lib/Settings';

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,4 +1,5 @@
 {
+  "inventory.label": "Inventory",
   "resultCount": "{count, number} {count, plural, one {Record found} other {Records found}}",
   "item.availability": "Availability",
   "item.availability.itemStatus": "Item status",


### PR DESCRIPTION
- Added `code` as a field to Contributor Types, Resource Types, and Formats.
- Added `source` as a field to Contributor Types, Resource Types, Formats and Material Types.
- Split the Inventory settings into sections.
- Bumped requirement on `stripes-smart-components` in order to get [this PR's functionality](https://github.com/folio-org/stripes-smart-components/pull/171).