### PR TITLE
add missing sort clauses to lookup tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Retrieve 1000 items from lookup tables. Refs UIIN-413.
 * Fix alphabetical order of lookup tables. Fixes UIIN-421.
 * Don't append wildcards to search terms. Fixes UIIN-481.
+* Add missing order-by clauses to item-record lookup tables. Fixes UIIN-522.
 
 ## [1.7.0](https://github.com/folio-org/ui-inventory/tree/v1.7.0) (2019-03-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.6.0...v1.7.0)

--- a/src/ViewItem.js
+++ b/src/ViewItem.js
@@ -57,6 +57,10 @@ class ViewItem extends React.Component {
     materialTypes: {
       type: 'okapi',
       path: 'material-types',
+      params: {
+        query: 'cql.allRecords=1 sortby name',
+        limit: '1000',
+      },
       records: 'mtypes',
     },
     loanTypes: {
@@ -64,18 +68,26 @@ class ViewItem extends React.Component {
       path: 'loan-types',
       params: {
         query: 'cql.allRecords=1 sortby name',
-        limit: '40',
+        limit: '1000',
       },
       records: 'loantypes',
     },
     callNumberTypes: {
       type: 'okapi',
       path: 'call-number-types',
+      params: {
+        query: 'cql.allRecords=1 sortby name',
+        limit: '1000',
+      },
       records: 'callNumberTypes',
     },
     itemNoteTypes: {
       type: 'okapi',
       path: 'item-note-types',
+      params: {
+        query: 'cql.allRecords=1 sortby name',
+        limit: '1000',
+      },
       records: 'itemNoteTypes',
     },
     requests: {


### PR DESCRIPTION
Lookup tables were missing their order-by and limit clauses.

Fixes [UIIN-522](https://issues.folio.org/browse/UIIN-522)