### PR TITLE
rename new-holdings-record button

### DIFF
--- a/src/edit/holdings/HoldingsForm.js
+++ b/src/edit/holdings/HoldingsForm.js
@@ -227,7 +227,7 @@ class HoldingsForm extends React.Component {
           {ariaLabel => (
             <Button
               buttonStyle="primary paneHeaderNewButton"
-              id="clickable-create-item"
+              id="clickable-create-holdings-record"
               type="submit"
               aria-label={ariaLabel}
               disabled={(pristine || submitting) && !copy}


### PR DESCRIPTION
The new-holdings-record button was named new-item-record. That ain't right. Practically, this change has absolutely no effect, but it reduces the cognitive dissonance when writing tests.