### PR TITLE
Add description of pieces to item detail screen. Fixes UIIN-447.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## 1.7.0 (IN PROGRESS)
+
+* Add description of pieces to item detail screen. Fixes UIIN-447.
+
 ## [1.6.0](https://github.com/folio-org/ui-inventory/tree/v1.6.0) (2019-01-25)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.5.0...v1.6.0)
 

--- a/src/ViewItem.js
+++ b/src/ViewItem.js
@@ -691,7 +691,7 @@ class ViewItem extends React.Component {
               </Row>
               <Row>
                 {(item.copyNumbers && item.copyNumbers.length > 0) &&
-                  <Col smOffset={0} sm={4}>
+                  <Col smOffset={0} sm={2}>
                     <KeyValue
                       label={<FormattedMessage id="ui-inventory.copyNumbers" />}
                       value={_.get(item, ['copyNumbers'], []).map((line, i) => <div key={i}>{line}</div>)}
@@ -699,13 +699,19 @@ class ViewItem extends React.Component {
                   </Col>
                 }
                 {(item.numberOfPieces) &&
-                  <Col smOffset={0} sm={4}>
+                  <Col smOffset={0} sm={2}>
                     <KeyValue
                       label={<FormattedMessage id="ui-inventory.numberOfPieces" />}
-                      value={_.get(item, ['numberOfPieces'], '')}
+                      value={_.get(item, ['numberOfPieces'], '-')}
                     />
                   </Col>
                 }
+                <Col smOffset={0} sm={4}>
+                  <KeyValue
+                    label={<FormattedMessage id="ui-inventory.descriptionOfPieces" />}
+                    value={_.get(item, ['descriptionOfPieces'], '-')}
+                  />
+                </Col>
               </Row>
             </Accordion>
             <Accordion


### PR DESCRIPTION
## Purpose

Add description of pieces to item detail screen.

## Link
https://issues.folio.org/browse/UIIN-447

## Screenshot
![item](https://user-images.githubusercontent.com/63545/52135067-ff89d280-2612-11e9-981f-c36a908df82c.png)
