### PR TITLE
Cleanup test output

### DIFF
--- a/test/bigtest/network/models/loan-type.js
+++ b/test/bigtest/network/models/loan-type.js
@@ -1,0 +1,3 @@
+import { Model } from '@bigtest/mirage';
+
+export default Model.extend();

--- a/test/bigtest/network/models/material-type.js
+++ b/test/bigtest/network/models/material-type.js
@@ -1,0 +1,3 @@
+import { Model } from '@bigtest/mirage';
+
+export default Model.extend();

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -251,6 +251,7 @@
   "removeIdentifier": "Remove identifier {num}",
   "editItemDialog": "Edit item dialog",
   "copyItemDialog": "Copy item dialog",
+  "copyItem": "Copy item",
   "confirmLocation.selectBtn": "Select",
   "confirmLocation.message": "This location has a status of inactive. Are you sure you want to select this location?",
   "confirmLocation.header": "Inactive location",


### PR DESCRIPTION
## Purpose
The BigTest output was pretty noisy with errors and warnings.

## Approach
- Add `copyItem` translation to English
- Add missing mirage model declarations

## Not addressed
- `A11y: please supply a string to the <Layer> prop 'contentLabel' for assistive technology users`: can be handled with https://issues.folio.org/browse/UIIN-381
- The CQL parser copied from https://github.com/indexdata/cql-js seems to have trouble parsing some of the query strings