### PR TITLE
UIIN-747: Fix the impact of the API change as per MODINVSTOR-315 for ui-inventory.

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
       "ill-policies": "1.0",
       "holdings-note-types": "1.0",
       "users": "15.0",
-      "location-units": "1.1",
+      "location-units": "2.0",
       "circulation": "4.0 5.0 6.0 7.0 8.0"
     },
     "permissionSets": [


### PR DESCRIPTION

"location-units" bumped to '2.0'.