### PR TITLE
UIIN-643 handle empty note-type

### DIFF
--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -559,14 +559,14 @@ class ViewInstance extends React.Component {
 
     const layoutNotes = (noteTypes, instanceNotes) => {
       return instanceNotes.map(({ noteId, notes }) => {
-        const { name } = noteTypes.find(note => note.id === noteId);
+        const noteType = noteTypes.find(note => note.id === noteId);
         return (
           <MultiColumnList
             contentData={notes}
             visibleColumns={['Staff only', 'Note']}
             columnMapping={{
               'Staff only': <FormattedMessage id="ui-inventory.staffOnly" />,
-              'Note': <FormattedMessage id={name} />,
+              'Note': noteType ? noteType.name : <FormattedMessage id="ui-inventory.unknownNoteType" />,
             }}
             columnWidths={{
               'Staff only': '25%',

--- a/test/ui-testing/new-title.js
+++ b/test/ui-testing/new-title.js
@@ -26,7 +26,7 @@ module.exports.test = function uiTest(uiTestCtx) {
         logout(nightmare, config, done);
       });
 
-      it('should navigate to users', (done) => {
+      it('should navigate to inventory', (done) => {
         clickApp(nightmare, done, 'inventory');
       });
 

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -405,5 +405,6 @@
   "filters.holdings": "Holdings",
   "filters.items": "Item",
   "yes": "Yes",
-  "no": "No"
+  "no": "No",
+  "unknownNoteType": "Unknown note type"
 }


### PR DESCRIPTION
`noteTypeId` is not a required field, hence the display of notes must handle
those that do not specify a type. The previous incarnation would cause
an NPE when the type was undefined.

Refs [UIIN-643](https://issues.folio.org/browse/UIIN-643) / #779