### PR TITLE
don't pass invalid props

### DIFF
--- a/src/edit/InstanceForm.js
+++ b/src/edit/InstanceForm.js
@@ -515,8 +515,6 @@ class InstanceForm extends React.Component {
                     component={TextField}
                     fullWidth
                     disabled={this.isFieldBlocked('indexTitle')}
-                    canEdit={!this.isFieldBlocked('indexTitle')}
-                    canDelete={!this.isFieldBlocked('indexTitle')}
                   />
                 </Col>
                 <SeriesFields


### PR DESCRIPTION
the `canEdit` and `canDelete` props look like they were likely
copy-pasted from the above `RepeatableField` fields but they are not
valid props here.