### PR TITLE
use an officially released version

### DIFF
--- a/package.json
+++ b/package.json
@@ -300,7 +300,7 @@
     "sinon": "^7.0.0"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^1.0.200010",
+    "@folio/react-intl-safe-html": "^1.0.2",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
     "query-string": "^5.0.0",


### PR DESCRIPTION
It appears that a previous commit inadvertently added a dependency on an
unreleased version of react-intl-safe-html. In fact, that CI version is
the same as the formally released version, 1.0.2.

Fixes [UIIN-500](https://issues.folio.org/browse/UIIN-500)