### PR TITLE
STCOM-396: Implement Pane header dropdown for Item pages

### DIFF
--- a/src/ItemsPerHoldingsRecord.js
+++ b/src/ItemsPerHoldingsRecord.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import { FormattedMessage } from 'react-intl';
 
 import {
   Accordion,
@@ -9,7 +9,6 @@ import {
   Col,
   Button,
 } from '@folio/stripes/components';
-import { Link } from 'react-router-dom';
 
 import Items from './Items';
 import ItemForm from './edit/items/ItemForm';
@@ -66,15 +65,41 @@ class ItemsPerHoldingsRecord extends React.Component {
   }
 
   onClickCloseNewItem = (e) => {
+    const { mutator } = this.props;
+
     if (e) e.preventDefault();
-    this.props.mutator.addItemMode.replace({ mode: false });
-    this.addItemModeThisLayer = false;
+
+    mutator.addItemMode.replace({ mode: false });
+    mutator.query.update({ layer: null });
   }
 
   createItem = (item) => {
-    // POST item record
     this.props.mutator.items.POST(item);
     this.onClickCloseNewItem();
+  }
+
+  renderButtonsGroup = () => {
+    const {
+      instance,
+      holdingsRecord,
+    } = this.props;
+
+    return (
+      <div>
+        <Button
+          to={{ pathname: `/inventory/view/${instance.id}/${holdingsRecord.id}` }}
+          style={{ marginRight: '5px' }}
+        >
+          <FormattedMessage id="ui-inventory.viewHoldings" />
+        </Button>
+        <Button
+          onClick={this.onClickAddNewItem}
+          buttonStyle="primary paneHeaderNewButton"
+        >
+          <FormattedMessage id="ui-inventory.addItem" />
+        </Button>
+      </div>
+    );
   }
 
   render() {
@@ -86,11 +111,7 @@ class ItemsPerHoldingsRecord extends React.Component {
     referenceTables.loanTypes = loantypes;
     referenceTables.materialTypes = materialtypes;
 
-    const viewHoldingsPath = `/inventory/view/${this.props.instance.id}/${this.props.holdingsRecord.id}`;
-
     const formatMsg = this.props.stripes.intl.formatMessage;
-    const viewHoldingsButton = <Link to={viewHoldingsPath}><Button id="clickable-view-holdings">{formatMsg({ id: 'ui-inventory.viewHoldings' })}</Button></Link>;
-    const newItemButton = <Button id="clickable-new-item" onClick={this.onClickAddNewItem} title={formatMsg({ id: 'ui-inventory.addItem' })} buttonStyle="primary paneHeaderNewButton">{formatMsg({ id: 'ui-inventory.addItem' })}</Button>;
     const labelLocation = holdingsRecord.permanentLocationId ? locationsById[holdingsRecord.permanentLocationId].name : '';
     const labelCallNumber = holdingsRecord.callNumber || '';
 
@@ -100,13 +121,7 @@ class ItemsPerHoldingsRecord extends React.Component {
         id={holdingsRecord.id}
         onToggle={accordionToggle}
         label={formatMsg({ id: 'ui-inventory.holdingsHeader' }, { location: labelLocation, callNumber: labelCallNumber })}
-        displayWhenOpen={(
-          <div>
-            {viewHoldingsButton}
-            {' '}
-            {newItemButton}
-          </div>
-        )}
+        displayWhenOpen={this.renderButtonsGroup()}
       >
         <Row>
           <Col sm={12}>

--- a/src/ViewItem.js
+++ b/src/ViewItem.js
@@ -3,7 +3,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
 import Link from 'react-router-dom/Link';
-import { FormattedTime } from 'react-intl';
+import {
+  FormattedTime,
+  FormattedMessage,
+} from 'react-intl';
 import {
   Pane,
   PaneMenu,
@@ -216,10 +219,42 @@ class ViewItem extends React.Component {
     this.props.mutator.query.update({ layer: 'copyItem' });
   }
 
+  /* eslint-disable quote-props */
+  getActionMenuItems = () => {
+    const firstItem = _.get(this.props.resources, 'items.records[0]');
+
+    return [
+      {
+        'data-test-inventory-edit-item-action': true,
+        label: <FormattedMessage id="ui-inventory.editItem" />,
+        href: this.craftLayerUrl('editItem'),
+        onClick: this.onClickEditItem,
+      },
+      {
+        'data-test-inventory-duplicate-item-action': true,
+        onClick: () => this.onCopy(firstItem),
+        label: <FormattedMessage id="ui-inventory.duplicateItem" />
+      }
+    ];
+  };
+  /* eslint-enable quote-props */
+
   render() {
-    const { location, resources: { items, holdingsRecords, instances1, materialTypes, loanTypes, requests },
+    const {
+      location,
+      resources: {
+        items,
+        holdingsRecords,
+        instances1,
+        materialTypes,
+        loanTypes,
+        requests,
+      },
       referenceTables,
-      okapi, stripes: { intl } } = this.props;
+      okapi,
+      paneWidth,
+      stripes: { intl },
+    } = this.props;
 
     const formatMsg = intl.formatMessage;
 
@@ -277,9 +312,10 @@ class ViewItem extends React.Component {
       <div>
         <Layer isOpen label="View Item">
           <Pane
-            defaultWidth={this.props.paneWidth}
+            data-test-item-view-page
+            defaultWidth={paneWidth}
             paneTitle={
-              <div style={{ textAlign: 'center' }}>
+              <div style={{ textAlign: 'center' }} data-test-header-title>
                 <AppIcon app="inventory" iconKey="item" size="small" />
                 {' '}
                 {_.get(item, ['barcode'], '')}
@@ -291,15 +327,7 @@ class ViewItem extends React.Component {
             lastMenu={detailMenu}
             dismissible
             onClose={this.props.onCloseViewItem}
-            actionMenuItems={[{
-              label: formatMsg({ id: 'ui-inventory.editItem' }),
-              href: this.craftLayerUrl('editItem'),
-              onClick: this.onClickEditItem,
-            }, {
-              id: 'clickable-copy-item',
-              onClick: () => this.onCopy(item),
-              label: formatMsg({ id: 'ui-inventory.copyItem' })
-            }]}
+            actionMenuItems={this.getActionMenuItems()}
           >
             <Row center="xs">
               <Col sm={6}>
@@ -307,13 +335,13 @@ class ViewItem extends React.Component {
                 {' '}
                 {instance.title}
                 {(instance.publication && instance.publication.length > 0) &&
-                <span>
-                  <em>, </em>
-                  <em>
-                    {instance.publication[0].publisher}
-                    {instance.publication[0].dateOfPublication ? `, ${instance.publication[0].dateOfPublication}` : ''}
-                  </em>
-                </span>
+                  <span>
+                    <em>, </em>
+                    <em>
+                      {instance.publication[0].publisher}
+                      {instance.publication[0].dateOfPublication ? `, ${instance.publication[0].dateOfPublication}` : ''}
+                    </em>
+                  </span>
                 }
                 <div>
                   { `${formatMsg({ id: 'ui-inventory.holdingsColon' })} ${labelPermanentHoldingsLocation} > ${labelCallNumber}`}
@@ -353,9 +381,9 @@ class ViewItem extends React.Component {
                   <KeyValue label={formatMsg({ id: 'ui-inventory.itemHrid' })} value={_.get(item, ['id'], '')} />
                 </Col>
                 { (item.barcode) &&
-                  <Col xs={3}>
-                    <KeyValue label={formatMsg({ id: 'ui-inventory.itemBarcode' })} value={_.get(item, ['barcode'], '')} />
-                  </Col>
+                <Col xs={3}>
+                  <KeyValue label={formatMsg({ id: 'ui-inventory.itemBarcode' })} value={_.get(item, ['barcode'], '')} />
+                </Col>
                 }
               </Row>
             </Accordion>
@@ -372,14 +400,14 @@ class ViewItem extends React.Component {
               </Row>
               <Row>
                 { (item.pieceIdentifiers) &&
-                  <Col smOffset={0} sm={4}>
-                    <KeyValue label={formatMsg({ id: 'ui-inventory.pieceIdentifiers' })} value={_.get(item, ['pieceIdentifiers'], []).map((line, i) => <div key={i}>{line}</div>)} />
-                  </Col>
+                <Col smOffset={0} sm={4}>
+                  <KeyValue label={formatMsg({ id: 'ui-inventory.pieceIdentifiers' })} value={_.get(item, ['pieceIdentifiers'], []).map((line, i) => <div key={i}>{line}</div>)} />
+                </Col>
                 }
                 { (item.numberOfPieces) &&
-                  <Col smOffset={0} sm={4}>
-                    <KeyValue label={formatMsg({ id: 'ui-inventory.numberOfPieces' })} value={_.get(item, ['numberOfPieces'], '')} />
-                  </Col>
+                <Col smOffset={0} sm={4}>
+                  <KeyValue label={formatMsg({ id: 'ui-inventory.numberOfPieces' })} value={_.get(item, ['numberOfPieces'], '')} />
+                </Col>
                 }
               </Row>
             </Accordion>
@@ -391,14 +419,14 @@ class ViewItem extends React.Component {
             >
               <Row>
                 { (item.enumeration) &&
-                  <Col smOffset={0} sm={4}>
-                    <KeyValue label={formatMsg({ id: 'ui-inventory.enumeration' })} value={_.get(item, ['enumeration'], '')} />
-                  </Col>
+                <Col smOffset={0} sm={4}>
+                  <KeyValue label={formatMsg({ id: 'ui-inventory.enumeration' })} value={_.get(item, ['enumeration'], '')} />
+                </Col>
                 }
                 { (item.chronology) &&
-                  <Col smOffset={0} sm={4}>
-                    <KeyValue label={formatMsg({ id: 'ui-inventory.chronology' })} value={_.get(item, ['chronology'], '')} />
-                  </Col>
+                <Col smOffset={0} sm={4}>
+                  <KeyValue label={formatMsg({ id: 'ui-inventory.chronology' })} value={_.get(item, ['chronology'], '')} />
+                </Col>
                 }
               </Row>
             </Accordion>
@@ -429,14 +457,14 @@ class ViewItem extends React.Component {
             >
               <Row>
                 { (item.permanentLoanType) &&
-                  <Col smOffset={0} sm={4}>
-                    <KeyValue label={formatMsg({ id: 'ui-inventory.permanentLoantype' })} value={_.get(item, ['permanentLoanType', 'name'], '')} />
-                  </Col>
+                <Col smOffset={0} sm={4}>
+                  <KeyValue label={formatMsg({ id: 'ui-inventory.permanentLoantype' })} value={_.get(item, ['permanentLoanType', 'name'], '')} />
+                </Col>
                 }
                 { (item.temporaryLoanType) &&
-                  <Col smOffset={0} sm={4}>
-                    <KeyValue label={formatMsg({ id: 'ui-inventory.temporaryLoantype' })} value={_.get(item, ['temporaryLoanType', 'name'], '')} />
-                  </Col>
+                <Col smOffset={0} sm={4}>
+                  <KeyValue label={formatMsg({ id: 'ui-inventory.temporaryLoantype' })} value={_.get(item, ['temporaryLoanType', 'name'], '')} />
+                </Col>
                 }
               </Row>
               <Row>
@@ -545,7 +573,6 @@ class ViewItem extends React.Component {
             stripes={this.props.stripes}
           />
         </Layer>
-
       </div>
     );
   }

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -84,6 +84,13 @@ class ItemForm extends React.Component {
       confirmTemporaryLocation: false,
     };
     this.cViewMetaData = props.stripes.connect(ViewMetaData);
+    /* eslint-disable quote-props */
+    this.actionMenuItems = [{
+      'data-test-inventory-cancel-item-edit-action': true,
+      label: <FormattedMessage id="ui-inventory.cancel" />,
+      onClick: props.onCancel,
+    }];
+    /* eslint-enable quote-props */
   }
 
   componentDidMount() {
@@ -228,7 +235,7 @@ class ItemForm extends React.Component {
     const labelCallNumber = holdingsRecord.callNumber || '';
 
     return (
-      <form>
+      <form data-test-item-page-type={initialValues.id ? 'edit' : 'create'}>
         <Paneset isRoot>
           <Pane
             defaultWidth="100%"
@@ -236,7 +243,10 @@ class ItemForm extends React.Component {
             onClose={onCancel}
             lastMenu={(initialValues.id) ? editItemLastMenu : addItemLastMenu}
             paneTitle={
-              <div style={{ textAlign: 'center' }}>
+              <div
+                style={{ textAlign: 'center' }}
+                data-test-header-title
+              >
                 <em>{instance.title}</em>
                 {(instance.publication && instance.publication.length > 0) &&
                   <span>
@@ -248,11 +258,11 @@ class ItemForm extends React.Component {
                   </span>
                 }
                 <div>
-                  &nbsp;
-                  {`Holdings: ${labelLocation} > ${labelCallNumber}`}
+                  {` Holdings: ${labelLocation} > ${labelCallNumber}`}
                 </div>
               </div>
             }
+            actionMenuItems={this.actionMenuItems}
           >
             <Row>
               <Col
@@ -408,7 +418,6 @@ class ItemForm extends React.Component {
               onConfirm={() => { this.confirmTemporaryLocation(true); }}
               onCancel={() => { this.confirmTemporaryLocation(false); }}
             />
-
           </Pane>
         </Paneset>
       </form>

--- a/test/bigtest/interactors/item-create-page.js
+++ b/test/bigtest/interactors/item-create-page.js
@@ -1,0 +1,21 @@
+import {
+  interactor,
+  clickable,
+  text,
+} from '@bigtest/interactor';
+
+@interactor class HeaderDropdown {
+  click = clickable('button');
+}
+
+@interactor class HeaderDropdownMenu {
+  clickCancel = clickable('[data-test-inventory-cancel-item-edit-action]');
+}
+
+@interactor class ItemCreatePage {
+  title = text('[data-test-header-title]');
+  headerDropdown = new HeaderDropdown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
+  headerDropdownMenu = new HeaderDropdownMenu();
+}
+
+export default new ItemCreatePage('[data-test-item-page-type="create"]');

--- a/test/bigtest/interactors/item-edit-page.js
+++ b/test/bigtest/interactors/item-edit-page.js
@@ -1,0 +1,21 @@
+import {
+  interactor,
+  clickable,
+  text,
+} from '@bigtest/interactor';
+
+@interactor class HeaderDropdown {
+  click = clickable('button');
+}
+
+@interactor class HeaderDropdownMenu {
+  clickCancel = clickable('[data-test-inventory-cancel-item-edit-action]');
+}
+
+@interactor class ItemEditPage {
+  title = text('[data-test-header-title]');
+  headerDropdown = new HeaderDropdown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
+  headerDropdownMenu = new HeaderDropdownMenu();
+}
+
+export default new ItemEditPage('[data-test-item-page-type="edit"]');

--- a/test/bigtest/interactors/item-view-page.js
+++ b/test/bigtest/interactors/item-view-page.js
@@ -1,0 +1,22 @@
+import {
+  interactor,
+  clickable,
+  text,
+} from '@bigtest/interactor';
+
+@interactor class HeaderDropdown {
+  click = clickable('button');
+}
+
+@interactor class HeaderDropdownMenu {
+  clickEdit = clickable('[data-test-inventory-edit-item-action]');
+  clickDuplicate = clickable('[data-test-inventory-duplicate-item-action]');
+}
+
+@interactor class ItemViewPage {
+  title = text('[data-test-header-title]');
+  headerDropdown = new HeaderDropdown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
+  headerDropdownMenu = new HeaderDropdownMenu();
+}
+
+export default new ItemViewPage('[data-test-item-view-page]');

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -150,4 +150,7 @@ export default function configure() {
     callNumberTypes: [],
     totalRecords: 0
   });
+
+  this.get('/material-types');
+  this.get('/loan-types');
 }

--- a/test/bigtest/tests/item-edit-page-test.js
+++ b/test/bigtest/tests/item-edit-page-test.js
@@ -1,0 +1,79 @@
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import setupApplication from '../helpers/setup-application';
+import ItemEditPage from '../interactors/item-edit-page';
+import InstanceViewPage from '../interactors/instance-view-page';
+
+describe('ItemEditPage', () => {
+  setupApplication();
+
+  let instance;
+
+  const holdings = {
+    id: '0e3a404a-61a9-4388-9d11-c7d62d491165',
+    callNumber: 911,
+  };
+
+  const item = {
+    id: '7fd93634-a3f5-4a7a-9db2-1c6dc4bd6b65',
+    status : {
+      name: 'Available',
+    },
+    title: 'ADVANCING RESEARCH',
+    holdingsRecordId: holdings.id,
+    barcode: 337,
+    pieceIdentifiers: [],
+    notes: [],
+    materialType: {
+      id: '1a54b431-2e4f-452d-9cae-9cee66c9a892',
+      name: 'book'
+    },
+    permanentLoanType: {
+      id: '2b94c631-fca9-4892-a730-03ee529ffe27',
+      name: 'Can circulate'
+    },
+    metadata: {
+      createdDate: '2018-11-08T09:13:10.786+0000',
+      createdByUserId: 'a57c472e-82fe-552f-864d-5f41ac1c8e43',
+      updatedDate: '2018-11-08T09:13:10.786+0000',
+      updatedByUserId: 'a57c472e-82fe-552f-864d-5f41ac1c8e43'
+    },
+    links: {},
+    effectiveLocation: {
+      id: 'fcd64ce1-6995-48f0-840e-89ffa2288371',
+      name: 'Main Library'
+    }
+  };
+
+  beforeEach(function () {
+    instance = this.server.create('instance', {
+      title: 'ADVANCING RESEARCH',
+    });
+
+    this.server.get('/holdings-storage/holdings/:id', holdings);
+    this.server.get('/inventory/items/:id', item);
+
+    this.visit(`/inventory/view/${instance.id}/${holdings.id}/${item.id}?layer=editItem`);
+  });
+
+  it('displays a title in the pane header', () => {
+    expect(ItemEditPage.title).to.equal(`${instance.title} Holdings: > ${holdings.callNumber}`);
+  });
+
+  describe('pane header menu', () => {
+    beforeEach(async () => {
+      await ItemEditPage.headerDropdown.click();
+    });
+
+    describe('clicking on cancel', () => {
+      beforeEach(async () => {
+        await ItemEditPage.headerDropdownMenu.clickCancel();
+      });
+
+      it('should redirect to instance view page after click', () => {
+        expect(InstanceViewPage.$root).to.exist;
+      });
+    });
+  });
+});

--- a/test/bigtest/tests/item-view-page-test.js
+++ b/test/bigtest/tests/item-view-page-test.js
@@ -1,0 +1,91 @@
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import setupApplication from '../helpers/setup-application';
+import ItemViewPage from '../interactors/item-view-page';
+import ItemEditPage from '../interactors/item-edit-page';
+import ItemCreatePage from '../interactors/item-create-page';
+
+describe('ItemViewPage', () => {
+  setupApplication();
+
+  describe('visiting the item view page', () => {
+    let instance;
+
+    const holdings = {
+      id: '0e3a404a-61a9-4388-9d11-c7d62d491165',
+    };
+
+    const item = {
+      id: '7fd93634-a3f5-4a7a-9db2-1c6dc4bd6b65',
+      status : {
+        name: 'Available',
+      },
+      title: '14 cows for America',
+      holdingsRecordId: '5f6d50f1-e3bf-4c04-8621-4e3dc3d9b543',
+      barcode: 337,
+      pieceIdentifiers: [],
+      notes: [],
+      materialType: {
+        id: '1a54b431-2e4f-452d-9cae-9cee66c9a892',
+        name: 'book'
+      },
+      permanentLoanType: {
+        id: '2b94c631-fca9-4892-a730-03ee529ffe27',
+        name: 'Can circulate'
+      },
+      metadata: {
+        createdDate: '2018-11-08T09:13:10.786+0000',
+        createdByUserId: 'a57c472e-82fe-552f-864d-5f41ac1c8e43',
+        updatedDate: '2018-11-08T09:13:10.786+0000',
+        updatedByUserId: 'a57c472e-82fe-552f-864d-5f41ac1c8e43'
+      },
+      links: {},
+      effectiveLocation: {
+        id: 'fcd64ce1-6995-48f0-840e-89ffa2288371',
+        name: 'Main Library'
+      }
+    };
+
+    beforeEach(async function () {
+      instance = this.server.create('instance', {
+        title: 'ADVANCING RESEARCH',
+      });
+
+      this.server.get('/holdings-storage/holdings/:id', holdings);
+      this.server.get('/inventory/items/:id', item);
+
+      this.visit(`/inventory/view/${instance.id}/${holdings.id}/${item.id}`);
+    });
+
+    it('displays the title in the pane header', () => {
+      expect(ItemViewPage.title).to.equal(`${item.barcode}Item . ${item.status.name}`);
+    });
+
+    describe('pane header dropdown menu', () => {
+      beforeEach(async () => {
+        await ItemViewPage.headerDropdown.click();
+      });
+
+      describe('clicking on edit', () => {
+        beforeEach(async () => {
+          await ItemViewPage.headerDropdownMenu.clickEdit();
+        });
+
+        it('should redirect to item edit page', () => {
+          expect(ItemEditPage.$root).to.exist;
+        });
+      });
+
+      describe('clicking on duplicate', () => {
+        beforeEach(async () => {
+          await ItemViewPage.headerDropdownMenu.clickDuplicate();
+        });
+
+        it('should redirect to item create page', () => {
+          expect(ItemCreatePage.$root).to.exist;
+        });
+      });
+    });
+  });
+});

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -263,5 +263,6 @@
   "itemCallNumber": "Item call number",
   "otherRelatedInstances": "Other related instances",
   "relatedInstances": "Related instances",
-  "copyItem": "Copy item"
+  "duplicateItem": "Duplicate item",
+  "editItem": "Edit item"
 }


### PR DESCRIPTION
## Purpose
Add pane header dropdowns to Item create, edit pages. Also, replace text of the 'copy' drop-down action item with 'duplicate'.

## Approach
- Create and pass `menuActionItems` prop with items to `Pane` component.
- Add tests to check dropdowns functionality

##Screenshots
Item details page:
<img width="1679" alt="new item creation page" src="https://user-images.githubusercontent.com/43621626/48842573-464e8700-ed9d-11e8-8db0-dcd572be30ac.png">

New item create page:
<img width="1679" alt="item edit page" src="https://user-images.githubusercontent.com/43621626/48842587-51091c00-ed9d-11e8-9d76-58ad3a20d16c.png">

Item edit page:
<img width="1679" alt="item details page" src="https://user-images.githubusercontent.com/43621626/48842611-59f9ed80-ed9d-11e8-9ef2-4e3fc4fac15d.png">
