### PR TITLE
update BigTest interactor for MCL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.7.0 (IN PROGRESS)
 
 * Add description of pieces to item detail screen. Fixes UIIN-447.
+* Update BigTest interactors to reflect MCL aria changes. Refs STRIPES-597.
 
 ## [1.6.0](https://github.com/folio-org/ui-inventory/tree/v1.6.0) (2019-01-25)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.5.0...v1.6.0)

--- a/test/bigtest/interactors/inventory.js
+++ b/test/bigtest/interactors/inventory.js
@@ -7,7 +7,7 @@ import {
 export default @interactor class InventoryInteractor {
   static defaultScope = '[data-test-inventory-instances]';
 
-  instances = collection('[role=listitem] a');
+  instances = collection('[role=row] a');
 
   instance = scoped('[data-test-instance-details]');
 }


### PR DESCRIPTION
MCL recently changed how it uses some ARIA properties and the downstream
tests need to reflect this.

Refs [STRIPES-597](https://issues.folio.org/browse/STRIPES-597), [STCOM-365](https://issues.folio.org/browse/STCOM-365)