### PR TITLE
Revert "UIIN-727 update circulation API to v8"

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
       "holdings-note-types": "1.0",
       "users": "15.0",
       "location-units": "1.1",
-      "circulation": "4.0 5.0 6.0 7.0 8.0"
+      "circulation": "4.0 5.0 6.0 7.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
Reverts folio-org/ui-inventory#709

Reverting only so we can tag a patch release at tip-of-master; this is the only feature-commit since `v1.12.0` was released and reverting (and then reapplying) a single PR will be easier than cherry-picking everything since this PR onto a release branch. Yes, yes, we may want to investigate a different branching strategy like GitFlow in the long term to mitigate this process. Today, I just need to publish a release. 