### PR TITLE
support circulation interface v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Click "search" button in tests (STCOM-354)
 * Provide `sortby` key for `<ControlledVocab>`. Refs STSMACOM-139.
 * Default term to empty string in cases when query is undefined. Fixes UIIN-371.
+* Support circulation v5.0, requiring service-point information on loans. Refs UIIN-383.
 
 ## [1.4.0](https://github.com/folio-org/ui-inventory/tree/v1.4.0) (2018-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.3.0...v1.4.0)

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
       "platforms": "1.0",
       "users": "15.0",
       "location-units": "1.1",
-      "circulation": "4.0"
+      "circulation": "4.0 5.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
Support circulation v5.0, requiring service-point information on loans.

Refs [UIIN-383](https://issues.folio.org/browse/UIIN-383)