### PR TITLE
Release v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.13.0 (IN PROGRESS)
 
-## [1.12.0](https://github.com/folio-org/ui-inventory/tree/v1.12.0) (2019-09-10)
+## [1.12.0](https://github.com/folio-org/ui-inventory/tree/v1.12.0) (2019-09-12)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.11.1...v1.12.0)
 
 * Relabel notes accordions. Fixes UIIN-632, UIIN-633, UIIN-634.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/inventory",
-  "version": "1.13.0",
+  "version": "1.12.0",
   "description": "Inventory manager",
   "repository": "folio-org/ui-inventory",
   "publishConfig": {


### PR DESCRIPTION
## Purpose
Release module for the FOLIO 2019Q3.2. Refs [UIIN-718](https://issues.folio.org/browse/UIIN-718). The previous PR #701 was done in the wrong way by assigning the 1.13.0 version instead of 1.12.0 which was already in place.