### PR TITLE
UIIN-696 allow unassigning of temporary loan type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix notes selector on item create form. Fixes UIIN-669.
 * Add ability to copy item's barcode to clipboard. Fixes UIIN-177.
 * Show damage status value from the lookup table, instead of the raw id. Refs UIIN-683.
+* Allow unassigning of temporary loan type. Fixes UIIN-696.
 
 ## [1.11.1](https://github.com/folio-org/ui-inventory/tree/v1.11.1) (2019-07-26)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.11.0...v1.11.1)

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { get, cloneDeep, isArray } from 'lodash';
+import { get, cloneDeep } from 'lodash';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import {
@@ -776,12 +776,15 @@ class ItemForm extends React.Component {
                     {placeholder => (
                       <Field
                         label={<FormattedMessage id="ui-inventory.loanTypeTemporary" />}
-                        placeholder={placeholder}
                         name="temporaryLoanType.id"
                         id="additem_loanTypeTemp"
                         component={Select}
                         fullWidth
-                        dataOptions={loanTypeOptions}
+                        dataOptions={[{
+                          label: placeholder,
+                          value: '',
+                          selected: !initialValues.loanType,
+                        }, ...loanTypeOptions]}
                       />
                     )}
                   </FormattedMessage>


### PR DESCRIPTION
Passing a `placeholder` prop to `<Select>` creates a disabled first
element. Here, we want a placeholder, but we want it enabled because
this field is optional.

Fixes [UIIN-696](https://issues.folio.org/browse/UIIN-696)