### PR TITLE
Settings: Default to a source of 'local' for newly-created types

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "webpack": "1.11.0"
   },
   "dependencies": {
-    "@folio/stripes-components": "^2.0.0",
+    "@folio/stripes-components": "^2.0.15",
     "@folio/stripes-form": "^0.8.1",
     "@folio/stripes-smart-components": "^1.4.14",
     "lodash": "^4.17.4",

--- a/settings/ContributorTypesSettings.js
+++ b/settings/ContributorTypesSettings.js
@@ -30,6 +30,7 @@ class FormatTypesSettings extends React.Component {
         objectLabel={formatMessage({ id: 'ui-inventory.contributors' })}
         visibleFields={['name', 'code', 'source']}
         readOnlyFields={['source']}
+        itemTemplate={{ source: 'local' }}
         hiddenFields={['description', 'numberOfObjects']}
         nameKey="name"
         id="contributor-types"

--- a/settings/FormatsSettings.js
+++ b/settings/FormatsSettings.js
@@ -30,6 +30,7 @@ class FormatTypesSettings extends React.Component {
         objectLabel={formatMessage({ id: 'ui-inventory.instances' })}
         visibleFields={['name', 'code', 'source']}
         readOnlyFields={['source']}
+        itemTemplate={{ source: 'local' }}
         hiddenFields={['description', 'numberOfObjects']}
         nameKey="name"
         id="formats"

--- a/settings/MaterialTypesSettings.js
+++ b/settings/MaterialTypesSettings.js
@@ -30,6 +30,7 @@ class MaterialTypesSettings extends React.Component {
         objectLabel={formatMessage({ id: 'ui-inventory.items' })}
         visibleFields={['name', 'source']}
         readOnlyFields={['source']}
+        itemTemplate={{ source: 'local' }}
         hiddenFields={['description', 'numberOfObjects']}
         nameKey="name"
         id="materialtypes"

--- a/settings/ResourceTypesSettings.js
+++ b/settings/ResourceTypesSettings.js
@@ -30,6 +30,7 @@ class FormatTypesSettings extends React.Component {
         objectLabel={formatMessage({ id: 'ui-inventory.instances' })}
         visibleFields={['name', 'code', 'source']}
         readOnlyFields={['source']}
+        itemTemplate={{ source: 'local' }}
         hiddenFields={['description', 'numberOfObjects']}
         nameKey="name"
         id="instance-types"


### PR DESCRIPTION
Using the new `itemTemplate` [functionality provided here](https://github.com/folio-org/stripes-components/pull/376).