### PR TITLE
Fix alphabetical order of lookup tables. Fixes UIIN-421.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.8.0 (IN PROGRESS)
 
 * Retrieve 1000 items from lookup tables. Refs UIIN-413.
+* Fix alphabetical order of lookup tables. Fixes UIIN-421.
 
 ## [1.7.0](https://github.com/folio-org/ui-inventory/tree/v1.7.0) (2019-03-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.6.0...v1.7.0)

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -55,26 +55,6 @@ class ViewHoldingsRecord extends React.Component {
       type: 'okapi',
       path: 'locations/%{temporaryLocationQuery.id}',
     },
-    illPolicies: {
-      type: 'okapi',
-      path: 'ill-policies',
-      records: 'illPolicies',
-    },
-    holdingsTypes: {
-      type: 'okapi',
-      path: 'holdings-types',
-      records: 'holdingsTypes',
-    },
-    callNumberTypes: {
-      type: 'okapi',
-      path: 'call-number-types',
-      records: 'callNumberTypes',
-    },
-    holdingsNoteTypes: {
-      type: 'okapi',
-      path: 'holdings-note-types',
-      records: 'holdingsNoteTypes',
-    },
   });
 
   constructor(props) {
@@ -247,13 +227,16 @@ class ViewHoldingsRecord extends React.Component {
     const {
       holdingsRecords,
       instances1,
-      illPolicies,
-      holdingsTypes,
-      callNumberTypes,
-      holdingsNoteTypes,
       permanentLocation,
       temporaryLocation,
     } = this.props.resources;
+
+    const {
+      holdingsTypes,
+      holdingsNoteTypes,
+      illPolicies,
+      callNumberTypes,
+    } = this.props.parentResources;
 
     if (!holdingsRecords || !holdingsRecords.hasLoaded) {
       return true;
@@ -280,12 +263,14 @@ class ViewHoldingsRecord extends React.Component {
       resources: {
         holdingsRecords,
         instances1,
-        illPolicies,
-        holdingsTypes,
-        callNumberTypes,
-        holdingsNoteTypes,
         permanentLocation,
         temporaryLocation,
+      },
+      parentResources: {
+        holdingsTypes,
+        holdingsNoteTypes,
+        illPolicies,
+        callNumberTypes,
       },
       referenceTables,
       okapi,
@@ -866,6 +851,20 @@ ViewHoldingsRecord.propTypes = {
   stripes: PropTypes.shape({
     connect: PropTypes.func.isRequired,
   }).isRequired,
+  parentResources: PropTypes.shape({
+    holdingsTypes: PropTypes.shape({
+      records: PropTypes.arrayOf(PropTypes.object),
+    }),
+    illPolicies: PropTypes.shape({
+      records: PropTypes.arrayOf(PropTypes.object),
+    }),
+    callNumberTypes: PropTypes.shape({
+      records: PropTypes.arrayOf(PropTypes.object),
+    }),
+    holdingsNoteTypes: PropTypes.shape({
+      records: PropTypes.arrayOf(PropTypes.object),
+    }),
+  }),
   resources: PropTypes.shape({
     instances1: PropTypes.shape({
       records: PropTypes.arrayOf(PropTypes.object),
@@ -880,18 +879,6 @@ ViewHoldingsRecord.propTypes = {
       records: PropTypes.arrayOf(PropTypes.object),
     }),
     temporaryLocation: PropTypes.shape({
-      records: PropTypes.arrayOf(PropTypes.object),
-    }),
-    illPolicies: PropTypes.shape({
-      records: PropTypes.arrayOf(PropTypes.object),
-    }),
-    holdingsTypes: PropTypes.shape({
-      records: PropTypes.arrayOf(PropTypes.object),
-    }),
-    callNumberTypes: PropTypes.shape({
-      records: PropTypes.arrayOf(PropTypes.object),
-    }),
-    holdingsNoteTypes: PropTypes.shape({
       records: PropTypes.arrayOf(PropTypes.object),
     }),
   }).isRequired,


### PR DESCRIPTION
It looks like some of the lookup resources were refetched without the order in `ViewHoldingsRecord`. Most of them were already accessible via `parentResources` props from `Instances`:

https://github.com/folio-org/ui-inventory/blob/master/src/Instances.js#L222-L240

## Link
https://issues.folio.org/browse/UIIN-421

