### PR TITLE
wait for more reliable elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## 1.2.3 (IN PROGRESS)
+
+* More stable inventory-search tests. Refs UIIN-306.
+
 ## [1.2.2](https://github.com/folio-org/ui-inventory/tree/v1.2.2) (2018-09-14)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.2.1...v1.2.2)
 

--- a/test/ui-testing/inventorySearch.js
+++ b/test/ui-testing/inventorySearch.js
@@ -27,7 +27,7 @@ module.exports.test = function test(uiTestCtx) {
           .wait('#input-inventory-search')
           .click('#input-inventory-search')
           .insert('#input-inventory-search', title)
-          .wait('#clickable-input-inventory-search-clear-field')
+          .wait('#clickable-reset-all')
           .wait(`#list-inventory div[role="listitem"] div[role="gridcell"][title*="${title}"]`)
           /* .evaluate(function evall(title2) {
             const list = document.querySelector('#list-inventory div[role="listitem"]:first-of-type > a > div[role="gridcell"]:nth-of-type(1)').title;
@@ -55,7 +55,7 @@ module.exports.test = function test(uiTestCtx) {
           .select('#input-inventory-search-qindex', 'title')
           .wait(55)
           .insert('#input-inventory-search', title)
-          .wait('#clickable-input-inventory-search-clear-field')
+          .wait('#clickable-reset-all')
           .wait(`#list-inventory div[role="listitem"] div[role="gridcell"][title*="${title}"]`)
           /* .evaluate(function evall(title2) {
             const list = document.querySelector('#list-inventory div[role="listitem"]:first-of-type > a > div[role="gridcell"]:nth-of-type(1)').title;
@@ -82,7 +82,7 @@ module.exports.test = function test(uiTestCtx) {
           .select('#input-inventory-search-qindex', 'contributor')
           .wait(55)
           .insert('#input-inventory-search', authorName)
-          .wait('#clickable-input-inventory-search-clear-field')
+          .wait('#clickable-reset-all')
           .wait(`#list-inventory div[role="listitem"] div[role="gridcell"][title*="${authorName}"]`)
           .then(done)
           .catch(done);


### PR DESCRIPTION
The old tests were unreliable. I dunno why that element they waited for
never seemed to trigger a rerender, but it didn't. Waiting for the
clear-all element instead of the clear-field element seems reliable.
Reliable tests are better than unreliable tests.

Fixes [UIIN-306](https://issues.folio.org/browse/UIIN-306)