### PR TITLE
Depend on multiple interface version for transition MODINVSTOR-231

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
       }
     ],
     "okapiInterfaces": {
-      "inventory": "7.0",
-      "instance-storage": "5.0",
-      "holdings-storage": "2.1",
-      "item-storage": "6.0",
+      "inventory": "7.0 8.0",
+      "instance-storage": "5.0 6.0",
+      "holdings-storage": "2.1 3.0",
+      "item-storage": "6.0 7.0",
       "loan-types": "2.0",
       "material-types": "2.0",
       "item-note-types": "1.0",


### PR DESCRIPTION
  Depend on multiple versions of inventory interfaces
  after merge -- but not release -- of inventory module changes.