### PR TITLE
Release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-inventory
 
-## [1.3.0] Unreleased
+## [1.3.0](https://github.com/folio-org/ui-inventory/tree/v1.3.0) (2018-09-27)
+[Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.2.1...v1.3.0)
 * Remove `instance.urls` from Instance form (UIIN-303)
 * Make HRID optional in Instance form (UIIN-304)
 * Validate HRID for uniqueness in Instance form (UIIN-288)
@@ -9,6 +10,7 @@
 * Remove API dependency on `cataloging-levels` (UIIN-312)
 * More stable inventory-search tests. Refs UIIN-306.
 * Remove `instance.edition` add `instance.editions` (UIIN-299)
+* Move files into src directory
 
 ## [1.2.3 (hot fix)](https://github.com/folio-org/ui-inventory/tree/v1.2.3) (2018-09-19)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.2.2...v1.2.3)


### PR DESCRIPTION
https://github.com/folio-org/ui-inventory/pull/297 changed the directory structure of `ui-inventory`, which `ui-plugin-find-instance` was relying on:
```
ERROR in ./node_modules/@folio/plugin-find-instance/InstanceSearch/InstanceSearchModal.js
Module not found: Error: Can't resolve '@folio/inventory/Instances' in '/home/jenkins/folio-testing-platform/node_modules/@folio/plugin-find-instance/InstanceSearch'
 @ ./node_modules/@folio/plugin-find-instance/InstanceSearch/InstanceSearchModal.js 15:0-51 29:47-56
 @ ./node_modules/@folio/plugin-find-instance/InstanceSearch/InstanceSearch.js
 @ ./node_modules/@folio/plugin-find-instance/InstanceSearch/index.js
 @ ./node_modules/@folio/plugin-find-instance/index.js
 @ ./node_modules/stripes-config.js
 @ ./node_modules/@folio/stripes-core/src/App.js
 @ ./node_modules/@folio/stripes-core/src/HotApp.js
 @ ./node_modules/@folio/stripes-core/src/index.js
 @ multi typeface-source-sans-pro @folio/stripes-components/lib/global.css ./node_modules/@folio/stripes-core/src/index
```

Long term, we should explore how that relationship gets defined. Exports? Have the plugin live within this repo?

For now, cut this release so `ui-plugin-find-instance` can update its dependency and point to the new file path.
