### PR TITLE
UIIN-557 repair and enable new-title test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## 1.11.0 (IN PROGRESS)
+
+* Do not attempt to manually set the read-only HRID field in tests. Refs UIIN-557.
+
 ## 1.10.0 (https://github.com/folio-org/ui-inventory/tree/v1.10.0) (2019-06-14)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.9.0...v1.10.0)
 

--- a/test/ui-testing/new-title.js
+++ b/test/ui-testing/new-title.js
@@ -1,15 +1,15 @@
 /* global Nightmare describe it before after */
 module.exports.test = function uiTest(uiTestCtx) {
   describe('Module test: inventory:new_title', function testDescribe() {
-    const { config, helpers: { login, openApp, createInventory, logout }, meta: { testVersion } } = uiTestCtx;
+    const { config, helpers: { login, clickApp, createInventory, logout }, meta: { testVersion } } = uiTestCtx;
     const nightmare = new Nightmare(config.nightmare);
 
     this.timeout(Number(config.test_timeout));
 
-    const title = '0';
+    const title = 'qwer';
     const ed = '[1st ed.]';
     const series = 'Catalogus (Museum van Hedendaagse Kunst Antwerpen), 92';
-    const id = new Date().valueOf();
+    const hrid = 'foo_' + new Date().valueOf();
     const isbn = '9789072828279';
     const contrib = 'Moritz Küng';
     const subjects = ['Venlet, Richard -- Exhibitions', 'Installations (Art) -- Exhibitions', 'Installations (Art)'];
@@ -25,75 +25,103 @@ module.exports.test = function uiTest(uiTestCtx) {
       after((done) => {
         logout(nightmare, config, done);
       });
-      it('should open module "Inventory" and find version tag ', (done) => {
-        nightmare
-          .use(openApp(nightmare, config, done, 'inventory', testVersion))
-          .then(result => result);
+
+      it('should navigate to users', (done) => {
+        clickApp(nightmare, done, 'inventory');
       });
+
+
       it('should create new instance ', (done) => {
         nightmare
           .wait('#clickable-newinventory')
           .click('#clickable-newinventory')
           .wait(55)
+          .wait('input[name=title]')
           .insert('input[name=title]', title)
-          .insert('input[name=hrid]', id)
+          // .wait('input[name=hrid]')
+          // .insert('input[name=hrid]', hrid)
+
           .click('#clickable-add-edition')
+          .wait('input[name="editions[0]"]')
           .insert('input[name="editions[0]"]', ed)
           .wait(55)
           .click('#clickable-add-series')
+          .wait('input[name="series[0]"]')
           .insert('input[name="series[0]"]', series)
           .wait(55)
           .click('#clickable-add-identifier')
           .wait(55)
-          .insert('input[name="identifiers[0].value', id)
+          .wait('input[name="identifiers[0].value')
+          .insert('input[name="identifiers[0].value', hrid)
+          .wait('select[name="identifiers[0].identifierTypeId')
           .type('select[name="identifiers[0].identifierTypeId', 's')
           .click('#clickable-add-identifier')
           .wait(55)
+          .wait('input[name="identifiers[1].value')
           .insert('input[name="identifiers[1].value', isbn)
           .type('select[name="identifiers[1].identifierTypeId', 'ii')
           .type('#select_instance_type', 'o')
           .click('#clickable-add-contributor')
+
+          .wait('input[name="contributors[0].name"')
           .insert('input[name="contributors[0].name"', contrib)
           .type('select[name="contributors[0].contributorNameTypeId"]', 'P')
           .click('#clickable-add-subject')
+          .wait('input[name="subjects[0]"]')
           .insert('input[name="subjects[0]"]', subjects[0])
           .click('#clickable-add-subject')
+          .wait('input[name="subjects[1]"]')
           .insert('input[name="subjects[1]"]', subjects[1])
           .click('#clickable-add-subject')
+          .wait('input[name="subjects[2]"]')
           .insert('input[name="subjects[2]"]', subjects[2])
           .click('#clickable-add-publication')
           .wait(55)
+          .wait('input[name="publication[0].publisher"]')
           .insert('input[name="publication[0].publisher"]', pub.publisher)
           .insert('input[name="publication[0].place"]', pub.place)
           .insert('input[name="publication[0].dateOfPublication"]', pub.date)
           .click('#clickable-add-description')
-          .wait(55)
+          .wait('input[name="physicalDescriptions[0]"]')
           .insert('input[name="physicalDescriptions[0]"]', desc)
           .click('#clickable-add-language')
           .wait(55)
+          .wait('select[name="languages[0]"]')
           .select('select[name="languages[0]"]', lang[0])
           .click('#clickable-add-language')
           .wait(55)
+          .wait('select[name="languages[1]"]')
           .select('select[name="languages[1]"]', lang[1])
           .click('#clickable-add-notes')
           .wait(55)
+          .wait('input[name="notes[0]"]')
           .insert('input[name="notes[0]"]', notes[0])
           .click('#clickable-add-notes')
           .wait(55)
+          .wait('input[name="notes[1]"]')
           .insert('input[name="notes[1]"]', notes[1])
           .click('#clickable-add-notes')
           .wait(55)
+          .wait('input[name="notes[2]"]')
           .insert('input[name="notes[2]"]', notes[2])
           .wait(55)
+          .wait('#clickable-create-instance')
           .click('#clickable-create-instance')
           .wait('#clickable-new-holdings-record')
           .then(() => { done(); })
           .catch(done);
       });
       createInventory(nightmare, config, '', 1);
+
       it('should find new title in list ', (done) => {
         nightmare
-          .wait('#list-inventory')
+          .wait('#input-inventory-search')
+          .click('#input-inventory-search')
+          .insert('#input-inventory-search', title)
+          .wait('#clickable-reset-all')
+          .wait('button[type=submit]')
+          .click('button[type=submit]')
+          .wait('#list-inventory[data-total-count]')
           .evaluate((name) => {
             const node = Array.from(
               document.querySelectorAll('#list-inventory div[role="row"][aria-rowindex="2"] > a > div')

--- a/test/ui-testing/test.js
+++ b/test/ui-testing/test.js
@@ -1,9 +1,10 @@
 // const newTitle = require('./new_title.js');
 const filters = require('./filters.js');
 const search = require('./search.js');
+const newTitle = require('./new-title.js');
 
 module.exports.test = function test(uiTestCtx) {
-  // newTitle.test(uiTestCtx);
+  newTitle.test(uiTestCtx);
   filters.test(uiTestCtx);
   search.test(uiTestCtx);
 };


### PR DESCRIPTION
The test was attempting to insert a value into a read-only field (hrid) and
nightmare handled this by leaving mouse-focus on the previous field,
causing the hrid value to be appended to the previously-focused field,
which would then cause the final search step to fail because the title
would not match the search string.

Fixes [UIIN-557](https://issues.folio.org/browse/UIIN-557)