### PR TITLE
Add query param to new request url. Part of UIIN-773

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 1.13.0 (IN PROGRESS)
 * Added iconAlignment "baseline" for <AppIcon>'s in the results list (UIIN-719)
-
 * Increase limit for holdings to 1000. Refs UIIN-723.
+* Add query param to new request url. Part of UIIN-773.
 
 ## [1.12.1](https://github.com/folio-org/ui-inventory/tree/v1.12.1) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.12.0...v1.12.1)

--- a/src/ViewItem.js
+++ b/src/ViewItem.js
@@ -302,8 +302,8 @@ class ViewItem extends React.Component {
     const request = get(resources, 'requests.records[0]');
 
     const newRequestLink = firstItem.barcode
-      ? `/requests?itemBarcode=${firstItem.barcode}&layer=create`
-      : `/requests?itemId=${firstItem.id}&layer=create`;
+      ? `/requests?itemBarcode=${firstItem.barcode}&query=${firstItem.barcode}&layer=create`
+      : `/requests?itemId=${firstItem.id}&query=${firstItem.id}&layer=create`;
 
     return (
       <Fragment>


### PR DESCRIPTION
This is kind of a workaround for the issue described in https://issues.folio.org/browse/UIIN-773.
In order to address it properly we would have to fix the routing (get rid of the query resource and refactor search and sort).

The small change introduced in this PR will perform a search for related item in the request app before the creation form will be presented (which is actually a nice to have). As a side effect it should also fix UIIN-773.