### PR TITLE
UIIN-652 restore settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,14 @@
         "visible": true
       },
       {
+        "permissionName": "settings.inventory.enabled",
+        "displayName": "Settings (Inventory): display list of settings pages",
+        "subPermissions": [
+          "settings.enabled"
+        ],
+        "visible": false
+      },
+      {
         "permissionName": "ui-inventory.settings.materialtypes",
         "displayName": "Settings (Inventory): Can create, edit and remove material types",
         "subPermissions": [
@@ -97,7 +105,7 @@
           "inventory-storage.material-types.item.get",
           "inventory-storage.material-types.item.post",
           "inventory-storage.material-types.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       },
@@ -110,7 +118,7 @@
           "inventory-storage.loan-types.item.get",
           "inventory-storage.loan-types.item.post",
           "inventory-storage.loan-types.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       },
@@ -123,7 +131,7 @@
           "inventory-storage.statistical-code-types.item.get",
           "inventory-storage.statistical-code-types.item.post",
           "inventory-storage.statistical-code-types.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       },
@@ -136,7 +144,7 @@
           "inventory-storage.instance-formats.item.get",
           "inventory-storage.instance-formats.item.post",
           "inventory-storage.instance-formats.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       },
@@ -149,7 +157,7 @@
           "inventory-storage.electronic-access-relationships.item.get",
           "inventory-storage.electronic-access-relationships.item.post",
           "inventory-storage.electronic-access-relationships.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       },
@@ -162,7 +170,7 @@
           "inventory-storage.holdings-types.item.get",
           "inventory-storage.holdings-types.item.post",
           "inventory-storage.holdings-types.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       },
@@ -175,7 +183,7 @@
           "inventory-storage.classification-types.item.get",
           "inventory-storage.classification-types.item.post",
           "inventory-storage.classification-types.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       },
@@ -188,7 +196,7 @@
           "inventory-storage.identifier-types.item.get",
           "inventory-storage.identifier-types.item.post",
           "inventory-storage.identifier-types.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       },
@@ -201,7 +209,7 @@
           "inventory-storage.instance-statuses.item.get",
           "inventory-storage.instance-statuses.item.post",
           "inventory-storage.instance-statuses.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       },
@@ -214,7 +222,7 @@
           "inventory-storage.statistical-codes.item.get",
           "inventory-storage.statistical-codes.item.post",
           "inventory-storage.statistical-codes.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       },
@@ -227,7 +235,7 @@
           "inventory-storage.alternative-title-types.item.get",
           "inventory-storage.alternative-title-types.item.post",
           "inventory-storage.alternative-title-types.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       },
@@ -240,7 +248,7 @@
           "inventory-storage.instance-types.item.get",
           "inventory-storage.instance-types.item.post",
           "inventory-storage.instance-types.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       },
@@ -253,7 +261,7 @@
           "inventory-storage.nature-of-content-terms.item.get",
           "inventory-storage.nature-of-content-terms.item.post",
           "inventory-storage.nature-of-content-terms.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       },
@@ -266,7 +274,7 @@
           "inventory-storage.modes-of-issuance.item.get",
           "inventory-storage.modes-of-issuance.item.post",
           "inventory-storage.modes-of-issuance.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       },
@@ -279,7 +287,7 @@
           "inventory-storage.instance-note-types.item.get",
           "inventory-storage.instance-note-types.item.post",
           "inventory-storage.instance-note-types.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       },
@@ -292,7 +300,7 @@
           "inventory-storage.ill-policies.item.get",
           "inventory-storage.ill-policies.item.post",
           "inventory-storage.ill-policies.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       },
@@ -305,7 +313,7 @@
           "inventory-storage.contributor-types.item.get",
           "inventory-storage.contributor-types.item.post",
           "inventory-storage.contributor-types.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       },
@@ -318,7 +326,7 @@
           "inventory-storage.call-number-types.item.get",
           "inventory-storage.call-number-types.item.post",
           "inventory-storage.call-number-types.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       },
@@ -331,7 +339,7 @@
           "inventory-storage.holdings-note-types.item.get",
           "inventory-storage.holdings-note-types.item.post",
           "inventory-storage.holdings-note-types.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       },
@@ -344,7 +352,7 @@
           "inventory-storage.item-note-types.item.get",
           "inventory-storage.item-note-types.item.post",
           "inventory-storage.item-note-types.item.put",
-          "settings.enabled"
+          "settings.inventory.enabled"
         ],
         "visible": true
       }


### PR DESCRIPTION
Access to inventory settings was inadvertently removed in #613. We don't
need `settings.inventory.enabled` to be a visible permission, but we do
need it to be present so that stripes-core will discover that this
module has settings.

Fixes [UIIN-652](https://issues.folio.org/browse/UIIN-652), Refs [FOLIO-2184](https://issues.folio.org/browse/FOLIO-2184)