### PR TITLE
send contributors.primary as correct type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Don't append wildcards to search terms. Fixes UIIN-481.
 * Provide the correct a11y props to `<Layer>`s.
 * Add missing order-by clauses to item-record lookup tables. Fixes UIIN-522.
+* Send `contributors.type.primary` as correct type. Refs MODINV-117.
 
 ## [1.7.0](https://github.com/folio-org/ui-inventory/tree/v1.7.0) (2019-03-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.6.0...v1.7.0)

--- a/src/edit/contributorFields.js
+++ b/src/edit/contributorFields.js
@@ -81,7 +81,7 @@ const ContributorFields = ({
           newItemTemplate={{
             name: '',
             contributorNameTypeId: '',
-            primary: '',
+            primary: false,
             contributorTypeId: '',
             contributorTypeText: '',
           }}


### PR DESCRIPTION
It's a boolean, not a string, as of [MODINV-117](https://issues.folio.org/browse/MODINV-117).

Fixes [UIIN-556](https://issues.folio.org/browse/UIIN-556)