### PR TITLE
Add subheadings to the locations accordion on the holding record view. Fixes UIIN-416.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add description of pieces to item detail screen. Fixes UIIN-447.
 * Update BigTest interactors to reflect MCL aria changes. Refs STRIPES-597.
 * Move `AppIcon` import to `@folio/stripes/core`. Refs STCOM-411.
+* Add subheadings to the Locations accordion on holding record view. Fixes UIIN-416.
 
 ## [1.6.0](https://github.com/folio-org/ui-inventory/tree/v1.6.0) (2019-01-25)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.5.0...v1.6.0)

--- a/src/edit/holdings/HoldingsForm.js
+++ b/src/edit/holdings/HoldingsForm.js
@@ -440,6 +440,14 @@ class HoldingsForm extends React.Component {
               label={<FormattedMessage id="ui-inventory.locations" />}
             >
               <Row>
+                <Col smOffset={0} sm={4}>
+                  <strong>
+                    <FormattedMessage id="ui-inventory.holdingsLocation" />
+                  </strong>
+                </Col>
+              </Row>
+              <br />
+              <Row>
                 <Col sm={4}>
                   <FormattedMessage id="ui-inventory.selectLocation">
                     {placeholder => (
@@ -525,6 +533,17 @@ class HoldingsForm extends React.Component {
                   />
                 </Col>
               </Row>
+              <Row>
+                <Col
+                  smOffset={0}
+                  sm={4}
+                >
+                  <strong>
+                    <FormattedMessage id="ui-inventory.holdingsCallNumber" />
+                  </strong>
+                </Col>
+              </Row>
+              <br />
               <Row>
                 <Col sm={2}>
                   <Field


### PR DESCRIPTION
## Purpose
Add subheadings to the locations accordion on the holding record view.

## Link
https://issues.folio.org/browse/UIIN-416

## Screenshot
![locations](https://user-images.githubusercontent.com/63545/52216784-0b6cd300-2865-11e9-8a9b-4a54d1ee90f1.png)
