### PR TITLE
UIIN-559:  Fix Loan and availability -> "Staff only"-checkbox alignment

### DIFF
--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -728,6 +728,7 @@ class ItemForm extends React.Component {
                         name: 'staffOnly',
                         label: <FormattedMessage id="ui-inventory.staffOnly" />,
                         component: Checkbox,
+                        type: 'checkbox',
                         inline: true,
                         vertical: true,
                         columnSize: {
@@ -822,6 +823,7 @@ class ItemForm extends React.Component {
                         name: 'staffOnly',
                         label: <FormattedMessage id="ui-inventory.staffOnly" />,
                         component: Checkbox,
+                        type: 'checkbox',
                         inline: true,
                         vertical: true,
                         columnSize: {

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -822,7 +822,12 @@ class ItemForm extends React.Component {
                         name: 'staffOnly',
                         label: <FormattedMessage id="ui-inventory.staffOnly" />,
                         component: Checkbox,
-                        type: 'checkbox',
+                        inline: true,
+                        vertical: true,
+                        columnSize: {
+                          xs: 3,
+                          lg: 2,
+                        }
                       }
                     ]}
                   />


### PR DESCRIPTION
I missed this part of the UI in my previous PR.

**Note:** I also added `type: 'checkbox'` for the checkboxes again. I removed this in my last PR but I realized that it's needed for redux-form to treat the inputs as checkboxes.

## Before
![image](https://user-images.githubusercontent.com/640976/59517692-602ff280-8ec4-11e9-8e7a-f9733b4401a4.png)

## After
![image](https://user-images.githubusercontent.com/640976/59517570-29f27300-8ec4-11e9-84ff-e61dd4cb0776.png)
