### PR TITLE
Fix craftLayerUrl() loading state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## 1.5.0 (IN PROGRESS)
+
+* Fix `craftLayerUrl()` loading state (FOLIO-1547)
+
 ## [1.4.0](https://github.com/folio-org/ui-inventory/tree/v1.4.0) (2018-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.3.0...v1.4.0)
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,6 +19,9 @@ export function formatDateTime(dateStr) {
 }
 
 export function craftLayerUrl(mode, location) {
-  const url = location.pathname + location.search;
-  return includes(url, '?') ? `${url}&layer=${mode}` : `${url}?layer=${mode}`;
+  if (location) {
+    const url = location.pathname + location.search;
+    return includes(url, '?') ? `${url}&layer=${mode}` : `${url}?layer=${mode}`;
+  }
+  return null;
 }


### PR DESCRIPTION
The `stripes-components` `craftLayerUrl()` was deprecated from `stripes-components`, since routing is not the responsibility of a component library.

In the `stripes-components` version, `location` was accessed from `this.props`: https://github.com/folio-org/stripes-components/blob/3926f3c6e566b67a9876872dc952198b0d009992/util/craftLayerUrl.js

Now that it's passed in directly, it can get in a state where location is not yet defined. Check added to return null from `craftLayerUrl()` if `location` is not yet available.