### PR TITLE
UIIN-643 don't show static elements as interactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Relabel notes accordions. Fixes UIIN-632, UIIN-633, UIIN-634.
 * Fix bug in alternative title validation. Fixes UIIN-558.
+* Don't present static tables as interactive. Refs UIIN-643.
 
 ## [1.11.1](https://github.com/folio-org/ui-inventory/tree/v1.11.1) (2019-07-26)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.11.0...v1.11.1)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -656,6 +656,7 @@ class ViewInstance extends React.Component {
                         }}
                         ariaLabel={ariaLabel}
                         containerRef={(ref) => { this.resultsList = ref; }}
+                        interactive={false}
                       />
                     )}
                   </FormattedMessage>
@@ -697,6 +698,7 @@ class ViewInstance extends React.Component {
                         formatter={alternativeTitlesRowFormatter}
                         ariaLabel={ariaLabel}
                         containerRef={(ref) => { this.resultsList = ref; }}
+                        interactive={false}
                       />
                     )}
                   </FormattedMessage>
@@ -751,6 +753,7 @@ class ViewInstance extends React.Component {
                         formatter={identifiersRowFormatter}
                         ariaLabel={ariaLabel}
                         containerRef={(ref) => { this.resultsList = ref; }}
+                        interactive={false}
                       />
                     )}
                   </FormattedMessage>
@@ -786,6 +789,7 @@ class ViewInstance extends React.Component {
                         formatter={contributorsRowFormatter}
                         ariaLabel={ariaLabel}
                         containerRef={(ref) => { this.resultsList = ref; }}
+                        interactive={false}
                       />
                     )}
                   </FormattedMessage>
@@ -820,6 +824,7 @@ class ViewInstance extends React.Component {
                         formatter={publicationRowFormatter}
                         ariaLabel={ariaLabel}
                         containerRef={(ref) => { this.resultsList = ref; }}
+                        interactive={false}
                       />
                     )}
                   </FormattedMessage>
@@ -892,6 +897,7 @@ class ViewInstance extends React.Component {
                           formatter={formatsRowFormatter}
                           ariaLabel={ariaLabel}
                           containerRef={(ref) => { this.resultsList = ref; }}
+                          interactive={false}
                         />
                       )}
                     </FormattedMessage>
@@ -963,6 +969,7 @@ class ViewInstance extends React.Component {
                         formatter={electronicAccessRowFormatter}
                         ariaLabel={ariaLabel}
                         containerRef={(ref) => { this.resultsList = ref; }}
+                        interactive={false}
                       />
                     )}
                   </FormattedMessage>
@@ -1015,6 +1022,7 @@ class ViewInstance extends React.Component {
                       formatter={classificationsRowFormatter}
                       ariaLabel={ariaLabel}
                       containerRef={(ref) => { this.resultsList = ref; }}
+                      interactive={false}
                     />
                   )}
                 </FormattedMessage>


### PR DESCRIPTION
Non-interactive tables should not be presented as though they are
interactive.

Refs [UIIN-643](https://issues.folio.org/browse/UIIN-643)