### PR TITLE
checkbox-ids are all lowercase

### DIFF
--- a/test/ui-testing/filters.js
+++ b/test/ui-testing/filters.js
@@ -7,8 +7,8 @@ module.exports.test = function uiTest(uiTestCtx) {
 
     this.timeout(Number(config.test_timeout));
     // Resource type filter test disabled as new resource types are being loaded.
-    // const filters = ['resource-Books', 'resource-Serials', 'resource-eBooks', 'language-English', 'language-Spanish', 'location-Annex'];
-    const filters = ['language-English', 'language-Spanish', 'location-Annex'];
+    // const filters = ['resource-books', 'resource-serials', 'resource-ebooks', 'language-english', 'language-spanish', 'location-annex'];
+    const filters = ['language-english', 'language-spanish', 'location-annex'];
     let hitCount = null;
     describe('Login > Open module "Inventory" > Get hit counts > Click filters > Logout', () => {
       before((done) => {


### PR DESCRIPTION
folio-org/stripes-components/pull/862 uses `kebabCase()` on checkbox ids
to make sure they are consistently formatted. This helps avoid illegal
values like `foo bar` but it also changed legal values like `Foo-Bar` to
`foo-bar` and that wasn't reflected in the tests. Until now!

Refs [STCOM-476](https://issues.folio.org/browse/STCOM-476)