### PR TITLE
Release v 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-inventory
 
-## 1.4.0 (IN PROGRESS)
+## [1.4.0](https://github.com/folio-org/ui-inventory/tree/v1.4.0) (2018-10-05)
+[Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.3.0...v1.4.0)
 
 * Remove `instance.instanceFormatId`, add `instance.instanceFormatIds` (UIIN-330)
 * Fix case-sensitive tests. Fixes UIIN-329.
@@ -12,6 +13,7 @@
 
 ## [1.3.0](https://github.com/folio-org/ui-inventory/tree/v1.3.0) (2018-09-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.2.1...v1.3.0)
+
 * Remove `instance.urls` from Instance form (UIIN-303)
 * Make HRID optional in Instance form (UIIN-304)
 * Validate HRID for uniqueness in Instance form (UIIN-288)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/inventory",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Inventory manager",
   "repository": "folio-org/ui-inventory",
   "publishConfig": {


### PR DESCRIPTION
In this release:
* Remove `instance.instanceFormatId`, add `instance.instanceFormatIds` (UIIN-330)
* Fix case-sensitive tests. Fixes UIIN-329.
* Add electronic access relationship reference data (UIIN-316)
* Requires: `inventory` interface (7.0) and `instance-storage` interface (5.0) (UIIN-316)
* Remove notes helper app (STRIPES-558)
* Copy `craftLayerUrl()` from `stripes-components` (Part of FOLIO-1547)
* Add dependency to stripes v1.0.0 to package.json. (Part of FOLIO-1547)