### PR TITLE
STCOR-226: Added selected record to the doc.title

### DIFF
--- a/ViewInstance.js
+++ b/ViewInstance.js
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
 
+import TitleManager from '@folio/stripes-core/src/components/TitleManager';
 import Pane from '@folio/stripes-components/lib/Pane';
 import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
 import { Accordion, ExpandAllButton } from '@folio/stripes-components/lib/Accordion';
@@ -200,6 +201,7 @@ class ViewInstance extends React.Component {
         dismissible
         onClose={this.props.onClose}
       >
+        <TitleManager record={instance.title} />
         <Row end="xs"><Col xs><ExpandAllButton accordionStatus={this.state.accordions} onToggle={this.handleExpandAll} /></Col></Row>
         <Accordion
           open={this.state.accordions.instanceAccordion}


### PR DESCRIPTION
Added the open instance's title to `document.title` for reflection in the tab/window. Visible when viewing the instance/holding/title.

Now:
<img width="1440" alt="screen shot 2018-07-05 at 10 14 42 am" src="https://user-images.githubusercontent.com/5324374/42328461-4c1c0ed8-803c-11e8-9138-e84eb601976c.png">
