### PR TITLE
Updated PaneHeaders in various components

### DIFF
--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -333,26 +333,18 @@ class ViewHoldingsRecord extends React.Component {
           <div data-test-holdings-view-page>
             <Pane
               defaultWidth={this.props.paneWidth}
+              appIcon={<AppIcon app="inventory" iconKey="holdings" />}
               paneTitle={
-                <div
-                  style={{ textAlign: 'center' }}
-                  data-test-header-title
-                >
-                  <AppIcon
-                    app="inventory"
-                    iconKey="holdings"
-                    size="small"
-                  />
-                  <strong>
-                    {holdingsRecord.permanentLocationId ? `${holdingsPermanentLocation.name} >` : null}
-                    {' '}
-                    {_.get(holdingsRecord, ['callNumber'], '')}
-                  </strong>
-                  &nbsp;
-                  <div>
-                    <FormattedMessage id="ui-inventory.holdings" />
-                  </div>
-                </div>
+                <span data-test-header-title>
+                  <FormattedMessage id="ui-inventory.holdings" />
+                </span>
+              }
+              paneSub={
+                <Fragment>
+                  {holdingsRecord.permanentLocationId ? `${holdingsPermanentLocation.name} >` : null}
+                  {' '}
+                  {_.get(holdingsRecord, ['callNumber'], '')}
+                </Fragment>
               }
               lastMenu={detailMenu}
               dismissible

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -336,15 +336,11 @@ class ViewHoldingsRecord extends React.Component {
               appIcon={<AppIcon app="inventory" iconKey="holdings" />}
               paneTitle={
                 <span data-test-header-title>
-                  <FormattedMessage id="ui-inventory.holdings" />
-                </span>
-              }
-              paneSub={
-                <Fragment>
                   {holdingsRecord.permanentLocationId ? `${holdingsPermanentLocation.name} >` : null}
                   {' '}
                   {_.get(holdingsRecord, ['callNumber'], '')}
-                </Fragment>
+                  <FormattedMessage id="ui-inventory.holdings" />
+                </span>
               }
               lastMenu={detailMenu}
               dismissible

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -336,7 +336,8 @@ class ViewHoldingsRecord extends React.Component {
               appIcon={<AppIcon app="inventory" iconKey="holdings" />}
               paneTitle={
                 <span data-test-header-title>
-                  {holdingsRecord.permanentLocationId ? `${holdingsPermanentLocation.name} >` : null}{' '}
+                  {holdingsRecord.permanentLocationId ? `${holdingsPermanentLocation.name} >` : null}
+                  {' '}
                   {_.get(holdingsRecord, ['callNumber'], '')}
                   <FormattedMessage id="ui-inventory.holdings" />
                 </span>

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -336,8 +336,7 @@ class ViewHoldingsRecord extends React.Component {
               appIcon={<AppIcon app="inventory" iconKey="holdings" />}
               paneTitle={
                 <span data-test-header-title>
-                  {holdingsRecord.permanentLocationId ? `${holdingsPermanentLocation.name} >` : null}
-                  {' '}
+                  {holdingsRecord.permanentLocationId ? `${holdingsPermanentLocation.name} > ` : null}
                   {_.get(holdingsRecord, ['callNumber'], '')}
                   <FormattedMessage id="ui-inventory.holdings" />
                 </span>

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -336,8 +336,7 @@ class ViewHoldingsRecord extends React.Component {
               appIcon={<AppIcon app="inventory" iconKey="holdings" />}
               paneTitle={
                 <span data-test-header-title>
-                  {holdingsRecord.permanentLocationId ? `${holdingsPermanentLocation.name} >` : null}
-                  {' '}
+                  {holdingsRecord.permanentLocationId ? `${holdingsPermanentLocation.name} >` : null}{' '}
                   {_.get(holdingsRecord, ['callNumber'], '')}
                   <FormattedMessage id="ui-inventory.holdings" />
                 </span>

--- a/src/ViewItem.js
+++ b/src/ViewItem.js
@@ -476,23 +476,15 @@ class ViewItem extends React.Component {
           <Pane
             data-test-item-view-page
             defaultWidth={paneWidth}
+            appIcon={<AppIcon app="inventory" iconKey="item" />}
             paneTitle={
-              <div
-                style={{ textAlign: 'center' }}
-                data-test-header-title
-              >
-                <AppIcon
-                  app="inventory"
-                  iconKey="item"
-                  size="small"
-                />
-                {' '}
+              <span data-test-header-title>
                 {_.get(item, ['barcode'], '')}
                 <FormattedMessage
                   id="ui-inventory.itemDotStatus"
                   values={{ status: _.get(item, ['status', 'name'], '') }}
                 />
-              </div>
+              </span>
             }
             lastMenu={detailMenu}
             dismissible

--- a/src/ViewMarc.js
+++ b/src/ViewMarc.js
@@ -75,11 +75,7 @@ class ViewMarc extends React.Component {
           label={<FormattedMessage id="ui-inventory.viewMarcSource" />}
         >
           <Pane
-            paneTitle={
-              <div style={{ textAlign: 'center' }}>
-                {_.get(instance, ['title'], '')}
-              </div>
-            }
+            paneTitle={_.get(instance, ['title'], '')}
             defaultWidth={paneWidth}
             dismissible
             onClose={onClose}

--- a/src/edit/holdings/HoldingsForm.js
+++ b/src/edit/holdings/HoldingsForm.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { cloneDeep } from 'lodash';
 import { FormattedMessage } from 'react-intl';
@@ -312,30 +312,27 @@ class HoldingsForm extends React.Component {
       <form data-test-holdings-page-type={holdingsPageType}>
         <Paneset isRoot>
           <Pane
+            actionMenu={this.getActionMenu}
             defaultWidth="100%"
             dismissible
             onClose={onCancel}
             lastMenu={holdingsPageType === 'edit' ? editHoldingsLastMenu : addHoldingsLastMenu}
             paneTitle={
-              <div
-                style={{ textAlign: 'center' }}
-                data-test-header-title
-              >
-                <strong>{instance.title}</strong>
-                {(instance.publication && instance.publication.length > 0) &&
-                  <div>
-                    <em>
-                      {instance.publication[0].publisher}
-                      {instance.publication[0].dateOfPublication
-                        ? `, ${instance.publication[0].dateOfPublication}`
-                        : null
-                      }
-                    </em>
-                  </div>
-                }
-              </div>
+              <span data-test-header-title>
+                {instance.title}
+              </span>
             }
-            actionMenu={this.getActionMenu}
+            paneSub={
+              (instance.publication && instance.publication.length > 0) ?
+                <Fragment>
+                  {instance.publication[0].publisher}
+                  {instance.publication[0].dateOfPublication
+                    ? `, ${instance.publication[0].dateOfPublication}`
+                    : null
+                  }
+                </Fragment>
+                : null
+            }
           >
             <Row end="xs">
               <Col xs>

--- a/src/edit/holdings/HoldingsForm.js
+++ b/src/edit/holdings/HoldingsForm.js
@@ -20,6 +20,8 @@ import {
   ConfirmationModal,
 } from '@folio/stripes/components';
 
+import { AppIcon } from '@folio/stripes-core';
+
 import {
   LocationSelection,
   LocationLookup,
@@ -244,7 +246,7 @@ class HoldingsForm extends React.Component {
         <FormattedMessage id="ui-inventory.updateHoldingsRecord">
           {ariaLabel => (
             <Button
-              buttonStyle="primary paneHeaderNewButton"
+              buttonStyle="primary"
               id="clickable-update-item"
               type="submit"
               aria-label={ariaLabel}
@@ -313,6 +315,7 @@ class HoldingsForm extends React.Component {
         <Paneset isRoot>
           <Pane
             actionMenu={this.getActionMenu}
+            appIcon={<AppIcon app="inventory" iconKey="holdings" />}
             defaultWidth="100%"
             dismissible
             onClose={onCancel}

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { get, cloneDeep } from 'lodash';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
@@ -335,33 +335,30 @@ class ItemForm extends React.Component {
             lastMenu={(initialValues.id) ? editItemLastMenu : addItemLastMenu}
             actionMenu={this.getActionMenu}
             paneTitle={
-              <div
-                style={{ textAlign: 'center' }}
-                data-test-header-title
-              >
-                <em>{instance.title}</em>
+              <span data-test-header-title>
+                {instance.title}
                 {(instance.publication && instance.publication.length > 0) &&
-                  <span>
-                    <em>, </em>
-                    <em>
-                      {instance.publication[0].publisher}
-                      {instance.publication[0].dateOfPublication
-                        ? `, ${instance.publication[0].dateOfPublication}`
-                        : null
-                      }
-                    </em>
-                  </span>
+                  <Fragment>
+                    {', '}
+                    {instance.publication[0].publisher}
+                    {instance.publication[0].dateOfPublication
+                      ? `, ${instance.publication[0].dateOfPublication}`
+                      : null
+                    }
+                  </Fragment>
                 }
-                <div>
-                  <FormattedMessage
-                    id="ui-inventory.holdingsTitle"
-                    values={{
-                      location: labelLocation,
-                      callNumber: labelCallNumber,
-                    }}
-                  />
-                </div>
-              </div>
+              </span>
+            }
+            paneSub={
+              <span data-test-header-sub>
+                <FormattedMessage
+                  id="ui-inventory.holdingsTitle"
+                  values={{
+                    location: labelLocation,
+                    callNumber: labelCallNumber,
+                  }}
+                />
+              </span>
             }
           >
             <Row>

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -22,6 +22,7 @@ import {
   ExpandAllButton,
   ConfirmationModal,
 } from '@folio/stripes/components';
+import { AppIcon } from '@folio/stripes-core';
 import stripesForm from '@folio/stripes/form';
 import {
   LocationSelection,
@@ -256,7 +257,7 @@ class ItemForm extends React.Component {
         <FormattedMessage id="ui-inventory.updateItem">
           {ariaLabel => (
             <Button
-              buttonStyle="primary paneHeaderNewButton"
+              buttonStyle="primary"
               id="clickable-update-item"
               type="submit"
               aria-label={ariaLabel}
@@ -334,6 +335,7 @@ class ItemForm extends React.Component {
             onClose={onCancel}
             lastMenu={(initialValues.id) ? editItemLastMenu : addItemLastMenu}
             actionMenu={this.getActionMenu}
+            appIcon={<AppIcon app="inventory" iconKey="item" />}
             paneTitle={
               <span data-test-header-title>
                 {instance.title}

--- a/test/bigtest/interactors/item-edit-page.js
+++ b/test/bigtest/interactors/item-edit-page.js
@@ -20,6 +20,7 @@ import {
   }
 
   title = text('[data-test-header-title]');
+  sub = text('[data-test-header-sub]');
   headerDropdown = new HeaderDropdown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
   headerDropdownMenu = new HeaderDropdownMenu();
 }

--- a/test/bigtest/tests/item-edit-page-test.js
+++ b/test/bigtest/tests/item-edit-page-test.js
@@ -59,7 +59,11 @@ describe('ItemEditPage', () => {
   });
 
   it('displays a title in the pane header', () => {
-    expect(ItemEditPage.title).to.equal(`${instance.title} Holdings: > ${holdings.callNumber}`);
+    expect(ItemEditPage.title).to.equal(`${instance.title}`);
+  });
+
+  it('displays a sub in the pane header', () => {
+    expect(ItemEditPage.sub).to.equal(`Holdings: > ${holdings.callNumber}`);
   });
 
   describe('pane header menu', () => {


### PR DESCRIPTION
In this PR I have updated how paneTitles are implemented in various components.

The primary purpose is to improve the design and ensure consistency across all modules.


## Before / after

### View holdings
![image](https://user-images.githubusercontent.com/640976/52864996-ce91bd80-313b-11e9-9d41-f1e4e294f065.png)
![image](https://user-images.githubusercontent.com/640976/52865011-d3567180-313b-11e9-8cb6-197617414f61.png)

### Edit holdings
![image](https://user-images.githubusercontent.com/640976/52865994-0994f080-313e-11e9-9a0c-7f0981894383.png)
![image](https://user-images.githubusercontent.com/640976/52866003-10bbfe80-313e-11e9-9ba7-9bd1520d5b5c.png)


### View Item
![image](https://user-images.githubusercontent.com/640976/52865071-f41ec700-313b-11e9-9c5a-07c2d8ba5c5f.png)
![image](https://user-images.githubusercontent.com/640976/52865076-f8e37b00-313b-11e9-9d46-daac94f96bc3.png)

### Edit item
![image](https://user-images.githubusercontent.com/640976/52865534-241a9a00-313d-11e9-929f-9b0b95babbec.png)
![image](https://user-images.githubusercontent.com/640976/52865544-28df4e00-313d-11e9-88ff-842a2d8aec54.png)


