### PR TITLE
UIIN-400 Bind update method to ViewInstance

### DIFF
--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -94,7 +94,7 @@ class ViewInstance extends React.Component {
     this.props.mutator.query.update({ layer: 'createHoldingsRecord' });
   }
 
-  update(instance) {
+  update = (instance) => {
     this.props.mutator.selectedInstance.PUT(instance).then(() => {
       this.closeEditInstance();
     });


### PR DESCRIPTION
## Purpose
Resolves https://issues.folio.org/browse/UIIN-400

![screen shot 2018-11-27 at 2 57 30 pm](https://user-images.githubusercontent.com/230597/49111090-c7ea5d00-f254-11e8-95a5-68d342b0e434.png)

## Approach
`this.props` was undefined in `update` because it didn't have the class scope. This regression was probably introduced with https://github.com/folio-org/ui-inventory/pull/341, but I'm not really sure how this ever worked before that.