### PR TITLE
UIIN-559: Update item notes form checkbox to render label vertically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.9.0 (In Progress)
 
 * Check for dependencies when deleting holding record. Part of UIIN-550.
+* Updated checkbox to render label vertically in item notes form (UIIN-559)
 
 ## [1.8.0](https://github.com/folio-org/ui-inventory/tree/v1.8.0) (2019-05-10)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.7.0...v1.8.0)

--- a/package.json
+++ b/package.json
@@ -312,7 +312,7 @@
     "@bigtest/mocha": "^0.5.1",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes": "^2.0.0",
+    "@folio/stripes": "^2.7.0",
     "@folio/stripes-cli": "^1.5.0",
     "@folio/stripes-core": "^3.0.1",
     "babel-eslint": "^9.0.0",

--- a/src/components/RepeatableField/FieldRow.js
+++ b/src/components/RepeatableField/FieldRow.js
@@ -196,11 +196,15 @@ class FieldRow extends React.Component {
               <Row>
                 <Col xs={10}>
                   <Row>
-                    {template.map((t, i) => (
-                      <Col xs key={`field-${i}`}>
-                        {this.renderControl(fields, f, fieldIndex, t, i)}
-                      </Col>
-                    ))}
+                    {template.map((t, i) => {
+                      const { columnSize } = t;
+                      const colSizes = typeof columnSize === 'object' ? columnSize : { xs: true };
+                      return (
+                        <Col {...colSizes} key={`field-${i}`}>
+                          {this.renderControl(fields, f, fieldIndex, t, i)}
+                        </Col>
+                      );
+                    })}
                   </Row>
                 </Col>
                 <Col xs={2}>

--- a/src/edit/holdings/note.js
+++ b/src/edit/holdings/note.js
@@ -39,6 +39,12 @@ const Note = ({ noteTypeOptions }) => (
             name: 'staffOnly',
             label: <FormattedMessage id="ui-inventory.staffOnly" />,
             component: Checkbox,
+            inline: true,
+            vertical: true,
+            columnSize: {
+              xs: 3,
+              lg: 2,
+            }
           }
         ]}
       />

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -728,7 +728,12 @@ class ItemForm extends React.Component {
                         name: 'staffOnly',
                         label: <FormattedMessage id="ui-inventory.staffOnly" />,
                         component: Checkbox,
-                        type: 'checkbox',
+                        inline: true,
+                        vertical: true,
+                        columnSize: {
+                          xs: 3,
+                          lg: 2,
+                        }
                       }
                     ]}
                   />


### PR DESCRIPTION
## Changes
- Updated checkbox in item notes form to render label vertically and updated the column width to take up less space and leave more room for the input fields instead
- Updated RepeatableField component to allow for changing column widths

**Note:** The RepeatableField-component will soon be replaced with the matching component from stripes-components so the change of the RepeatableField-component within UI-Inventory is only temporary. Similar functionality will be possible when using the RepeatableField-component from stripes-components in the future because you will have more control over your row content.

## Before
![image](https://user-images.githubusercontent.com/640976/58872166-bed6be80-86c3-11e9-8bdb-efd2aa6a5462.png)

## After
![image](https://user-images.githubusercontent.com/640976/58872108-9fd82c80-86c3-11e9-8a74-8429d6dd5c83.png)