### PR TITLE
pass missing props.stripes to forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 * Display effective location on Item details view. UIIN-196.
 * Enable un-setting a location. Fixes UIIN-198.
 * Require inventory 5.3, item-storage 5.3, holdings-storage 1.3. UIIN-194,-195,-196
+* Show metadata on holdings-edit and item-edit pages. Refs UIIN-191.
 
 ## [1.0.0](https://github.com/folio-org/ui-instances/tree/v1.0.0) (2017-09-08)
 [Full Changelog](https://github.com/folio-org/ui-items/compare/v0.0.1...v1.0.0)

--- a/ItemsPerHoldingsRecord.js
+++ b/ItemsPerHoldingsRecord.js
@@ -131,6 +131,7 @@ class ItemsPerHoldingsRecord extends React.Component {
             holdingsRecord={holdingsRecord}
             referenceTables={referenceTables}
             intl={this.props.stripes.intl}
+            stripes={this.props.stripes}
           />
         </Layer>
       </Accordion>);

--- a/ViewHoldingsRecord.js
+++ b/ViewHoldingsRecord.js
@@ -288,6 +288,7 @@ class ViewHoldingsRecord extends React.Component {
             instance={instance}
             copy
             referenceTables={referenceTables}
+            stripes={this.props.stripes}
           />
         </Layer>
       </div>

--- a/ViewInstance.js
+++ b/ViewInstance.js
@@ -384,6 +384,7 @@ class ViewInstance extends React.Component {
             formatMsg={formatMsg}
             instance={instance}
             referenceTables={referenceTables}
+            stripes={stripes}
           />
         </Layer>
       </Pane>

--- a/ViewItem.js
+++ b/ViewItem.js
@@ -470,6 +470,7 @@ class ViewItem extends React.Component {
             holdingsRecord={holdingsRecord}
             referenceTables={referenceTables}
             intl={intl}
+            stripes={this.props.stripes}
           />
         </Layer>
 


### PR DESCRIPTION
Displaying metadata on the holdings- and item-edit forms requires
passing in stripes so we can connect those forms, but it was not being
passed in all locations where those forms are instantiated.

Refs [UIIN-191](https://issues.folio.org/browse/UIIN-191)