### PR TITLE
UIIN-618 new search array syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix item details retaining loan data for closed loan. Part of UIIN-484.
 * Do not attempt to manually set the read-only HRID field in tests. Refs UIIN-557.
 * Remove unnecessary permissions. Refs UIORG-150.
+* Use new array-search syntax for identifiers, contributors. Fixes UIIN-618, UIIN-621, UIIN-623, UIIN-624.
 
 ## 1.10.0 (https://github.com/folio-org/ui-inventory/tree/v1.10.0) (2019-06-14)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.9.0...v1.10.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/inventory",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Inventory manager",
   "repository": "folio-org/ui-inventory",
   "publishConfig": {

--- a/src/Instances.js
+++ b/src/Instances.js
@@ -5,7 +5,6 @@ import {
   keyBy,
   get,
   template,
-  isEmpty,
 } from 'lodash';
 import {
   injectIntl,
@@ -68,14 +67,14 @@ const filterConfig = [
 ];
 
 const searchableIndexes = [
-  { label: 'ui-inventory.search.all', value: 'all', queryTemplate: 'title="%{query.query}" or contributors =/@value "%{query.query}" or identifiers =/@value "%{query.query}"' },
+  { label: 'ui-inventory.search.all', value: 'all', queryTemplate: 'title="%{query.query}" or contributors =/@name "%{query.query}" or identifiers =/@value "%{query.query}"' },
   { label: 'ui-inventory.barcode', value: 'item.barcode', queryTemplate: 'item.barcode=="%{query.query}"' },
   { label: 'ui-inventory.instanceId', value: 'id', queryTemplate: 'id="%{query.query}"' },
   { label: 'ui-inventory.title', value: 'title', queryTemplate: 'title="%{query.query}"' },
   { label: 'ui-inventory.identifier', value: 'identifier', queryTemplate: 'identifiers =/@value "%{query.query}"' },
-  { label: 'ui-inventory.isbn', prefix: '- ', value: 'isbn', queryTemplate: 'identifiers =/@identifierTypeId="<%= identifierTypeId %>" "%{query.query}"' },
-  { label: 'ui-inventory.issn', prefix: '- ', value: 'issn', queryTemplate: 'identifiers =/@identifierTypeId="<%= identifierTypeId %>" "%{query.query}"' },
-  { label: 'ui-inventory.contributor', value: 'contributor', queryTemplate: 'contributors =/@value "%{query.query}' },
+  { label: 'ui-inventory.isbn', prefix: '- ', value: 'isbn', queryTemplate: 'identifiers =/@value/@identifierTypeId="<%= identifierTypeId %>" "%{query.query}"' },
+  { label: 'ui-inventory.issn', prefix: '- ', value: 'issn', queryTemplate: 'identifiers =/@value/@identifierTypeId="<%= identifierTypeId %>" "%{query.query}"' },
+  { label: 'ui-inventory.contributor', value: 'contributor', queryTemplate: 'contributors =/@name "%{query.query}"' },
   { label: 'ui-inventory.subject', value: 'subject', queryTemplate: 'subjects="%{query.query}"' },
 ];
 
@@ -281,18 +280,6 @@ class Instances extends React.Component {
     this.props.updateLocation({ qindex });
   }
 
-  onFilterChange = (e) => {
-    console.log(e)
-    //
-    // // if we're clearing the filters, clear the query index too
-    if (isEmpty(e)) {
-      this.props.updateLocation({ qindex: 'all' });
-    }
-
-    // const qindex = e.target.value;
-    // this.props.updateLocation({ qindex });
-  }
-
   updateFilters(prevFilters) { // provided for onChangeFilter
     const filters = Object.keys(prevFilters).filter(key => filters[key]).join(',');
     this.props.updateLocation({ filters });
@@ -421,7 +408,6 @@ class Instances extends React.Component {
           selectedIndex={get(this.props.resources.query, 'qindex')}
           searchableIndexesPlaceholder={null}
           onChangeIndex={this.onChangeIndex}
-          filterChangeCallback={this.onFilterChange}
           filterConfig={filterConfig}
           initialResultCount={INITIAL_RESULT_COUNT}
           resultCountIncrement={RESULT_COUNT_INCREMENT}


### PR DESCRIPTION
RMB v26 provides a new search syntax for array values which is
implemented here for contributors and identifiers. It's hard to
overstate how happy I am about this.

Search syntax details at [RMB-380](https://issues.folio.org/browse/RMB-380); official documentation in the [rmb repository](https://github.com/folio-org/raml-module-builder/tree/master/cql2pgjson#-relation-modifiers-for-array-searches).

Fixes [UIIN-618](https://issues.folio.org/browse/UIIN-618), [UIIN-621](https://issues.folio.org/browse/UIIN-621), [UIIN-623](https://issues.folio.org/browse/UIIN-623), [UIIN-624](https://issues.folio.org/browse/UIIN-624)
