### PR TITLE
correctly show inventory-edit checkbox statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## 1.5.1 (IN PROGRESS)
+
+* Correctly show instance-edit checkbox status. Fixes UIIN-417
+
 ## [1.5.0](https://github.com/folio-org/ui-inventory/tree/v1.5.0) (2018-12-14)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.4.0...v1.5.0)
 

--- a/src/edit/InstanceForm.js
+++ b/src/edit/InstanceForm.js
@@ -331,6 +331,7 @@ class InstanceForm extends React.Component {
                       name="discoverySuppress"
                       id="input_discovery_suppress"
                       component={Checkbox}
+                      type="checkbox"
                     />
                   </Col>
                   <Col sm={3}>
@@ -339,6 +340,7 @@ class InstanceForm extends React.Component {
                       name="staffSuppress"
                       id="input_staff_suppress"
                       component={Checkbox}
+                      type="checkbox"
                     />
                   </Col>
                   <Col sm={3}>
@@ -347,6 +349,7 @@ class InstanceForm extends React.Component {
                       name="previouslyHeld"
                       id="input_previously_held"
                       component={Checkbox}
+                      type="checkbox"
                     />
                   </Col>
                 </Row>


### PR DESCRIPTION
`<Checkbox>` fields need the `type="checkbox"` prop in order to
correctly cast their values.

Fixes [UIIN-417](https://issues.folio.org/browse/UIIN-417)