### PR TITLE
accomodate lack of title attribute in results list

### DIFF
--- a/test/ui-testing/filters.js
+++ b/test/ui-testing/filters.js
@@ -24,12 +24,9 @@ module.exports.test = function uiTest(uiTestCtx) {
       });
       it('should find hit count with no filters applied', (done) => {
         nightmare
-          .wait('p[title*="records found"]:not([title^="0 "]')
-          .wait(1111)
+          .wait('#list-inventory')
           .evaluate(() => {
-            let count = document.querySelector('p[title*="records found"]').title;
-            count = count.replace(/^(\d+).+/, '$1');
-            return count;
+            return document.querySelector('#list-inventory').getAttribute('data-total-count');
           })
           .then((result) => {
             done();
@@ -46,10 +43,9 @@ module.exports.test = function uiTest(uiTestCtx) {
             .click('#clickable-reset-all')
             .wait(`#clickable-filter-${filter}`)
             .click(`#clickable-filter-${filter}`)
-            .wait('#clickable-reset-all')
-            .wait(`p[title*="record"]:not([title^="${hitCount} "]`)
-            .click(`#clickable-filter-${filter}`)
-            .wait(`p[title="${hitCount} records found"]`)
+            .wait(`#list-inventory:not([data-total-count^="${hitCount}"])`)
+            .click('#clickable-reset-all')
+            .wait(`#list-inventory[data-total-count^="${hitCount}"]`)
             .then(done)
             .catch(done);
         });


### PR DESCRIPTION
Update the filter tests to use the `<MultiColumnList>`'s
`data-total-count` attribute instead of parsing the sub-header span's
title, which was pretty gross, and which was removed due to a11y
considerations regardless.

Refs [STCOM-296](https://issues.folio.org/browse/STCOM-296)