### PR TITLE
UIORG-150 remove unnecessary permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix item details retaining loan data for closed loan. Part of UIIN-484.
 * Do not attempt to manually set the read-only HRID field in tests. Refs UIIN-557.
+* Remove unnecessary permissions. Refs UIORG-150.
 
 ## 1.10.0 (https://github.com/folio-org/ui-inventory/tree/v1.10.0) (2019-06-14)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.9.0...v1.10.0)

--- a/package.json
+++ b/package.json
@@ -126,14 +126,6 @@
         "visible": true
       },
       {
-        "permissionName": "settings.inventory.enabled",
-        "displayName": "Settings (Inventory): display list of settings pages",
-        "subPermissions": [
-          "settings.enabled"
-        ],
-        "visible": true
-      },
-      {
         "permissionName": "ui-inventory.settings.instance-formats",
         "displayName": "Settings (Inventory): Can create, edit and remove formats",
         "subPermissions": [


### PR DESCRIPTION
Settings permissions are more granular than "settings pages" so this
value was useless.

Refs [UIORG-150](https://issues.folio.org/browse/UIORG-150)