### PR TITLE
UITEN-35 restore settings menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
           "inventory-storage.material-types.item.get",
           "inventory-storage.material-types.item.post",
           "inventory-storage.material-types.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -110,7 +110,7 @@
           "inventory-storage.loan-types.item.get",
           "inventory-storage.loan-types.item.post",
           "inventory-storage.loan-types.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -123,7 +123,7 @@
           "inventory-storage.statistical-code-types.item.get",
           "inventory-storage.statistical-code-types.item.post",
           "inventory-storage.statistical-code-types.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -136,7 +136,7 @@
           "inventory-storage.instance-formats.item.get",
           "inventory-storage.instance-formats.item.post",
           "inventory-storage.instance-formats.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -149,7 +149,7 @@
           "inventory-storage.electronic-access-relationships.item.get",
           "inventory-storage.electronic-access-relationships.item.post",
           "inventory-storage.electronic-access-relationships.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -162,7 +162,7 @@
           "inventory-storage.holdings-types.item.get",
           "inventory-storage.holdings-types.item.post",
           "inventory-storage.holdings-types.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -175,7 +175,7 @@
           "inventory-storage.classification-types.item.get",
           "inventory-storage.classification-types.item.post",
           "inventory-storage.classification-types.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -188,7 +188,7 @@
           "inventory-storage.identifier-types.item.get",
           "inventory-storage.identifier-types.item.post",
           "inventory-storage.identifier-types.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -201,7 +201,7 @@
           "inventory-storage.instance-statuses.item.get",
           "inventory-storage.instance-statuses.item.post",
           "inventory-storage.instance-statuses.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -214,7 +214,7 @@
           "inventory-storage.statistical-codes.item.get",
           "inventory-storage.statistical-codes.item.post",
           "inventory-storage.statistical-codes.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -227,7 +227,7 @@
           "inventory-storage.alternative-title-types.item.get",
           "inventory-storage.alternative-title-types.item.post",
           "inventory-storage.alternative-title-types.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -240,7 +240,7 @@
           "inventory-storage.instance-types.item.get",
           "inventory-storage.instance-types.item.post",
           "inventory-storage.instance-types.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -253,7 +253,7 @@
           "inventory-storage.nature-of-content-terms.item.get",
           "inventory-storage.nature-of-content-terms.item.post",
           "inventory-storage.nature-of-content-terms.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -266,7 +266,7 @@
           "inventory-storage.modes-of-issuance.item.get",
           "inventory-storage.modes-of-issuance.item.post",
           "inventory-storage.modes-of-issuance.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -279,7 +279,7 @@
           "inventory-storage.instance-note-types.item.get",
           "inventory-storage.instance-note-types.item.post",
           "inventory-storage.instance-note-types.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -292,7 +292,7 @@
           "inventory-storage.ill-policies.item.get",
           "inventory-storage.ill-policies.item.post",
           "inventory-storage.ill-policies.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -305,7 +305,7 @@
           "inventory-storage.contributor-types.item.get",
           "inventory-storage.contributor-types.item.post",
           "inventory-storage.contributor-types.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -318,7 +318,7 @@
           "inventory-storage.call-number-types.item.get",
           "inventory-storage.call-number-types.item.post",
           "inventory-storage.call-number-types.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -331,7 +331,7 @@
           "inventory-storage.holdings-note-types.item.get",
           "inventory-storage.holdings-note-types.item.post",
           "inventory-storage.holdings-note-types.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -344,7 +344,7 @@
           "inventory-storage.item-note-types.item.get",
           "inventory-storage.item-note-types.item.post",
           "inventory-storage.item-note-types.item.put",
-          "settings.inventory.enabled"
+          "settings.enabled"
         ],
         "visible": true
       }


### PR DESCRIPTION
When `settings.inventory.enabiled` was removed in #613 under the auspices of
[UITEN-35](https://issues.folio.org/browse/UITEN-35), the permission sets that relied on it should have been updated
to include `settings.enabled` in order to cause Settings to be
accessible.

Removing `settings.inventory.enabled` _was_ the right thing to do; it was
functionally a do-nothing permission because the individual menu items
are controlled by more granular permissions. BUT we do need to make sure
that the top-level Settings menu is displayed when any of those
granular permissions are granted.

Refs [UITEN-35](https://issues.folio.org/browse/UITEN-35)