### PR TITLE
Replace query resource with react-router history push. Refs STCOM-302

### DIFF
--- a/package.json
+++ b/package.json
@@ -305,6 +305,7 @@
     "query-string": "^5.0.0",
     "react-hot-loader": "^4.3.12",
     "react-intl": "^2.3.0",
+    "react-router": "^4.0.0",
     "react-router-dom": "^4.0.0",
     "redux-form": "^7.0.3"
   },

--- a/src/Instances.js
+++ b/src/Instances.js
@@ -457,7 +457,7 @@ Instances.propTypes = {
   disableRecordCreation: PropTypes.bool,
   onSelectRow: PropTypes.func,
   visibleColumns: PropTypes.arrayOf(PropTypes.string),
-  updateLocation: PropTypes.func,
+  updateLocation: PropTypes.func.isRequired,
 };
 
 export default withLocation(Instances);

--- a/src/Instances.js
+++ b/src/Instances.js
@@ -14,6 +14,7 @@ import packageInfo from '../package';
 import InstanceForm from './edit/InstanceForm';
 import ViewInstance from './ViewInstance';
 import formatters from './referenceFormatters';
+import withLocation from './withLocation';
 
 const INITIAL_RESULT_COUNT = 30;
 const RESULT_COUNT_INCREMENT = 30;
