### PR TITLE
restore missing element IDs

### DIFF
--- a/src/ItemsPerHoldingsRecord.js
+++ b/src/ItemsPerHoldingsRecord.js
@@ -95,12 +95,14 @@ class ItemsPerHoldingsRecord extends React.Component {
     return (
       <div>
         <Button
+          id="clickable-view-holdings"
           to={{ pathname: `/inventory/view/${instance.id}/${holdingsRecord.id}` }}
           style={{ marginRight: '5px' }}
         >
           <FormattedMessage id="ui-inventory.viewHoldings" />
         </Button>
         <Button
+          id="clickable-new-item"
           onClick={this.onClickAddNewItem}
           buttonStyle="primary paneHeaderNewButton"
         >


### PR DESCRIPTION
Element IDs for the view-holdings button and new-item-record button were
inadvertently removed in #366. This restores them.