### PR TITLE
Another take on UIIN-758 with separate routes. 

### DIFF
--- a/src/components/FilterNavigation/FilterNavigation.js
+++ b/src/components/FilterNavigation/FilterNavigation.js
@@ -8,7 +8,7 @@ import {
 
 import { segments } from '../../constants';
 
-const FiltersNavigation = ({ segment }) => (
+const FilterNavigation = ({ segment }) => (
   <ButtonGroup
     fullWidth
     data-test-filters-navigation
@@ -17,7 +17,7 @@ const FiltersNavigation = ({ segment }) => (
       Object.keys(segments).map(name => (
         <Button
           key={`${name}`}
-          to={`/inventory?segment=${name}`}
+          to={`/inventory/${name}`}
           buttonStyle={`${segment === name ? 'primary' : 'default'}`}
         >
           <FormattedMessage id={`ui-inventory.filters.${name}`} />
@@ -27,12 +27,12 @@ const FiltersNavigation = ({ segment }) => (
   </ButtonGroup>
 );
 
-FiltersNavigation.propTypes = {
+FilterNavigation.propTypes = {
   segment: PropTypes.string,
 };
 
-FiltersNavigation.defaultProps = {
+FilterNavigation.defaultProps = {
   segment: segments.instances,
 };
 
-export default FiltersNavigation;
+export default FilterNavigation;

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -1,0 +1,208 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  omit,
+  get,
+  set,
+  flowRight,
+} from 'lodash';
+import {
+  injectIntl,
+  intlShape,
+} from 'react-intl';
+import { AppIcon } from '@folio/stripes/core';
+import { SearchAndSort } from '@folio/stripes/smart-components';
+
+import FilterNavigation from '../FilterNavigation';
+import packageInfo from '../../../package';
+import InstanceForm from '../../edit/InstanceForm';
+import ViewInstance from '../../ViewInstance';
+import formatters from '../../referenceFormatters';
+import withLocation from '../../withLocation';
+import {
+  getCurrentFilters,
+  parseFiltersToStr,
+} from '../../utils';
+
+const INITIAL_RESULT_COUNT = 30;
+const RESULT_COUNT_INCREMENT = 30;
+
+class InstancesView extends React.Component {
+  static defaultProps = {
+    browseOnly: false,
+    showSingleResult: true,
+  };
+
+  static propTypes = {
+    data: PropTypes.object,
+    parentResources: PropTypes.object,
+    parentMutator: PropTypes.object,
+    showSingleResult: PropTypes.bool,
+    browseOnly: PropTypes.bool,
+    disableRecordCreation: PropTypes.bool,
+    onSelectRow: PropTypes.func,
+    visibleColumns: PropTypes.arrayOf(PropTypes.string),
+    updateLocation: PropTypes.func.isRequired,
+    onCreate: PropTypes.func,
+    segment: PropTypes.string,
+    isLoading: PropTypes.bool,
+    intl: intlShape,
+    match: PropTypes.shape({
+      path: PropTypes.string.isRequired,
+      params: PropTypes.object.isRequired,
+    }).isRequired,
+    renderFilters: PropTypes.func.isRequired,
+    searchableIndexes: PropTypes.arrayOf(PropTypes.object).isRequired,
+  };
+
+  state = {};
+
+  onChangeIndex = (e) => {
+    const qindex = e.target.value;
+    this.props.updateLocation({ qindex });
+  };
+
+  onFilterChangeHandler = ({ name, values }) => {
+    const { data: { query } } = this.props;
+    const curFilters = getCurrentFilters(get(query.filters));
+    const mergedFilters = values.length
+      ? { ...curFilters, [name]: values }
+      : omit(curFilters, name);
+    const filtersStr = parseFiltersToStr(mergedFilters);
+
+    this.props.updateLocation({ filters: filtersStr });
+  };
+
+  closeNewInstance = (e) => {
+    if (e) e.preventDefault();
+    this.setState({ copiedInstance: null });
+    this.props.updateLocation({ layer: null });
+  };
+
+  onCreate = (instance) => {
+    this.props.onCreate(instance).then(() => this.closeNewInstance());
+  }
+
+  copyInstance = (instance) => {
+    let copiedInstance = omit(instance, ['id', 'hrid']);
+    copiedInstance = set(copiedInstance, 'source', 'FOLIO');
+    this.setState({ copiedInstance });
+    this.props.updateLocation({ layer: 'create' });
+  }
+
+  renderNavigation = () => (
+    <FilterNavigation segment={this.props.segment} />
+  );
+
+  render() {
+    const {
+      showSingleResult,
+      browseOnly,
+      onSelectRow,
+      disableRecordCreation,
+      visibleColumns,
+      intl,
+      isLoading,
+      data,
+      parentResources,
+      parentMutator,
+      renderFilters,
+      searchableIndexes,
+      match: {
+        path,
+      }
+    } = this.props;
+
+    if (isLoading) {
+      return null;
+    }
+
+    const resultsFormatter = {
+      'title': ({ title }) => (
+        <AppIcon
+          size="small"
+          app="inventory"
+          iconKey="instance"
+          iconAlignment="baseline"
+        >
+          {title}
+        </AppIcon>
+      ),
+      'relation': r => formatters.relationsFormatter(r, data.instanceRelationshipTypes),
+      'publishers': r => r.publication.map(p => (p ? `${p.publisher} ${p.dateOfPublication ? `(${p.dateOfPublication})` : ''}` : '')).join(', '),
+      'publication date': r => r.publication.map(p => p.dateOfPublication).join(', '),
+      'contributors': r => formatters.contributorsFormatter(r, data.contributorTypes),
+    };
+
+    const formattedSearchableIndexes = searchableIndexes.map(index => {
+      const { prefix = '' } = index;
+      const label = prefix + intl.formatMessage({ id: index.label });
+
+      return { ...index, label };
+    });
+
+    // workaround for SearchAndSort
+    const packageData = {
+      ...packageInfo,
+      stripes: {
+        ...packageInfo.stripes,
+        route: path,
+      },
+    };
+
+    return (
+      <div data-test-inventory-instances>
+        <SearchAndSort
+          packageInfo={packageData}
+          objectName="inventory"
+          maxSortKeys={1}
+          renderNavigation={this.renderNavigation}
+          searchableIndexes={formattedSearchableIndexes}
+          selectedIndex={get(data.query, 'qindex')}
+          searchableIndexesPlaceholder={null}
+          onChangeIndex={this.onChangeIndex}
+          initialResultCount={INITIAL_RESULT_COUNT}
+          resultCountIncrement={RESULT_COUNT_INCREMENT}
+          viewRecordComponent={ViewInstance}
+          editRecordComponent={InstanceForm}
+          newRecordInitialValues={(this.state && this.state.copiedInstance) ? this.state.copiedInstance : {
+            discoverySuppress: false,
+            staffSuppress: false,
+            previouslyHeld: false,
+            source: 'FOLIO'
+          }}
+          visibleColumns={visibleColumns || ['title', 'contributors', 'publishers', 'relation']}
+          columnMapping={{
+            title: intl.formatMessage({ id: 'ui-inventory.instances.columns.title' }),
+            contributors: intl.formatMessage({ id: 'ui-inventory.instances.columns.contributors' }),
+            publishers: intl.formatMessage({ id: 'ui-inventory.instances.columns.publishers' }),
+            relation: intl.formatMessage({ id: 'ui-inventory.instances.columns.relation' }),
+          }}
+          columnWidths={{ title: '40%' }}
+          resultsFormatter={resultsFormatter}
+          onCreate={this.onCreate}
+          viewRecordPerms="ui-inventory.instance.view"
+          newRecordPerms="ui-inventory.instance.create"
+          disableRecordCreation={disableRecordCreation || false}
+          parentResources={parentResources}
+          parentMutator={parentMutator}
+          detailProps={{
+            referenceTables: data,
+            onCopy: this.copyInstance,
+          }}
+          path={`${path}/(view|viewsource)/:id/:holdingsrecordid?/:itemid?`}
+          showSingleResult={showSingleResult}
+          browseOnly={browseOnly}
+          onSelectRow={onSelectRow}
+          renderFilters={renderFilters}
+          onFilterChange={this.onFilterChangeHandler}
+        />
+      </div>
+    );
+  }
+}
+
+export default flowRight(
+  injectIntl,
+  withLocation,
+)(InstancesView);

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -45,7 +45,6 @@ class InstancesView extends React.Component {
     updateLocation: PropTypes.func.isRequired,
     onCreate: PropTypes.func,
     segment: PropTypes.string,
-    isLoading: PropTypes.bool,
     intl: intlShape,
     match: PropTypes.shape({
       path: PropTypes.string.isRequired,
@@ -102,7 +101,6 @@ class InstancesView extends React.Component {
       disableRecordCreation,
       visibleColumns,
       intl,
-      isLoading,
       data,
       parentResources,
       parentMutator,
@@ -112,10 +110,6 @@ class InstancesView extends React.Component {
         path,
       }
     } = this.props;
-
-    if (isLoading) {
-      return null;
-    }
 
     const resultsFormatter = {
       'title': ({ title }) => (

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -141,7 +141,12 @@ class InstancesView extends React.Component {
       return { ...index, label };
     });
 
-    // workaround for SearchAndSort
+    // SearchAndSort is currently using packageInfo.stripes.route as a path
+    // for navigating to a details screen. The code below allows us to
+    // control how the routing for the details screen should look like.
+    // It will handle cases like /inventory or /inventory/holdings or inventory/items
+    // depending on the chosen search segment.
+    // This will go away after we refactor to SearchAndSortQuery.
     const packageData = {
       ...packageInfo,
       stripes: {

--- a/src/components/InstancesList/index.js
+++ b/src/components/InstancesList/index.js
@@ -1,0 +1,1 @@
+export { default } from './InstancesList';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -3,3 +3,4 @@ export { default as RepeatableField } from './RepeatableField';
 export { default as InstanceFilters } from './InstanceFilters';
 export { default as HoldingFilters } from './HoldingFilters';
 export { default as ItemFilters } from './ItemFilters';
+export { default as InstancesList } from './InstancesList';

--- a/src/constants.js
+++ b/src/constants.js
@@ -44,7 +44,7 @@ export const filterConfig = [
   },
 ];
 
-export const searchableIndexes = [
+export const instanceIndexes = [
   { label: 'ui-inventory.search.all', value: 'all', queryTemplate: 'title="%{query.query}" or contributors =/@name "%{query.query}" or identifiers =/@value "%{query.query}"' },
   { label: 'ui-inventory.barcode', value: 'item.barcode', queryTemplate: 'item.barcode=="%{query.query}"' },
   { label: 'ui-inventory.instanceId', value: 'id', queryTemplate: 'id="%{query.query}"' },
@@ -54,6 +54,14 @@ export const searchableIndexes = [
   { label: 'ui-inventory.issn', prefix: '- ', value: 'issn', queryTemplate: 'identifiers =/@value/@identifierTypeId="<%= identifierTypeId %>" "%{query.query}"' },
   { label: 'ui-inventory.contributor', value: 'contributor', queryTemplate: 'contributors =/@name "%{query.query}"' },
   { label: 'ui-inventory.subject', value: 'subject', queryTemplate: 'subjects="%{query.query}"' },
+];
+
+export const holdingIndexes = [
+  // TODO: add holding indexes
+];
+
+export const itemIndexes = [
+  // TODO: add item indexes
 ];
 
 export const segments = {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,11 @@ import Switch from 'react-router-dom/Switch';
 import { hot } from 'react-hot-loader';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
-import InstancesRoute from './routes/InstancesRoute';
+import {
+  InstancesRoute,
+  HoldingsRoute,
+  ItemsRoute,
+} from './routes';
 import Settings from './settings';
 
 const InventoryRouting = (props) => {
@@ -17,6 +21,14 @@ const InventoryRouting = (props) => {
 
   return (
     <Switch>
+      <Route
+        path={`${path}/holdings`}
+        component={HoldingsRoute}
+      />
+      <Route
+        path={`${path}/items`}
+        component={ItemsRoute}
+      />
       <Route
         path={path}
         component={InstancesRoute}

--- a/src/routes/HoldingsRoute.js
+++ b/src/routes/HoldingsRoute.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { stripesConnect } from '@folio/stripes/core';
+
+import withData from './withData';
+import { HoldingsView } from '../views';
+
+class HoldingsRoute extends React.Component {
+  static manifest = Object.freeze({
+    records: {
+      type: 'okapi',
+      records: 'instances',
+      recordsRequired: '%{resultCount}',
+      perRequest: 30,
+      path: 'inventory/instances',
+      GET: {
+        params: {
+          query: () => {
+            // TODO: add query implementation for holdings
+            return null;
+          }
+        },
+        staticFallback: { params: {} },
+      },
+    },
+  });
+
+  render() {
+    const {
+      showSingleResult,
+      browseOnly,
+      onSelectRow,
+      disableRecordCreation,
+      resources,
+      mutator,
+      isLoading,
+      getData,
+      createInstance,
+    } = this.props;
+
+    if (isLoading()) {
+      return null;
+    }
+
+    return (
+      <HoldingsView
+        parentResources={resources}
+        parentMutator={mutator}
+        data={getData()}
+        browseOnly={browseOnly}
+        showSingleResult={showSingleResult}
+        onCreate={createInstance}
+        onSelectRow={onSelectRow}
+        disableRecordCreation={disableRecordCreation}
+      />
+    );
+  }
+}
+
+HoldingsRoute.propTypes = {
+  resources: PropTypes.object.isRequired,
+  mutator: PropTypes.object.isRequired,
+  showSingleResult: PropTypes.bool,
+  browseOnly: PropTypes.bool,
+  disableRecordCreation: PropTypes.bool,
+  onSelectRow: PropTypes.func,
+  isLoading: PropTypes.func,
+  getData: PropTypes.func,
+  createInstance: PropTypes.func,
+};
+
+export default stripesConnect(withData(HoldingsRoute));

--- a/src/routes/InstancesRoute.js
+++ b/src/routes/InstancesRoute.js
@@ -1,42 +1,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  concat,
-  keyBy,
-  get,
-  map,
-  omit,
-  set,
-  template,
-} from 'lodash';
+import { template } from 'lodash';
 import { stripesConnect } from '@folio/stripes/core';
 import { makeQueryFunction } from '@folio/stripes/smart-components';
 
-import InstancesView from '../views';
+import withData from './withData';
+import { InstancesView } from '../views';
 import {
-  searchableIndexes,
+  instanceIndexes,
   filterConfig,
 } from '../constants';
-import { psTitleRelationshipId } from '../utils';
-
-const INITIAL_RESULT_COUNT = 30;
 
 class InstancesRoute extends React.Component {
-  static defaultProps = {
-    browseOnly: false,
-    showSingleResult: true,
+  static propTypes = {
+    resources: PropTypes.object.isRequired,
+    mutator: PropTypes.object.isRequired,
+    showSingleResult: PropTypes.bool,
+    browseOnly: PropTypes.bool,
+    disableRecordCreation: PropTypes.bool,
+    onSelectRow: PropTypes.func,
+    isLoading: PropTypes.func,
+    getData: PropTypes.func,
+    createInstance: PropTypes.func,
   };
 
   static manifest = Object.freeze({
-    numFiltersLoaded: { initialValue: 1 }, // will be incremented as each filter loads
-    query: {
-      initialValue: {
-        query: '',
-        filters: '',
-        sort: 'title',
-      },
-    },
-    resultCount: { initialValue: INITIAL_RESULT_COUNT },
     records: {
       type: 'okapi',
       records: 'instances',
@@ -53,7 +41,7 @@ class InstancesRoute extends React.Component {
               logger
             ] = args;
             const queryIndex = resourceData.query.qindex ? resourceData.query.qindex : 'all';
-            const searchableIndex = searchableIndexes.find(idx => idx.value === queryIndex);
+            const searchableIndex = instanceIndexes.find(idx => idx.value === queryIndex);
             let queryTemplate = '';
 
             if (queryIndex === 'isbn' || queryIndex === 'issn') {
@@ -83,182 +71,7 @@ class InstancesRoute extends React.Component {
         staticFallback: { params: {} },
       },
     },
-    identifierTypes: {
-      type: 'okapi',
-      records: 'identifierTypes',
-      path: 'identifier-types?limit=1000&query=cql.allRecords=1 sortby name',
-    },
-    contributorTypes: {
-      type: 'okapi',
-      records: 'contributorTypes',
-      path: 'contributor-types?limit=400&query=cql.allRecords=1 sortby name',
-    },
-    contributorNameTypes: {
-      type: 'okapi',
-      records: 'contributorNameTypes',
-      path: 'contributor-name-types?limit=1000&query=cql.allRecords=1 sortby ordering',
-    },
-    instanceFormats: {
-      type: 'okapi',
-      records: 'instanceFormats',
-      path: 'instance-formats?limit=1000&query=cql.allRecords=1 sortby name',
-    },
-    instanceTypes: {
-      type: 'okapi',
-      records: 'instanceTypes',
-      path: 'instance-types?limit=1000&query=cql.allRecords=1 sortby name',
-    },
-    classificationTypes: {
-      type: 'okapi',
-      records: 'classificationTypes',
-      path: 'classification-types?limit=1000&query=cql.allRecords=1 sortby name',
-    },
-    alternativeTitleTypes: {
-      type: 'okapi',
-      records: 'alternativeTitleTypes',
-      path: 'alternative-title-types?limit=1000&query=cql.allRecords=1 sortby name',
-    },
-    locations: {
-      type: 'okapi',
-      records: 'locations',
-      path: 'locations?limit=1000&query=cql.allRecords=1 sortby name',
-    },
-    instanceRelationshipTypes: {
-      type: 'okapi',
-      records: 'instanceRelationshipTypes',
-      path: 'instance-relationship-types?limit=1000&query=cql.allRecords=1 sortby name',
-    },
-    instanceStatuses: {
-      type: 'okapi',
-      records: 'instanceStatuses',
-      path: 'instance-statuses?limit=1000&query=cql.allRecords=1 sortby name',
-    },
-    modesOfIssuance: {
-      type: 'okapi',
-      records: 'issuanceModes',
-      path: 'modes-of-issuance?limit=1000&query=cql.allRecords=1 sortby name',
-    },
-    instanceNoteTypes: {
-      type: 'okapi',
-      path: 'instance-note-types',
-      params: {
-        query: 'cql.allRecords=1 sortby name',
-        limit: '1000',
-      },
-      records: 'instanceNoteTypes',
-    },
-    electronicAccessRelationships: {
-      type: 'okapi',
-      records: 'electronicAccessRelationships',
-      path: 'electronic-access-relationships?limit=1000&query=cql.allRecords=1 sortby name',
-    },
-    statisticalCodeTypes: {
-      type: 'okapi',
-      records: 'statisticalCodeTypes',
-      path: 'statistical-code-types?limit=1000&query=cql.allRecords=1 sortby name',
-    },
-    statisticalCodes: {
-      type: 'okapi',
-      records: 'statisticalCodes',
-      path: 'statistical-codes?limit=1000&query=cql.allRecords=1 sortby name',
-    },
-    illPolicies: {
-      type: 'okapi',
-      path: 'ill-policies?limit=1000&query=cql.allRecords=1 sortby name',
-      records: 'illPolicies',
-    },
-    holdingsTypes: {
-      type: 'okapi',
-      path: 'holdings-types?limit=1000&query=cql.allRecords=1 sortby name',
-      records: 'holdingsTypes',
-    },
-    callNumberTypes: {
-      type: 'okapi',
-      path: 'call-number-types?limit=1000&query=cql.allRecords=1 sortby name',
-      records: 'callNumberTypes',
-    },
-    holdingsNoteTypes: {
-      type: 'okapi',
-      path: 'holdings-note-types?limit=1000&query=cql.allRecords=1 sortby name',
-      records: 'holdingsNoteTypes',
-    },
-    itemNoteTypes: {
-      type: 'okapi',
-      path: 'item-note-types',
-      params: {
-        query: 'cql.allRecords=1 sortby name',
-        limit: '1000',
-      },
-      records: 'itemNoteTypes',
-    },
-    itemDamagedStatuses: {
-      type: 'okapi',
-      path: 'item-damaged-statuses?limit=1000&query=cql.allRecords=1 sortby name',
-      records: 'itemDamageStatuses',
-    },
-    natureOfContentTerms: {
-      type: 'okapi',
-      path: 'nature-of-content-terms?limit=1000&query=cql.allRecords=1 sortby name',
-      records: 'natureOfContentTerms',
-    },
   });
-
-  createInstance = (instance) => {
-    // Massage record to add preceeding and succeeding title fields in the
-    // right place.
-    const instanceCopy = this.combineRelTitles(instance);
-
-    // POST item record
-    this.props.mutator.records.POST(instanceCopy).then(() => {
-      this.closeNewInstance();
-    });
-  };
-
-  combineRelTitles = (instance) => {
-    // preceding/succeeding titles are stored in parentInstances and childInstances
-    // in the instance record. Each title needs to provide an instance relationship
-    // type ID corresponding to 'preceeding-succeeding' in addition to the actual
-    // parent/child instance ID.
-    let instanceCopy = instance;
-    const titleRelationshipTypeId = psTitleRelationshipId(this.props.resources.instanceRelationshipTypes.records);
-    const precedingTitles = map(instanceCopy.precedingTitles, p => { p.instanceRelationshipTypeId = titleRelationshipTypeId; return p; });
-    set(instanceCopy, 'parentInstances', concat(instanceCopy.parentInstances, precedingTitles));
-    const succeedingTitles = map(instanceCopy.succeedingTitles, p => { p.instanceRelationshipTypeId = titleRelationshipTypeId; return p; });
-    set(instanceCopy, 'childInstances', succeedingTitles);
-    instanceCopy = omit(instanceCopy, ['precedingTitles', 'succeedingTitles']);
-    return instanceCopy;
-  }
-
-  isLoading() {
-    const { manifest } = InstancesRoute;
-    const { resources } = this.props;
-
-    for (const key in manifest) {
-      if (key !== 'records' && manifest[key].type === 'okapi' &&
-        !(resources[key] && resources[key].hasLoaded)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  getData() {
-    const { manifest } = InstancesRoute;
-    const { resources } = this.props;
-    const data = {};
-
-    for (const key in manifest) {
-      if (key !== 'records' && manifest[key].type === 'okapi') {
-        data[key] = get(resources, `${key}.records`, []);
-      }
-    }
-
-    data.locationsById = keyBy(data.locations, 'id');
-    data.query = resources.query;
-
-    return data;
-  }
 
   render() {
     const {
@@ -268,9 +81,12 @@ class InstancesRoute extends React.Component {
       disableRecordCreation,
       resources,
       mutator,
+      isLoading,
+      getData,
+      createInstance,
     } = this.props;
 
-    if (this.isLoading()) {
+    if (isLoading()) {
       return null;
     }
 
@@ -278,10 +94,10 @@ class InstancesRoute extends React.Component {
       <InstancesView
         parentResources={resources}
         parentMutator={mutator}
-        data={this.getData()}
+        data={getData()}
         browseOnly={browseOnly}
         showSingleResult={showSingleResult}
-        onCreate={this.createInstance}
+        onCreate={createInstance}
         onSelectRow={onSelectRow}
         disableRecordCreation={disableRecordCreation}
       />
@@ -289,66 +105,4 @@ class InstancesRoute extends React.Component {
   }
 }
 
-InstancesRoute.propTypes = {
-  resources: PropTypes.shape({
-    records: PropTypes.shape({
-      hasLoaded: PropTypes.bool.isRequired,
-      other: PropTypes.shape({
-        totalRecords: PropTypes.number,
-        total_records: PropTypes.number,
-      }),
-      successfulMutations: PropTypes.arrayOf(
-        PropTypes.shape({
-          record: PropTypes.shape({
-            id: PropTypes.string.isRequired,
-          }).isRequired,
-        }),
-      ),
-    }),
-    numFiltersLoaded: PropTypes.number,
-    resultCount: PropTypes.number,
-    instanceTypes: PropTypes.shape({
-      records: PropTypes.arrayOf(PropTypes.object),
-    }),
-    instanceRelationshipTypes: PropTypes.shape({
-      records: PropTypes.arrayOf(PropTypes.object),
-    }),
-    itemNoteTypes: PropTypes.shape({
-      records: PropTypes.arrayOf(PropTypes.object),
-    }),
-    locations: PropTypes.shape({
-      records: PropTypes.arrayOf(PropTypes.object),
-    }),
-    query: PropTypes.shape({
-      qindex: PropTypes.string,
-      term: PropTypes.string,
-    }),
-  }).isRequired,
-  match: PropTypes.shape({
-    path: PropTypes.string.isRequired,
-    params: PropTypes.object.isRequired,
-  }).isRequired,
-  mutator: PropTypes.shape({
-    addInstanceMode: PropTypes.shape({
-      replace: PropTypes.func,
-    }),
-    numFiltersLoaded: PropTypes.shape({
-      replace: PropTypes.func.isRequired,
-    }),
-    records: PropTypes.shape({
-      POST: PropTypes.func,
-    }),
-    resultCount: PropTypes.shape({
-      replace: PropTypes.func,
-    }),
-    query: PropTypes.shape({
-      update: PropTypes.func,
-    }),
-  }).isRequired,
-  showSingleResult: PropTypes.bool, // eslint-disable-line react/no-unused-prop-types
-  browseOnly: PropTypes.bool,
-  disableRecordCreation: PropTypes.bool,
-  onSelectRow: PropTypes.func,
-};
-
-export default stripesConnect(InstancesRoute);
+export default stripesConnect(withData(InstancesRoute));

--- a/src/routes/ItemsRoute.js
+++ b/src/routes/ItemsRoute.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { stripesConnect } from '@folio/stripes/core';
+
+import withData from './withData';
+import { ItemsView } from '../views';
+
+class ItemsRoute extends React.Component {
+  static manifest = Object.freeze({
+    records: {
+      type: 'okapi',
+      records: 'instances',
+      recordsRequired: '%{resultCount}',
+      perRequest: 30,
+      path: 'inventory/instances',
+      GET: {
+        params: {
+          query: () => {
+            // TODO: add query implementation for items
+            return null;
+          }
+        },
+        staticFallback: { params: {} },
+      },
+    },
+  });
+
+  render() {
+    const {
+      showSingleResult,
+      browseOnly,
+      onSelectRow,
+      disableRecordCreation,
+      resources,
+      mutator,
+      isLoading,
+      getData,
+      createInstance,
+    } = this.props;
+
+    if (isLoading()) {
+      return null;
+    }
+
+    return (
+      <ItemsView
+        parentResources={resources}
+        parentMutator={mutator}
+        data={getData()}
+        browseOnly={browseOnly}
+        showSingleResult={showSingleResult}
+        onCreate={createInstance}
+        onSelectRow={onSelectRow}
+        disableRecordCreation={disableRecordCreation}
+      />
+    );
+  }
+}
+
+ItemsRoute.propTypes = {
+  resources: PropTypes.object.isRequired,
+  mutator: PropTypes.object.isRequired,
+  showSingleResult: PropTypes.bool,
+  browseOnly: PropTypes.bool,
+  disableRecordCreation: PropTypes.bool,
+  onSelectRow: PropTypes.func,
+  isLoading: PropTypes.func,
+  getData: PropTypes.func,
+  createInstance: PropTypes.func,
+};
+
+export default stripesConnect(withData(ItemsRoute));

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,0 +1,3 @@
+export { default as InstancesRoute } from './InstancesRoute';
+export { default as HoldingsRoute } from './HoldingsRoute';
+export { default as ItemsRoute } from './ItemsRoute';

--- a/src/routes/withData.js
+++ b/src/routes/withData.js
@@ -1,0 +1,220 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  get,
+  keyBy,
+  map,
+  concat,
+  set,
+  psTitleRelationshipId,
+  omit,
+} from 'lodash';
+
+const INITIAL_RESULT_COUNT = 30;
+
+// HOC used to reuse instance manifest
+const withData = WrappedComponent => class WithDataComponent extends React.Component {
+  static manifest = Object.freeze(
+    Object.assign({}, WrappedComponent.manifest, {
+      numFiltersLoaded: { initialValue: 1 }, // will be incremented as each filter loads
+      query: {
+        initialValue: {
+          query: '',
+          filters: '',
+          sort: 'title',
+        },
+      },
+      resultCount: { initialValue: INITIAL_RESULT_COUNT },
+      identifierTypes: {
+        type: 'okapi',
+        records: 'identifierTypes',
+        path: 'identifier-types?limit=1000&query=cql.allRecords=1 sortby name',
+      },
+      contributorTypes: {
+        type: 'okapi',
+        records: 'contributorTypes',
+        path: 'contributor-types?limit=400&query=cql.allRecords=1 sortby name',
+      },
+      contributorNameTypes: {
+        type: 'okapi',
+        records: 'contributorNameTypes',
+        path: 'contributor-name-types?limit=1000&query=cql.allRecords=1 sortby ordering',
+      },
+      instanceFormats: {
+        type: 'okapi',
+        records: 'instanceFormats',
+        path: 'instance-formats?limit=1000&query=cql.allRecords=1 sortby name',
+      },
+      instanceTypes: {
+        type: 'okapi',
+        records: 'instanceTypes',
+        path: 'instance-types?limit=1000&query=cql.allRecords=1 sortby name',
+      },
+      classificationTypes: {
+        type: 'okapi',
+        records: 'classificationTypes',
+        path: 'classification-types?limit=1000&query=cql.allRecords=1 sortby name',
+      },
+      alternativeTitleTypes: {
+        type: 'okapi',
+        records: 'alternativeTitleTypes',
+        path: 'alternative-title-types?limit=1000&query=cql.allRecords=1 sortby name',
+      },
+      locations: {
+        type: 'okapi',
+        records: 'locations',
+        path: 'locations?limit=1000&query=cql.allRecords=1 sortby name',
+      },
+      instanceRelationshipTypes: {
+        type: 'okapi',
+        records: 'instanceRelationshipTypes',
+        path: 'instance-relationship-types?limit=1000&query=cql.allRecords=1 sortby name',
+      },
+      instanceStatuses: {
+        type: 'okapi',
+        records: 'instanceStatuses',
+        path: 'instance-statuses?limit=1000&query=cql.allRecords=1 sortby name',
+      },
+      modesOfIssuance: {
+        type: 'okapi',
+        records: 'issuanceModes',
+        path: 'modes-of-issuance?limit=1000&query=cql.allRecords=1 sortby name',
+      },
+      instanceNoteTypes: {
+        type: 'okapi',
+        path: 'instance-note-types',
+        params: {
+          query: 'cql.allRecords=1 sortby name',
+          limit: '1000',
+        },
+        records: 'instanceNoteTypes',
+      },
+      electronicAccessRelationships: {
+        type: 'okapi',
+        records: 'electronicAccessRelationships',
+        path: 'electronic-access-relationships?limit=1000&query=cql.allRecords=1 sortby name',
+      },
+      statisticalCodeTypes: {
+        type: 'okapi',
+        records: 'statisticalCodeTypes',
+        path: 'statistical-code-types?limit=1000&query=cql.allRecords=1 sortby name',
+      },
+      statisticalCodes: {
+        type: 'okapi',
+        records: 'statisticalCodes',
+        path: 'statistical-codes?limit=1000&query=cql.allRecords=1 sortby name',
+      },
+      illPolicies: {
+        type: 'okapi',
+        path: 'ill-policies?limit=1000&query=cql.allRecords=1 sortby name',
+        records: 'illPolicies',
+      },
+      holdingsTypes: {
+        type: 'okapi',
+        path: 'holdings-types?limit=1000&query=cql.allRecords=1 sortby name',
+        records: 'holdingsTypes',
+      },
+      callNumberTypes: {
+        type: 'okapi',
+        path: 'call-number-types?limit=1000&query=cql.allRecords=1 sortby name',
+        records: 'callNumberTypes',
+      },
+      holdingsNoteTypes: {
+        type: 'okapi',
+        path: 'holdings-note-types?limit=1000&query=cql.allRecords=1 sortby name',
+        records: 'holdingsNoteTypes',
+      },
+      itemNoteTypes: {
+        type: 'okapi',
+        path: 'item-note-types',
+        params: {
+          query: 'cql.allRecords=1 sortby name',
+          limit: '1000',
+        },
+        records: 'itemNoteTypes',
+      },
+      itemDamagedStatuses: {
+        type: 'okapi',
+        path: 'item-damaged-statuses?limit=1000&query=cql.allRecords=1 sortby name',
+        records: 'itemDamageStatuses',
+      },
+      natureOfContentTerms: {
+        type: 'okapi',
+        path: 'nature-of-content-terms?limit=1000&query=cql.allRecords=1 sortby name',
+        records: 'natureOfContentTerms',
+      },
+    }),
+  );
+
+  static propTypes = {
+    resources: PropTypes.object.isRequired,
+    mutator: PropTypes.object.isRequired,
+  };
+
+  createInstance = (instance) => {
+    // Massage record to add preceeding and succeeding title fields in the
+    // right place.
+    const instanceCopy = this.combineRelTitles(instance);
+
+    // POST item record
+    return this.props.mutator.records.POST(instanceCopy);
+  };
+
+  combineRelTitles = (instance) => {
+    // preceding/succeeding titles are stored in parentInstances and childInstances
+    // in the instance record. Each title needs to provide an instance relationship
+    // type ID corresponding to 'preceeding-succeeding' in addition to the actual
+    // parent/child instance ID.
+    let instanceCopy = instance;
+    const titleRelationshipTypeId = psTitleRelationshipId(this.props.resources.instanceRelationshipTypes.records);
+    const precedingTitles = map(instanceCopy.precedingTitles, p => { p.instanceRelationshipTypeId = titleRelationshipTypeId; return p; });
+    set(instanceCopy, 'parentInstances', concat(instanceCopy.parentInstances, precedingTitles));
+    const succeedingTitles = map(instanceCopy.succeedingTitles, p => { p.instanceRelationshipTypeId = titleRelationshipTypeId; return p; });
+    set(instanceCopy, 'childInstances', succeedingTitles);
+    instanceCopy = omit(instanceCopy, ['precedingTitles', 'succeedingTitles']);
+    return instanceCopy;
+  }
+
+  isLoading = () => {
+    const { manifest } = WithDataComponent;
+    const { resources } = this.props;
+
+    for (const key in manifest) {
+      if (key !== 'records' && manifest[key].type === 'okapi' &&
+        !(resources[key] && resources[key].hasLoaded)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  getData = () => {
+    const { manifest } = WithDataComponent;
+    const { resources } = this.props;
+    const data = {};
+
+    for (const key in manifest) {
+      if (key !== 'records' && manifest[key].type === 'okapi') {
+        data[key] = get(resources, `${key}.records`, []);
+      }
+    }
+
+    data.locationsById = keyBy(data.locations, 'id');
+    data.query = resources.query;
+
+    return data;
+  }
+
+  render() {
+    return (<WrappedComponent
+      getData={this.getData}
+      isLoading={this.isLoading}
+      createInstance={this.createInstance}
+      {...this.props}
+    />);
+  }
+};
+
+
+export default withData;

--- a/src/routes/withData.js
+++ b/src/routes/withData.js
@@ -6,9 +6,10 @@ import {
   map,
   concat,
   set,
-  psTitleRelationshipId,
   omit,
 } from 'lodash';
+
+import { psTitleRelationshipId } from '../utils';
 
 const INITIAL_RESULT_COUNT = 30;
 
@@ -172,6 +173,7 @@ const withData = WrappedComponent => class WithDataComponent extends React.Compo
     const succeedingTitles = map(instanceCopy.succeedingTitles, p => { p.instanceRelationshipTypeId = titleRelationshipTypeId; return p; });
     set(instanceCopy, 'childInstances', succeedingTitles);
     instanceCopy = omit(instanceCopy, ['precedingTitles', 'succeedingTitles']);
+
     return instanceCopy;
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -59,4 +59,3 @@ export function psTitleRelationshipId(idTypes) {
   const relationshipDetail = find(idTypes, { 'name': 'preceding-succeeding' });
   return relationshipDetail ? relationshipDetail.id : '';
 }
-

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,7 +6,6 @@ import {
 } from 'lodash';
 import {
   itemStatuses,
-  segments,
 } from './constants';
 
 export function craftLayerUrl(mode, location) { // eslint-disable-line import/prefer-default-export
@@ -61,8 +60,3 @@ export function psTitleRelationshipId(idTypes) {
   return relationshipDetail ? relationshipDetail.id : '';
 }
 
-export function getSegment(params) {
-  const { segment } = params;
-
-  return segments[segment] || segments.instances;
-}

--- a/src/views/HoldingsView.js
+++ b/src/views/HoldingsView.js
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
 import {
-  InstanceFilters,
+  HoldingFilters,
   InstancesList,
 } from '../components';
 import { getCurrentFilters } from '../utils';
-import { instanceIndexes } from '../constants';
+import { holdingIndexes } from '../constants';
 
-class InstancesView extends React.Component {
+class HoldingsView extends React.Component {
   static propTypes = {
     data: PropTypes.object,
   };
@@ -17,8 +17,6 @@ class InstancesView extends React.Component {
   renderFilters = (onChange) => {
     const {
       data: {
-        locations,
-        instanceTypes,
         query,
       },
     } = this.props;
@@ -26,11 +24,10 @@ class InstancesView extends React.Component {
     const activeFilters = getCurrentFilters(get(query, 'filters', ''));
 
     return (
-      <InstanceFilters
+      <HoldingFilters
         activeFilters={activeFilters}
         data={{
-          locations,
-          resourceTypes: instanceTypes,
+          // TODO provide data to holding filters
         }}
         onChange={onChange}
         onClear={(name) => onChange({ name, values: [] })}
@@ -44,12 +41,12 @@ class InstancesView extends React.Component {
         <InstancesList
           {...this.props}
           renderFilters={this.renderFilters}
-          segment="instances"
-          searchableIndexes={instanceIndexes}
+          segment="holdings"
+          searchableIndexes={holdingIndexes}
         />
       </div>
     );
   }
 }
 
-export default InstancesView;
+export default HoldingsView;

--- a/src/views/ItemsView.js
+++ b/src/views/ItemsView.js
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
 import {
-  InstanceFilters,
+  ItemFilters,
   InstancesList,
 } from '../components';
 import { getCurrentFilters } from '../utils';
-import { instanceIndexes } from '../constants';
+import { itemIndexes } from '../constants';
 
-class InstancesView extends React.Component {
+class ItemsView extends React.Component {
   static propTypes = {
     data: PropTypes.object,
   };
@@ -17,8 +17,6 @@ class InstancesView extends React.Component {
   renderFilters = (onChange) => {
     const {
       data: {
-        locations,
-        instanceTypes,
         query,
       },
     } = this.props;
@@ -26,11 +24,10 @@ class InstancesView extends React.Component {
     const activeFilters = getCurrentFilters(get(query, 'filters', ''));
 
     return (
-      <InstanceFilters
+      <ItemFilters
         activeFilters={activeFilters}
         data={{
-          locations,
-          resourceTypes: instanceTypes,
+          // TODO provide data to item filters
         }}
         onChange={onChange}
         onClear={(name) => onChange({ name, values: [] })}
@@ -44,12 +41,12 @@ class InstancesView extends React.Component {
         <InstancesList
           {...this.props}
           renderFilters={this.renderFilters}
-          segment="instances"
-          searchableIndexes={instanceIndexes}
+          segment="items"
+          searchableIndexes={itemIndexes}
         />
       </div>
     );
   }
 }
 
-export default InstancesView;
+export default ItemsView;

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -1,1 +1,3 @@
-export { default } from './InstancesView';
+export { default as InstancesView } from './InstancesView';
+export { default as HoldingsView } from './HoldingsView';
+export { default as ItemsView } from './ItemsView';

--- a/test/bigtest/interactors/holdings-edit-page.js
+++ b/test/bigtest/interactors/holdings-edit-page.js
@@ -24,4 +24,7 @@ import {
   }
 }
 
-export default new HoldingsEditPage('[data-test-holdings-page-type="edit"]');
+export default new HoldingsEditPage({
+  scope: '[data-test-holdings-page-type="edit"]',
+  timeout: 3000,
+});

--- a/test/bigtest/interactors/holdings-edit-page.js
+++ b/test/bigtest/interactors/holdings-edit-page.js
@@ -26,5 +26,5 @@ import {
 
 export default new HoldingsEditPage({
   scope: '[data-test-holdings-page-type="edit"]',
-  timeout: 3000,
+  timeout: 6000,
 });

--- a/test/bigtest/interactors/instance-view-page.js
+++ b/test/bigtest/interactors/instance-view-page.js
@@ -59,4 +59,7 @@ import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tes
   hasSucceedingTitles = isPresent('[data-test-succeeding-titles]');
 }
 
-export default new InstanceViewPage('[data-test-instance-details]');
+export default new InstanceViewPage({
+  scope: '[data-test-instance-details]',
+  timeout: 3000,
+});

--- a/test/bigtest/interactors/inventory.js
+++ b/test/bigtest/interactors/inventory.js
@@ -15,7 +15,7 @@ export default @interactor class InventoryInteractor {
   instances = collection('#list-inventory [role=row] a');
 
   instance = scoped('[data-test-instance-details]');
-  chooseSearchOption= selectable('#input-inventory-search-qindex');
+  chooseSearchOption = selectable('#input-inventory-search-qindex');
 
   fillSearchField = fillable('#input-inventory-search');
   clickSearch = clickable('[data-test-search-and-sort-submit]');

--- a/test/bigtest/interactors/routes/holdings-route.js
+++ b/test/bigtest/interactors/routes/holdings-route.js
@@ -1,0 +1,7 @@
+import {
+  interactor,
+} from '@bigtest/interactor';
+
+export default @interactor class HoldingsRouteInteractor {
+  static defaultScope = '[data-test-inventory-instances]';
+}

--- a/test/bigtest/interactors/routes/items-route.js
+++ b/test/bigtest/interactors/routes/items-route.js
@@ -1,0 +1,7 @@
+import {
+  interactor,
+} from '@bigtest/interactor';
+
+export default @interactor class ItemsRouteInteractor {
+  static defaultScope = '[data-test-inventory-instances]';
+}

--- a/test/bigtest/network/factories/instance.js
+++ b/test/bigtest/network/factories/instance.js
@@ -47,13 +47,13 @@ export default Factory.extend({
   },
 
   withPrecedingTitle: trait({
-    afterCreate(instance, server) {
+    afterCreate(instance) {
       instance.parentInstances = [{ id: '1008409091', superInstanceId: '9999999', instanceRelationshipTypeId: 'cde80cc2-0c8b-4672-82d4-721e51dcb990' }];
     }
   }),
 
   withSucceedingTitle: trait({
-    afterCreate(instance, server) {
+    afterCreate(instance) {
       instance.childInstances = [{ id: '1008409092', subInstanceId: '8888888', instanceRelationshipTypeId: 'cde80cc2-0c8b-4672-82d4-721e51dcb990' }];
     }
   }),

--- a/test/bigtest/tests/instances-index-test.js
+++ b/test/bigtest/tests/instances-index-test.js
@@ -8,7 +8,10 @@ import InventoryInteractor from '../interactors/inventory';
 describe('Instances', () => {
   setupApplication();
 
-  const inventory = new InventoryInteractor();
+  const inventory = new InventoryInteractor({
+    timeout: 3000,
+    scope: '[data-test-inventory-instances]',
+  });
 
   beforeEach(async function () {
     this.server.createList('instance', 25, 'withHoldingAndItem');

--- a/test/bigtest/tests/mirage/routes/holdings-route-test.js
+++ b/test/bigtest/tests/mirage/routes/holdings-route-test.js
@@ -1,0 +1,20 @@
+import { beforeEach, describe, it } from '@bigtest/mocha';
+
+import { expect } from 'chai';
+
+import setupApplication from '../../../helpers/setup-application';
+import HoldingsRouteInteractor from '../../../interactors/routes/holdings-route';
+
+describe('HoldingsRoute', () => {
+  setupApplication();
+
+  const holdingsRoute = new HoldingsRouteInteractor();
+
+  beforeEach(async function () {
+    this.visit('/inventory/holdings');
+  });
+
+  it('opens holdings route', () => {
+    expect(holdingsRoute.isPresent).to.equal(true);
+  });
+});

--- a/test/bigtest/tests/mirage/routes/items-route-test.js
+++ b/test/bigtest/tests/mirage/routes/items-route-test.js
@@ -1,0 +1,20 @@
+import { beforeEach, describe, it } from '@bigtest/mocha';
+
+import { expect } from 'chai';
+
+import setupApplication from '../../../helpers/setup-application';
+import ItemsRouteInteractor from '../../../interactors/routes/items-route';
+
+describe('ItemsRoute', () => {
+  setupApplication();
+
+  const itemsRoute = new ItemsRouteInteractor();
+
+  beforeEach(async function () {
+    this.visit('/inventory/items');
+  });
+
+  it('opens items route', () => {
+    expect(itemsRoute.isPresent).to.equal(true);
+  });
+});


### PR DESCRIPTION
This PR separates each search segment introduces in https://github.com/folio-org/ui-inventory/pull/753 into a separate route. I originally thought it wouldn't be possible to do so with SAS but it is by modifying `packageInfo` passed into SAS:

https://github.com/folio-org/ui-inventory/pull/763/files#diff-fd3611f373f0b1a809dc00c54a815ecbR145-R151

With this PR in place it should be a bit easier to refactor ui-inventory into `SearchAndSortQuery` in the future.