### PR TITLE
Turn on react-hot-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,6 +192,7 @@
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
     "query-string": "^5.0.0",
+    "react-hot-loader": "^4.3.12",
     "react-intl": "^2.3.0",
     "react-router-dom": "^4.0.0",
     "redux-form": "^7.0.3"

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Route from 'react-router-dom/Route';
 import Switch from 'react-router-dom/Switch';
+import { hot } from 'react-hot-loader';
 import Instances from './Instances';
 import Settings from './settings';
 
@@ -52,4 +53,4 @@ How did you get to
   }
 }
 
-export default InstancesRouting;
+export default hot(module)(InstancesRouting);


### PR DESCRIPTION
Setup for `stripes-core` took place in https://github.com/folio-org/stripes-core/pull/431.

Turns on hot reloading for this module.