### PR TITLE
UIIN-667 preserve checkbox state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Refactor forms to use final form. Part of UIIN-668.
 * Don't present static tables as interactive. Refs UIIN-643.
 * Refactor item's copy number to a single field. Part of UIIN-653.
+* Preserve holdings record checkbox state. Fixes UIIN-667.
 
 ## [1.11.1](https://github.com/folio-org/ui-inventory/tree/v1.11.1) (2019-07-26)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.11.0...v1.11.1)

--- a/src/edit/holdings/HoldingsForm.js
+++ b/src/edit/holdings/HoldingsForm.js
@@ -346,6 +346,7 @@ class HoldingsForm extends React.Component {
                     name="discoverySuppress"
                     id="input_discovery_suppress"
                     component={Checkbox}
+                    type="checkbox"
                   />
                 </Col>
               </Row>
@@ -704,17 +705,18 @@ class HoldingsForm extends React.Component {
                       {
                         name: 'publicDisplay',
                         label: <FormattedMessage id="ui-inventory.publicDisplay" />,
-                        component: Checkbox
+                        component: Checkbox,
+                        type: 'checkbox',
                       },
                       {
                         name: 'enumeration',
                         label: <FormattedMessage id="ui-inventory.enumeration" />,
-                        component: TextField
+                        component: TextField,
                       },
                       {
                         name: 'chronology',
                         label: <FormattedMessage id="ui-inventory.chronology" />,
-                        component: TextField
+                        component: TextField,
                       },
                     ]}
                   />


### PR DESCRIPTION
The "suppress from discovery" checkbox on the holdings form was missing
a required attribute.

Fixes [UIIN-667](https://issues.folio.org/browse/UIIN-667)