### PR TITLE
Add stripes serve to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,26 +19,26 @@
     "hasSettings": true,
     "queryResource": "query",
     "icons": [
-     {
-       "name": "app",
-       "alt": "View and manage instance records, holdings records and item records",
-       "title": "Inventory"
-     },
-     {
-       "name": "holdings",
-       "alt": "",
-       "title": "Holding"
-     },
-     {
-       "name": "item",
-       "alt": "",
-       "title": "Item"
-     },
-     {
-       "name": "instance",
-       "alt": "",
-       "title": "Instance"
-     }
+      {
+        "name": "app",
+        "alt": "View and manage instance records, holdings records and item records",
+        "title": "Inventory"
+      },
+      {
+        "name": "holdings",
+        "alt": "",
+        "title": "Holding"
+      },
+      {
+        "name": "item",
+        "alt": "",
+        "title": "Item"
+      },
+      {
+        "name": "instance",
+        "alt": "",
+        "title": "Instance"
+      }
     ],
     "okapiInterfaces": {
       "inventory": "5.0",
@@ -57,7 +57,6 @@
       "platforms": "1.0",
       "users": "15.0",
       "location-units": "1.1",
-      "locations": "2.0",
       "circulation": "3.0"
     },
     "permissionSets": [
@@ -162,10 +161,13 @@
     }
   },
   "scripts": {
+    "start": "stripes serve",
     "lint": "eslint *.js lib settings edit data test/ui-testing",
     "test": "cd ../ui-testing; env FOLIO_UI_URL=http://localhost:3000 yarn test-module -o --run=inventory"
   },
   "devDependencies": {
+    "@folio/eslint-config-stripes": "^1.1.0",
+    "@folio/stripes-cli": "^1.2.0",
     "babel-core": "^6.17.0",
     "babel-eslint": "^7.0.0",
     "babel-preset-es2015": "^6.18.0",
@@ -173,7 +175,6 @@
     "babel-preset-stage-2": "^6.16.0",
     "babel-register": "^6.18.0",
     "eslint": "^4.8.0",
-    "@folio/eslint-config-stripes": "^1.1.0",
     "webpack": "1.11.0"
   },
   "dependencies": {


### PR DESCRIPTION
[Stripes CLI](https://github.com/folio-org/stripes-cli) provides a `serve` command that can be used to run a module by itself, without defining an entire platform to run in a `workspace`.

This is handy for:
- working on a single module
- testing a module in isolation
- cutting down the `node` process overhead of running several actively building modules in a local `webpack` server

To use (after a `yarn install`):
```
yarn start
```

By default, `http://localhost:3000` will attempt to connect to a back end at `http://localhost:9130`. To connect to a different Okapi cluster:
```
yarn start --okapi https://my-okapi-cluster.folio.org
```

[Full list of available `stripes serve` options](https://github.com/folio-org/stripes-cli/blob/master/doc/commands.md#serve-command)

Related to https://github.com/folio-org/ui-checkin/pull/51