### PR TITLE
UIIN-683 show damage status value, not the ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Preserve holdings record checkbox state. Fixes UIIN-667.
 * Fix notes selector on item create form. Fixes UIIN-669.
 * Add ability to copy item's barcode to clipboard. Fixes UIIN-177.
-
+* Show damage status value from the lookup table, instead of the raw id. Refs UIIN-683.
 
 ## [1.11.1](https://github.com/folio-org/ui-inventory/tree/v1.11.1) (2019-07-26)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.11.0...v1.11.1)

--- a/src/ViewItem.js
+++ b/src/ViewItem.js
@@ -945,7 +945,7 @@ class ViewItem extends React.Component {
                       <Col smOffset={0} sm={4}>
                         <KeyValue
                           label={<FormattedMessage id="ui-inventory.itemDamagedStatus" />}
-                          value={item.itemDamagedStatusId}
+                          value={refLookup(referenceTables.itemDamagedStatuses, get(item, ['itemDamagedStatusId'])).name}
                         />
                       </Col>
                     }


### PR DESCRIPTION
Damage status recently changed from an enumerable value to a lookup table
value backed by `id` and `name` attributes but the view-item page hadn't
been updated to reflect that and instead still showed the raw ID.

Refs [UIIN-683](https://issues.folio.org/browse/UIIN-683)