### PR TITLE
Retrieve up to 40 loan-types for editing dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 * Require inventory 5.3, item-storage 5.3, holdings-storage 1.3. UIIN-194,-195,-196
 * Show metadata on holdings-edit and item-edit pages. Refs UIIN-191.
 * Add initial MARC source view. UIIN-93
+* Retrieve up to 40 loan-types for editing dropdown, and sort them by name. Fixes UIIN-213.
 
 ## [1.0.0](https://github.com/folio-org/ui-instances/tree/v1.0.0) (2017-09-08)
 [Full Changelog](https://github.com/folio-org/ui-items/compare/v0.0.1...v1.0.0)

--- a/ViewItem.js
+++ b/ViewItem.js
@@ -45,6 +45,10 @@ class ViewItem extends React.Component {
     loanTypes: {
       type: 'okapi',
       path: 'loan-types',
+      params: {
+        query: 'cql.allRecords=1 sortby name',
+        limit: '40',
+      },
       records: 'loantypes',
     },
     requests: {


### PR DESCRIPTION
Also, sort them by name.

Fixes UIIN-213.