@@ -264,22 +265,23 @@ class Instances extends React.Component {
 
   onChangeIndex = (e) => {
     const qindex = e.target.value;
-    this.props.mutator.query.update({ qindex });
+    this.props.updateLocation({ qindex });
   }
 
-  updateFilters(filters) { // provided for onChangeFilter
-    this.props.mutator.query.update({ filters: Object.keys(filters).filter(key => filters[key]).join(',') });
+  updateFilters(prevFilters) { // provided for onChangeFilter
+    const filters = Object.keys(prevFilters).filter(key => filters[key]).join(',');
+    this.props.updateLocation({ filters });
   }
 
   closeNewInstance = (e) => {
     if (e) e.preventDefault();
     this.setState({ copiedInstance: null });
-    this.props.mutator.query.update({ layer: null });
+    this.props.updateLocation({ layer: null });
   }
 
   copyInstance(instance) {
     this.setState({ copiedInstance: _.omit(instance, ['id', 'hrid']) });
-    this.props.mutator.query.update({ layer: 'create' });
+    this.props.updateLocation({ layer: 'create' });
   }
 
   createInstance = (instance) => {
@@ -455,6 +457,7 @@ Instances.propTypes = {
   disableRecordCreation: PropTypes.bool,
   onSelectRow: PropTypes.func,
   visibleColumns: PropTypes.arrayOf(PropTypes.string),
+  updateLocation: PropTypes.func,
 };
 
-export default Instances;
+export default withLocation(Instances);

--- a/src/ItemsPerHoldingsRecord.js
+++ b/src/ItemsPerHoldingsRecord.js
@@ -13,6 +13,7 @@ import {
 
 import Items from './Items';
 import ItemForm from './edit/items/ItemForm';
+import withlocation from './withLocation';
 
 /**
  * Accordion wrapper for an individual Holdings record on the instance-view
@@ -68,7 +69,7 @@ class ItemsPerHoldingsRecord extends React.Component {
 
     mutator.addItemMode.replace({ mode: true });
     this.addItemModeThisLayer = true;
-    mutator.query.update({ layer: 'createItem' });
+    this.props.updateLocation({ layer: 'createItem' });
   };
 
   onClickCloseNewItem = (e) => {
@@ -78,7 +79,7 @@ class ItemsPerHoldingsRecord extends React.Component {
 
     mutator.addItemMode.replace({ mode: false });
     this.addItemModeThisLayer = false;
-    mutator.query.update({ layer: null });
+    this.props.updateLocation({ layer: null });
   }
 
   createItem = (item) => {
@@ -230,6 +231,7 @@ ItemsPerHoldingsRecord.propTypes = {
   okapi: PropTypes.object,
   accordionToggle: PropTypes.func.isRequired,
   accordionStates: PropTypes.object.isRequired,
+  updateLocation: PropTypes.func,
 };
 
-export default ItemsPerHoldingsRecord;
+export default withlocation(ItemsPerHoldingsRecord);

--- a/src/ItemsPerHoldingsRecord.js
+++ b/src/ItemsPerHoldingsRecord.js
@@ -231,7 +231,7 @@ ItemsPerHoldingsRecord.propTypes = {
   okapi: PropTypes.object,
   accordionToggle: PropTypes.func.isRequired,
   accordionStates: PropTypes.object.isRequired,
-  updateLocation: PropTypes.func,
+  updateLocation: PropTypes.func.isRequired,
 };
 
 export default withlocation(ItemsPerHoldingsRecord);

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -26,6 +26,7 @@ import {
 
 import { craftLayerUrl } from './utils';
 import HoldingsForm from './edit/holdings/HoldingsForm';
+import withLocation from './withLocation';
 
 class ViewHoldingsRecord extends React.Component {
   static manifest = Object.freeze({
@@ -112,12 +113,12 @@ class ViewHoldingsRecord extends React.Component {
   // Edit Holdings records handlers
   onClickEditHoldingsRecord = (e) => {
     if (e) e.preventDefault();
-    this.props.mutator.query.update({ layer: 'editHoldingsRecord' });
+    this.props.updateLocation({ layer: 'editHoldingsRecord' });
   }
 
   onClickCloseEditHoldingsRecord = (e) => {
     if (e) e.preventDefault();
-    this.props.mutator.query.update({ layer: null });
+    this.props.updateLocation({ layer: null });
   }
 
   updateHoldingsRecord = (holdingsRecord) => {
@@ -133,10 +134,7 @@ class ViewHoldingsRecord extends React.Component {
     const instance = instances1.records[0];
 
     this.props.mutator.holdingsRecords.POST(holdingsRecord).then((data) => {
-      this.props.mutator.query.update({
-        _path: `/inventory/view/${instance.id}/${data.id}`,
-        layer: null,
-      });
+      this.props.goTo(`/inventory/view/${instance.id}/${data.id}`);
     });
   }
 
@@ -163,7 +161,7 @@ class ViewHoldingsRecord extends React.Component {
       return newState;
     });
 
-    this.props.mutator.query.update({ layer: 'copyHoldingsRecord' });
+    this.props.updateLocation({ layer: 'copyHoldingsRecord' });
   }
 
   refLookup = (referenceTable, id) => {
@@ -846,7 +844,9 @@ ViewHoldingsRecord.propTypes = {
     temporaryLocationQuery: PropTypes.object.isRequired,
   }),
   onCloseViewHoldingsRecord: PropTypes.func.isRequired,
+  updateLocation: PropTypes.func,
+  goTo: PropTypes.func,
 };
 
 
-export default ViewHoldingsRecord;
+export default withLocation(ViewHoldingsRecord);

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -844,8 +844,8 @@ ViewHoldingsRecord.propTypes = {
     temporaryLocationQuery: PropTypes.object.isRequired,
   }),
   onCloseViewHoldingsRecord: PropTypes.func.isRequired,
-  updateLocation: PropTypes.func,
-  goTo: PropTypes.func,
+  updateLocation: PropTypes.func.isRequired,
+  goTo: PropTypes.func.isRequired,
 };
 
 

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -38,6 +38,7 @@ import ViewHoldingsRecord from './ViewHoldingsRecord';
 import ViewItem from './ViewItem';
 import ViewMarc from './ViewMarc';
 import makeConnectedInstance from './ConnectedInstance';
+import withLocation from './withLocation';
 
 class ViewInstance extends React.Component {
   static manifest = Object.freeze({
@@ -88,13 +89,14 @@ class ViewInstance extends React.Component {
   // Edit Instance Handlers
   onClickEditInstance = (e) => {
     if (e) e.preventDefault();
-    this.props.mutator.query.update({ layer: 'edit' });
+    console.log(this.props);
+    this.props.updateLocation({ layer: 'edit' });
   }
 
   onClickAddNewHoldingsRecord = (e) => {
     if (e) e.preventDefault();
     this.log('clicked "add new holdings record"');
-    this.props.mutator.query.update({ layer: 'createHoldingsRecord' });
+    this.props.updateLocation({ layer: 'createHoldingsRecord' });
   }
 
   update = (instance) => {
@@ -105,22 +107,22 @@ class ViewInstance extends React.Component {
 
   resetLayerQueryParam = (e) => {
     if (e) e.preventDefault();
-    this.props.mutator.query.update({ layer: null });
+    this.props.updateLocation({ layer: null });
   }
 
   closeViewItem = (e) => {
     if (e) e.preventDefault();
-    this.props.mutator.query.update({ _path: `/inventory/view/${this.props.match.params.id}` });
+    this.props.goTo(`/inventory/view/${this.props.match.params.id}`);
   }
 
   closeViewMarc = (e) => {
     if (e) e.preventDefault();
-    this.props.mutator.query.update({ _path: `/inventory/view/${this.props.match.params.id}` });
+    this.props.goTo(`/inventory/view/${this.props.match.params.id}`);
   }
 
   closeViewHoldingsRecord = (e) => {
     if (e) e.preventDefault();
-    this.props.mutator.query.update({ _path: `/inventory/view/${this.props.match.params.id}` });
+    this.props.goTo(`/inventory/view/${this.props.match.params.id}`);
   }
 
   createHoldingsRecord = (holdingsRecord) => {
@@ -1048,7 +1050,8 @@ ViewInstance.propTypes = {
   onClose: PropTypes.func,
   onCopy: PropTypes.func,
   paneWidth: PropTypes.string.isRequired,
+  updateLocation: PropTypes.func,
   okapi: PropTypes.object,
 };
 
-export default ViewInstance;
+export default withLocation(ViewInstance);

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -89,7 +89,6 @@ class ViewInstance extends React.Component {
   // Edit Instance Handlers
   onClickEditInstance = (e) => {
     if (e) e.preventDefault();
-    console.log(this.props);
     this.props.updateLocation({ layer: 'edit' });
   }
 

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -1049,7 +1049,7 @@ ViewInstance.propTypes = {
   onClose: PropTypes.func,
   onCopy: PropTypes.func,
   paneWidth: PropTypes.string.isRequired,
-  updateLocation: PropTypes.func,
+  updateLocation: PropTypes.func.isRequired,
   okapi: PropTypes.object,
 };
 

--- a/src/ViewItem.js
+++ b/src/ViewItem.js
@@ -31,6 +31,7 @@ import {
 
 import { craftLayerUrl } from './utils';
 import ItemForm from './edit/items/ItemForm';
+import withLocation from './withLocation';
 
 class ViewItem extends React.Component {
   static manifest = Object.freeze({
@@ -190,12 +191,12 @@ class ViewItem extends React.Component {
 
   onClickEditItem = (e) => {
     if (e) e.preventDefault();
-    this.props.mutator.query.update({ layer: 'editItem' });
+    this.props.updateLocation({ layer: 'editItem' });
   }
 
   onClickCloseEditItem = (e) => {
     if (e) e.preventDefault();
-    this.props.mutator.query.update({ layer: null });
+    this.props.updateLocation({ layer: null });
   }
 
   saveItem = (item) => {
@@ -208,10 +209,7 @@ class ViewItem extends React.Component {
     const instance = instances1.records[0];
 
     this.props.mutator.items.POST(item).then((data) => {
-      this.props.mutator.query.update({
-        _path: `/inventory/view/${instance.id}/${holdingsRecord.id}/${data.id}`,
-        layer: null,
-      });
+      this.props.goTo(`/inventory/view/${instance.id}/${holdingsRecord.id}/${data.id}`);
     });
   }
 
@@ -239,7 +237,7 @@ class ViewItem extends React.Component {
       return newState;
     });
 
-    this.props.mutator.query.update({ layer: 'copyItem' });
+    this.props.updateLocation({ layer: 'copyItem' });
   }
 
   getActionMenu = ({ onToggle }) => {
@@ -1077,6 +1075,8 @@ ViewItem.propTypes = {
     query: PropTypes.object.isRequired,
   }),
   onCloseViewItem: PropTypes.func.isRequired,
+  updateLocation: PropTypes.func,
+  goTo: PropTypes.func,
 };
 
-export default ViewItem;
+export default withLocation(ViewItem);

--- a/src/ViewItem.js
+++ b/src/ViewItem.js
@@ -1075,8 +1075,8 @@ ViewItem.propTypes = {
     query: PropTypes.object.isRequired,
   }),
   onCloseViewItem: PropTypes.func.isRequired,
-  updateLocation: PropTypes.func,
-  goTo: PropTypes.func,
+  updateLocation: PropTypes.func.isRequired,
+  goTo: PropTypes.func.isRequired,
 };
 
 export default withLocation(ViewItem);

--- a/src/withLocation.js
+++ b/src/withLocation.js
@@ -1,0 +1,57 @@
+import omitBy from 'lodash/omitBy';
+import isNil from 'lodash/isNil';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { parse, stringify } from 'query-string';
+import { compose } from 'redux';
+import { withRouter } from 'react-router';
+
+function withLocation(WrappedComponent) {
+  class Location extends React.Component {
+    static manifest = WrappedComponent.manifest;
+    static propTypes = {
+      location: PropTypes.shape({
+        pathname: PropTypes.string.isRequired,
+        search: PropTypes.string,
+      }).isRequired,
+      history: PropTypes.shape({
+        push: PropTypes.func.isRequired,
+      }).isRequired,
+    };
+
+    updateLocation = (newParams) => {
+      const { location, history } = this.props;
+      const { search, pathname } = location;
+      const prevParams = parse(search);
+      const params = Object.assign(prevParams, newParams);
+      const cleanParams = omitBy(params, isNil);
+      const url = `${pathname}?${stringify(cleanParams)}`;
+
+      history.push(url);
+    }
+
+    goTo = (path, params) => {
+      const { history } = this.props;
+      const url = (params) ? `${path}?${stringify(params)}` : path;
+
+      history.push(url);
+    }
+
+    render() {
+      return (
+        <WrappedComponent
+          updateLocation={this.updateLocation}
+          goTo={this.goTo}
+          {...this.props}
+        />
+      );
+    }
+  }
+
+  return Location;
+}
+
+export default compose(
+  withRouter,
+  withLocation,
+);

--- a/src/withLocation.js
+++ b/src/withLocation.js
@@ -12,7 +12,7 @@ function withLocation(WrappedComponent) {
     static propTypes = {
       location: PropTypes.shape({
         pathname: PropTypes.string.isRequired,
-        search: PropTypes.string,
+        search: PropTypes.string.isRequired,
       }).isRequired,
       history: PropTypes.shape({
         push: PropTypes.func.isRequired,


### PR DESCRIPTION
This PR is an attempt to replace navigation based on query resource with the tools provided by react-router. It should fix issues found in STCOM-302. 

I'm pretty sure the naming in the Location HOC (and perhaps `withLocation` name) could be improved. I wonder if you can come up with a better naming. 

I primary wanted to see if we can get rid of query resource completely and replace it with the set of navigation helpers (perhaps these helpers could be moved up to stripes-core eventually).
