### PR TITLE
Ensure new item associated with intended holdingsRecord UIIN-492

### DIFF
--- a/src/ItemsPerHoldingsRecord.js
+++ b/src/ItemsPerHoldingsRecord.js
@@ -24,6 +24,7 @@ class ItemsPerHoldingsRecord extends React.Component {
   static manifest = Object.freeze({
     query: {},
     addItemMode: { initialValue: { mode: false } },
+    addItemForHoldingsRecordId: {},
     materialTypes: {
       type: 'okapi',
       path: 'material-types',
@@ -59,15 +60,11 @@ class ItemsPerHoldingsRecord extends React.Component {
   }
 
   // Add Item handlers
-  onClickAddNewItem = (e) => {
+  onClickAddNewItem = (holdingsRecordId) => {
     const { mutator } = this.props;
 
-    if (e) {
-      e.preventDefault();
-      e.stopPropagation();
-    }
-
     mutator.addItemMode.replace({ mode: true });
+    mutator.addItemForHoldingsRecordId.replace({ holdingsRecordId });
     this.addItemModeThisLayer = true;
     this.props.updateLocation({ layer: 'createItem' });
   };
@@ -79,6 +76,7 @@ class ItemsPerHoldingsRecord extends React.Component {
 
     mutator.addItemMode.replace({ mode: false });
     this.addItemModeThisLayer = false;
+    mutator.addItemForHoldingsRecordId.replace({});
     this.props.updateLocation({ layer: null });
   }
 
@@ -105,7 +103,9 @@ class ItemsPerHoldingsRecord extends React.Component {
         </Button>
         <Button
           id="clickable-new-item"
-          onClick={this.onClickAddNewItem}
+          onClick={() => {
+            this.onClickAddNewItem(holdingsRecord.id);
+          }}
           buttonStyle="primary paneHeaderNewButton"
         >
           <Icon icon="plus-sign">
@@ -124,6 +124,7 @@ class ItemsPerHoldingsRecord extends React.Component {
         materialTypes,
         loanTypes,
         query,
+        addItemForHoldingsRecordId,
       },
       instance,
       holdingsRecord,
@@ -142,7 +143,8 @@ class ItemsPerHoldingsRecord extends React.Component {
     const labelLocation = holdingsRecord.permanentLocationId ? locationsById[holdingsRecord.permanentLocationId].name : '';
     const labelCallNumber = holdingsRecord.callNumber || '';
 
-    if (query.layer === 'createItem') {
+    if (query.layer === 'createItem'
+      && addItemForHoldingsRecordId.holdingsRecordId === holdingsRecord.id) {
       return (
         <Layer
           key={`itemformlayer_${holdingsRecord.id}`}


### PR DESCRIPTION
The problem is, an item form layer is created for each and every holdingsRecord when an add-item button is clicked, and the last layer (and thus holdingsRecord ID) wins.

In this PR, the current holdingsRecord ID is passed through the button and put on a "global variable"/resource that is queried before rendering any edit form layer, in order to only render the intended layer. 

Merely wondering, would using a 'resource' like this be best practice these days?  