### PR TITLE
use current stripes-form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-inventory
 
+## 1.3.0 (IN PROGRESS)
+
+* Update to stripes-form 0.9.0. Refs STRIPES-555.
+
+
 ## [1.2.1](https://github.com/folio-org/ui-inventory/tree/v1.2.1) (2018-09-13)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.2.0...v1.2.1)
 
@@ -20,7 +25,7 @@
 ## [1.1.1](https://github.com/folio-org/ui-inventory/tree/v1.1.1) (2018-09-06)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.1.0...v1.1.1)
 
-* Fix toggle accordion feature after new accordions added. (UIIN-279) 
+* Fix toggle accordion feature after new accordions added. (UIIN-279)
 * Update dependency on eslint-config-stripes (UIIN-280)
 * Update core Stripes dependencies (UIIN-278)
 

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
   },
   "dependencies": {
     "@folio/stripes-components": "^3.0.8",
-    "@folio/stripes-form": "^0.8.2",
+    "@folio/stripes-form": "^0.9.0",
     "@folio/stripes-smart-components": "^1.5.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",


### PR DESCRIPTION
Because stripes-form has not been released as a v1.0.x package,
this means ^0.8.0 is effectively ~0.8.0, meaning those packages
are locked at 0.8.x, not 0.x.x as intended. stripes-form 0.8.0
pulled in an old version of stripes-components which pulled in
an old version of React which brought darkness upon the land.

Refs [STRIPES-555](https://issues.folio.org/browse/STRIPES-555)