### PR TITLE
UIIN-655 omit optional FK fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## 1.12.0 (IN PROGRESS)
+
+* Do not send optional FKs as empty strings; omit them. Refs UIIN-655.
+
 ## [1.11.0](https://github.com/folio-org/ui-inventory/tree/v1.11.0) (2019-07-24)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.10.0...v1.11.0)
 

--- a/src/edit/contributorFields.js
+++ b/src/edit/contributorFields.js
@@ -78,7 +78,6 @@ const ContributorFields = props => {
             name: '',
             contributorNameTypeId: '',
             primary: false,
-            contributorTypeId: '',
             contributorTypeText: '',
           }}
           canAdd={canAdd}


### PR DESCRIPTION
FK fields that contain UUIDs are now validated so an empty string fails
validation. This means an optional field containing a foreign key,
i.e. any field represented by a `<Select>` element, must be omitted from
the response rather than sent as an empty string.

Refs [UIIN-655](https://issues.folio.org/browse/UIIN-655)