### PR TITLE
don't append wildcards to search terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Retrieve 1000 items from lookup tables. Refs UIIN-413.
 * Fix alphabetical order of lookup tables. Fixes UIIN-421.
+* Don't append wildcards to search terms. Fixes UIIN-481.
 
 ## [1.7.0](https://github.com/folio-org/ui-inventory/tree/v1.7.0) (2019-03-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.6.0...v1.7.0)

--- a/src/Instances.js
+++ b/src/Instances.js
@@ -55,14 +55,14 @@ const filterConfig = [
 ];
 
 const searchableIndexes = [
-  { label: 'All (title, contributor, identifier)', value: 'all', makeQuery: term => `(title="${term}*" or contributors adj "\\"name\\": \\"${term}*\\"" or identifiers adj "\\"value\\": \\"${term}*\\"")` },
-  { label: 'Instance ID', value: 'id', makeQuery: term => `(id="${term}*")` },
-  { label: 'Title', value: 'title', makeQuery: term => `(title="${term}*")` },
-  { label: 'Identifier', value: 'identifier', makeQuery: term => `(identifiers adj "\\"value\\": \\"${term}*\\"")` },
-  { label: '- ISBN', value: 'isbn', makeQuery: (term, args) => `identifiers == "*\\"value\\": \\"${term}*\\", \\"identifierTypeId\\": \\"${args.identifierTypeId}\\"*"` },
-  { label: '- ISSN', value: 'issn', makeQuery: (term, args) => `identifiers == "*\\"value\\": \\"${term}*\\", \\"identifierTypeId\\": \\"${args.identifierTypeId}\\"*"` },
-  { label: 'Contributor', value: 'contributor', makeQuery: term => `(contributors adj "\\"name\\": \\"${term}*\\"")` },
-  { label: 'Subject', value: 'subject', makeQuery: term => `(subjects="${term}*")` },
+  { label: 'All (title, contributor, identifier)', value: 'all', makeQuery: term => `(title="${term}" or contributors adj "\\"name\\": \\"${term}\\"" or identifiers adj "\\"value\\": \\"${term}\\"")` },
+  { label: 'Instance ID', value: 'id', makeQuery: term => `(id="${term}")` },
+  { label: 'Title', value: 'title', makeQuery: term => `(title="${term}")` },
+  { label: 'Identifier', value: 'identifier', makeQuery: term => `(identifiers adj "\\"value\\": \\"${term}\\"")` },
+  { label: '- ISBN', value: 'isbn', makeQuery: (term, args) => `identifiers == "*\\"value\\": \\"${term}\\", \\"identifierTypeId\\": \\"${args.identifierTypeId}\\""` },
+  { label: '- ISSN', value: 'issn', makeQuery: (term, args) => `identifiers == "*\\"value\\": \\"${term}\\", \\"identifierTypeId\\": \\"${args.identifierTypeId}\\""` },
+  { label: 'Contributor', value: 'contributor', makeQuery: term => `(contributors adj "\\"name\\": \\"${term}\\"")` },
+  { label: 'Subject', value: 'subject', makeQuery: term => `(subjects="${term}")` },
 ];
 
 class Instances extends React.Component {


### PR DESCRIPTION
Don't append `*` to search terms automatically; let the user determine
if they want this. The way CQL is translated, a search for `foo` will
return things like `the foo and the bar` but not `foobar`.

Fixes [UIIN-481](https://issues.folio.org/browse/UIIN-481)