### PR TITLE
UIIN-79: do not show results by default

### DIFF
--- a/test/ui-testing/filters.js
+++ b/test/ui-testing/filters.js
@@ -9,7 +9,6 @@ module.exports.test = function uiTest(uiTestCtx) {
     // Resource type filter test disabled as new resource types are being loaded.
     // const filters = ['resource-books', 'resource-serials', 'resource-ebooks', 'language-english', 'language-spanish', 'location-annex'];
     const filters = ['language-english', 'language-spanish', 'location-annex'];
-    let hitCount = null;
     describe('Login > Open module "Inventory" > Get hit counts > Click filters > Logout', () => {
       before((done) => {
         login(nightmare, config, done); // logs in with the default admin credentials
@@ -38,7 +37,7 @@ module.exports.test = function uiTest(uiTestCtx) {
             .click('#clickable-reset-all')
             .wait(`#clickable-filter-${filter}`)
             .click(`#clickable-filter-${filter}`)
-            .wait(`#list-inventory[data-total-count]`)
+            .wait('#list-inventory[data-total-count]')
             .click('#clickable-reset-all')
             .wait('#paneHeaderpane-results-subtitle')
             .wait('span[class^="noResultsMessageLabel"]')

--- a/test/ui-testing/filters.js
+++ b/test/ui-testing/filters.js
@@ -22,20 +22,15 @@ module.exports.test = function uiTest(uiTestCtx) {
           .use(openApp(nightmare, config, done, 'inventory', testVersion))
           .then(result => result);
       });
-      it('should find hit count with no filters applied', (done) => {
+      it('should find "no results" message with no filters applied', (done) => {
         nightmare
-          .wait('#list-inventory')
-          .evaluate(() => {
-            return document.querySelector('#list-inventory').getAttribute('data-total-count');
-          })
-          .then((result) => {
-            done();
-            hitCount = result;
-          })
+          .wait('#paneHeaderpane-results-subtitle')
+          .wait('span[class^="noResultsMessageLabel"]')
+          .then(done)
           .catch(done);
       });
       filters.forEach((filter) => {
-        it(`should click ${filter} and change hit count`, (done) => {
+        it(`should click ${filter} and find hit count`, (done) => {
           nightmare
             .wait('#input-inventory-search')
             .type('#input-inventory-search', 0)
@@ -43,9 +38,10 @@ module.exports.test = function uiTest(uiTestCtx) {
             .click('#clickable-reset-all')
             .wait(`#clickable-filter-${filter}`)
             .click(`#clickable-filter-${filter}`)
-            .wait(`#list-inventory:not([data-total-count^="${hitCount}"])`)
+            .wait(`#list-inventory[data-total-count]`)
             .click('#clickable-reset-all')
-            .wait(`#list-inventory[data-total-count^="${hitCount}"]`)
+            .wait('#paneHeaderpane-results-subtitle')
+            .wait('span[class^="noResultsMessageLabel"]')
             .then(done)
             .catch(done);
         });

--- a/test/ui-testing/search.js
+++ b/test/ui-testing/search.js
@@ -44,7 +44,7 @@ module.exports.test = function test(uiTestCtx) {
           .wait('#clickable-reset-all')
           .wait('button[type=submit]')
           .click('button[type=submit]')
-          .wait(`#list-inventory[data-total-count]`)
+          .wait('#list-inventory[data-total-count]')
           .wait(contentWait, title)
           .then(done)
           .catch(done);
@@ -67,7 +67,7 @@ module.exports.test = function test(uiTestCtx) {
           .wait('#clickable-reset-all')
           .wait('button[type=submit]')
           .click('button[type=submit]')
-          .wait(`#list-inventory[data-total-count]`)
+          .wait('#list-inventory[data-total-count]')
           .wait(contentWait, title)
 
           /* .evaluate(function evall(title2) {
@@ -96,7 +96,7 @@ module.exports.test = function test(uiTestCtx) {
           .wait('#clickable-reset-all')
           .wait('button[type=submit]')
           .click('button[type=submit]')
-          .wait(`#list-inventory[data-total-count]`)
+          .wait('#list-inventory[data-total-count]')
           .wait(contentWait, authorName)
           .then(done)
           .catch(done);

--- a/test/ui-testing/search.js
+++ b/test/ui-testing/search.js
@@ -1,6 +1,6 @@
 /* global Nightmare describe it before after */
 module.exports.test = function test(uiTestCtx) {
-  describe('Module test: inventory:inventorySearch', function startTest() {
+  describe('Module test: inventory:search', function startTest() {
     const { config, helpers: { login, openApp, logout }, meta: { testVersion } } = uiTestCtx;
     const nightmare = new Nightmare(config.nightmare);
 
@@ -16,7 +16,6 @@ module.exports.test = function test(uiTestCtx) {
     describe('Login > Click Inventory > Enter Search Term > Wait for Results > Confirm search term at top of results > Click Reset All > Wait for results pan to change state > Logout\n', () => {
       const title = 'California';
       const authorName = 'Huntley, Henry Veel';
-      let hitCount = 0;
       before((done) => {
         login(nightmare, config, done); // logs in with the default admin credentials
       });
@@ -28,16 +27,11 @@ module.exports.test = function test(uiTestCtx) {
           .use(openApp(nightmare, config, done, 'inventory', testVersion))
           .then(result => result);
       });
-      it('should find hit count with no filters applied', (done) => {
+      it('should find "no results" message with no filters applied', (done) => {
         nightmare
-          .wait('#list-inventory')
-          .evaluate(() => {
-            return document.querySelector('#list-inventory').getAttribute('data-total-count');
-          })
-          .then((result) => {
-            done();
-            hitCount = result;
-          })
+          .wait('#paneHeaderpane-results-subtitle')
+          .wait('span[class^="noResultsMessageLabel"]')
+          .then(done)
           .catch(done);
       });
       it(`should search for: "${title}"`, (done) => {
@@ -50,7 +44,7 @@ module.exports.test = function test(uiTestCtx) {
           .wait('#clickable-reset-all')
           .wait('button[type=submit]')
           .click('button[type=submit]')
-          .wait(`#list-inventory:not([data-total-count^="${hitCount}"])`)
+          .wait(`#list-inventory[data-total-count]`)
           .wait(contentWait, title)
           .then(done)
           .catch(done);
@@ -59,7 +53,8 @@ module.exports.test = function test(uiTestCtx) {
         nightmare
           .wait('#clickable-reset-all')
           .click('#clickable-reset-all')
-          .wait(`#list-inventory[data-total-count^="${hitCount}"]`)
+          .wait('#paneHeaderpane-results-subtitle')
+          .wait('span[class^="noResultsMessageLabel"]')
           .then(done)
           .catch(done);
       });
@@ -72,7 +67,7 @@ module.exports.test = function test(uiTestCtx) {
           .wait('#clickable-reset-all')
           .wait('button[type=submit]')
           .click('button[type=submit]')
-          .wait(`#list-inventory:not([data-total-count^="${hitCount}"])`)
+          .wait(`#list-inventory[data-total-count]`)
           .wait(contentWait, title)
 
           /* .evaluate(function evall(title2) {
@@ -89,7 +84,8 @@ module.exports.test = function test(uiTestCtx) {
         nightmare
           .wait('#clickable-reset-all')
           .click('#clickable-reset-all')
-          .wait(`#list-inventory[data-total-count^="${hitCount}"]`)
+          .wait('#paneHeaderpane-results-subtitle')
+          .wait('span[class^="noResultsMessageLabel"]')
           .then(done)
           .catch(done);
       });
@@ -100,7 +96,7 @@ module.exports.test = function test(uiTestCtx) {
           .wait('#clickable-reset-all')
           .wait('button[type=submit]')
           .click('button[type=submit]')
-          .wait(`#list-inventory:not([data-total-count^="${hitCount}"])`)
+          .wait(`#list-inventory[data-total-count]`)
           .wait(contentWait, authorName)
           .then(done)
           .catch(done);

--- a/test/ui-testing/test.js
+++ b/test/ui-testing/test.js
@@ -1,9 +1,9 @@
 // const newTitle = require('./new_title.js');
 const filters = require('./filters.js');
-const inventorySearch = require('./inventorySearch.js');
+const search = require('./search.js');
 
 module.exports.test = function test(uiTestCtx) {
   // newTitle.test(uiTestCtx);
   filters.test(uiTestCtx);
-  inventorySearch.test(uiTestCtx);
+  search.test(uiTestCtx);
 };


### PR DESCRIPTION
Tests must accomodate the fact that inventory no longer shows any rows
until a search term or filter is applied. See #593.

Refs [UIIN-79](https://issues.folio.org/browse/UIIN-79)