### PR TITLE
Fix filter selection. Part of UIIN-758

### DIFF
--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -63,7 +63,7 @@ class InstancesView extends React.Component {
 
   onFilterChangeHandler = ({ name, values }) => {
     const { data: { query } } = this.props;
-    const curFilters = getCurrentFilters(get(query.filters));
+    const curFilters = getCurrentFilters(get(query, 'filters', ''));
     const mergedFilters = values.length
       ? { ...curFilters, [name]: values }
       : omit(curFilters, name);


### PR DESCRIPTION
The PR fixes a bug where only one filter could be active (when second filter was selected the previous one would clear out). 

Thanks to @Baroquem for spotting this issue! 