### PR TITLE
Copy craftLayerUrl() from stripes-components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix case-sensitive tests. Fixes UIIN-329.
 * Remove notes helper app
+* Copy `craftLayerUrl()` from `stripes-components`
 
 ## [1.3.0](https://github.com/folio-org/ui-inventory/tree/v1.3.0) (2018-09-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.2.1...v1.3.0)

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -14,7 +14,7 @@ import IconButton from '@folio/stripes-components/lib/IconButton';
 import AppIcon from '@folio/stripes-components/lib/AppIcon';
 import ViewMetaData from '@folio/stripes-smart-components/lib/ViewMetaData';
 
-import craftLayerUrl from '@folio/stripes-components/util/craftLayerUrl';
+import { craftLayerUrl } from './utils';
 
 import HoldingsForm from './edit/holdings/HoldingsForm';
 

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -20,7 +20,7 @@ import Headline from '@folio/stripes-components/lib/Headline';
 import MultiColumnList from '@folio/stripes-components/lib/MultiColumnList';
 import ViewMetaData from '@folio/stripes-smart-components/lib/ViewMetaData';
 
-import craftLayerUrl from '@folio/stripes-components/util/craftLayerUrl';
+import { craftLayerUrl } from './utils';
 
 import formatters from './referenceFormatters';
 
@@ -206,7 +206,7 @@ class ViewInstance extends React.Component {
         <IconButton
           id="clickable-edit-instance"
           style={{ visibility: !instance ? 'hidden' : 'visible' }}
-          href={this.craftLayerUrl('edit')}
+          href={this.craftLayerUrl('edit', location)}
           onClick={this.onClickEditInstance}
           title={formatMsg({ id: 'ui-inventory.editInstance' })}
           icon="edit"
@@ -232,7 +232,7 @@ class ViewInstance extends React.Component {
     const newHoldingsRecordButton = (
       <Button
         id="clickable-new-holdings-record"
-        href={this.craftLayerUrl('createHoldingsRecord')}
+        href={this.craftLayerUrl('createHoldingsRecord', location)}
         onClick={this.onClickAddNewHoldingsRecord}
         title={formatMsg({ id: 'ui-inventory.addHoldings' })}
         buttonStyle="primary"

--- a/src/ViewItem.js
+++ b/src/ViewItem.js
@@ -13,7 +13,7 @@ import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import IconButton from '@folio/stripes-components/lib/IconButton';
 import AppIcon from '@folio/stripes-components/lib/AppIcon';
 import ViewMetaData from '@folio/stripes-smart-components/lib/ViewMetaData';
-import craftLayerUrl from '@folio/stripes-components/util/craftLayerUrl';
+import { craftLayerUrl } from './utils';
 
 import ItemForm from './edit/items/ItemForm';
 
@@ -246,7 +246,7 @@ class ViewItem extends React.Component {
           icon="edit"
           id="clickable-edit-item"
           style={{ visibility: !item ? 'hidden' : 'visible' }}
-          href={this.craftLayerUrl('editItem')}
+          href={this.craftLayerUrl('editItem', location)}
           onClick={this.onClickEditItem}
           title="Edit Item"
         />

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FormattedDate, FormattedTime } from 'react-intl';
+import includes from 'lodash/includes';
 
 export function formatDate(dateStr) {
   if (!dateStr) return dateStr;
@@ -15,4 +16,9 @@ export function formatDateTime(dateStr) {
       <FormattedTime value={dateStr} />
     </span>
   );
+}
+
+export function craftLayerUrl(mode, location) {
+  const url = location.pathname + location.search;
+  return includes(url, '?') ? `${url}&layer=${mode}` : `${url}?layer=${mode}`;
 }


### PR DESCRIPTION
`craftLayerUrl()` assists with `<SearchAndSort>`'s routing, and will be deprecated for any other use (modules should define their own routes, instead of relying on `<SearchAndSort>` to do it for them).