### PR TITLE
UIIN-725 correctly import Field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.13.0 (IN PROGRESS)
 
+* Correctly import `<Field>` in `StatisticalCodeSettings`. Refs UIIN-725
+
 ## [1.12.0](https://github.com/folio-org/ui-inventory/tree/v1.12.0) (2019-09-12)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.11.1...v1.12.0)
 

--- a/package.json
+++ b/package.json
@@ -403,11 +403,12 @@
     "react-final-form-listeners": "^1.0.2",
     "react-hot-loader": "^4.3.12",
     "react-intl": "^2.3.0",
-    "react-router": "^4.0.0",
-    "react-router-dom": "^4.0.0"
+    "redux-form": "^7.0.3"
   },
   "peerDependencies": {
     "@folio/stripes": "^2.9.0",
-    "react": "*"
+    "react": "*",
+    "react-router": "^5.0.1",
+    "react-router-dom": "^5.0.1"
   }
 }

--- a/src/settings/StatisticalCodeSettings.js
+++ b/src/settings/StatisticalCodeSettings.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import { Field } from 'react-final-form';
+import { Field } from 'redux-form';
 import { FormattedMessage } from 'react-intl';
 
 import { ControlledVocab } from '@folio/stripes/smart-components';


### PR DESCRIPTION
Forms in ui-inventory were converted from redux-form to
react-final-form, but `<ControlledVocab>` is a stripes-smart-component
form, not a ui-inventory form. Hence, its `<Field>` components must be
imported from `redux-form`.

Fixes [UIIN-725](https://issues.folio.org/browse/UIIN-725)