### PR TITLE
console cleanup

### DIFF
--- a/src/ViewItem.js
+++ b/src/ViewItem.js
@@ -400,6 +400,13 @@ class ViewItem extends React.Component {
     return false;
   };
 
+  formValues = item => {
+    const target = Object.assign({}, item);
+    target.copyNumbers = item.copyNumbers.length ? item.copyNumbers[0] : '';
+
+    return target;
+  };
+
   render() {
     const {
       location,
@@ -1134,7 +1141,7 @@ class ViewItem extends React.Component {
               <ItemForm
                 form={`itemform_${item.id}`}
                 onSubmit={(record) => { this.saveItem(record); }}
-                initialValues={item}
+                initialValues={this.formValues(item)}
                 onCancel={this.onClickCloseEditItem}
                 okapi={okapi}
                 instance={instance}


### PR DESCRIPTION
Copy-number is an array on the backend but exposed as a non-repeatable
field on the front-end. Thus, we need to convert the value when
displaying the form (to provide the expected data-type to the Field,
which would get an array but wants a string/number) just as we don when
saving the form (which would receive a string/number but wants an
array).