### PR TITLE
clean up props-mismatch console warning

### DIFF
--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -211,25 +211,6 @@ class ItemForm extends React.Component {
     this.props.form.change('itemDamagedStatusDate', new Date());
   }
 
-  onSave = (e) => {
-    const {
-      form: {
-        getFieldState,
-        mutators: {
-          updateValue,
-        },
-      },
-    } = this.props;
-
-    const { value } = getFieldState('copyNumbers');
-
-    if (value && !isArray(value)) {
-      updateValue('copyNumbers', [value]);
-    }
-
-    this.props.handleSubmit(e);
-  }
-
   render() {
     const {
       pristine,
@@ -250,6 +231,7 @@ class ItemForm extends React.Component {
         itemDamagedStatuses,
       },
       copy,
+      handleSubmit,
     } = this.props;
 
     const {
@@ -352,7 +334,7 @@ class ItemForm extends React.Component {
     const labelCallNumber = holdingsRecord.callNumber || '';
 
     return (
-      <form onSubmit={this.onSave} data-test-item-page-type={initialValues.id ? 'edit' : 'create'}>
+      <form onSubmit={handleSubmit} data-test-item-page-type={initialValues.id ? 'edit' : 'create'}>
         <Paneset isRoot>
           <Pane
             defaultWidth="100%"
@@ -534,7 +516,7 @@ class ItemForm extends React.Component {
                 <Col sm={3}>
                   <Field
                     label={<FormattedMessage id="ui-inventory.copyNumber" />}
-                    name="copyNumbers"
+                    name="copyNumbers[0]"
                     component={TextField}
                     fullWidth
                   />


### PR DESCRIPTION
Copy-number is an array on the backend but exposed as a non-repeatable
field on the front-end. Previously, the raw array was provided to the
`<Field>`, resulting in a prop-types console warning. Rather than converting
back and forth between array and scalar values, we just operate on the
first element of the array.

Replaces #691