### PR TITLE
Default term to empty string in cases when query is undefined. Fixes UIIN-371.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Instance view: Add staff and discovery suppress, previously held (UIIN-343)
 * Click "search" button in tests (STCOM-354)
 * Provide `sortby` key for `<ControlledVocab>`. Refs STSMACOM-139.
+* Default term to empty string in cases when query is undefined. Fixes UIIN-371.
 
 ## [1.4.0](https://github.com/folio-org/ui-inventory/tree/v1.4.0) (2018-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.3.0...v1.4.0)

--- a/src/Instances.js
+++ b/src/Instances.js
@@ -110,7 +110,7 @@ class Instances extends React.Component {
               makeQueryArgs = { identifierTypeId: (identifierType ? identifierType.id : 'identifier-type-not-found') };
             }
 
-            let cql = searchableIndex.makeQuery(resourceData.query.query, makeQueryArgs);
+            let cql = searchableIndex.makeQuery(resourceData.query.query || '', makeQueryArgs);
 
             const filterCql = filters2cql(filterConfig, resourceData.query.filters);
             if (filterCql) {


### PR DESCRIPTION
It looks like `resourceData.query.query` is undefined in some cases (I'm still not sure what those cases are). This PR sets the `term` to an empty string in cases when `query=undefined` in order to fix these kind of situations:

`query: (title="undefined*" or contributors adj "\"name\": \"undefined*\"" or identifiers adj "\"value\": \"undefined*\"") sortby title`