### PR TITLE
Renamed getActionMenu to createActionMenuGetter

### DIFF
--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -150,7 +150,7 @@ class ViewInstance extends React.Component {
     return ref || {};
   }
 
-  getActionMenu = instance => ({ onToggle }) => {
+  createActionMenuGetter = instance => ({ onToggle }) => {
     const { onCopy } = this.props;
     return (
       <Fragment>
@@ -361,7 +361,7 @@ class ViewInstance extends React.Component {
         lastMenu={detailMenu}
         dismissible
         onClose={onClose}
-        actionMenu={this.getActionMenu(instance)}
+        actionMenu={this.createActionMenuGetter(instance)}
       >
         <TitleManager record={instance.title} />
         <Row end="xs">


### PR DESCRIPTION
Renamed getActionMenu to createActionMenuGetter for better clarity of what's going on since we are passing the instance into the curried function.