### PR TITLE
STCOR-377 use consistent selector

### DIFF
--- a/test/ui-testing/search.js
+++ b/test/ui-testing/search.js
@@ -45,8 +45,8 @@ module.exports.test = function test(uiTestCtx) {
 
       it('should create inventory record', (done) => {
         nightmare
-          .wait('#clickable-inventory-module')
-          .click('#clickable-inventory-module')
+          .wait('#app-list-item-clickable-inventory-module')
+          .click('#app-list-item-clickable-inventory-module')
           .wait('#clickable-newinventory')
           .click('#clickable-newinventory')
           .wait('#input_instance_title')
@@ -69,8 +69,8 @@ module.exports.test = function test(uiTestCtx) {
 
       it('should create inventory record', (done) => {
         nightmare
-          .wait('#clickable-inventory-module')
-          .click('#clickable-inventory-module')
+          .wait('#app-list-item-clickable-inventory-module')
+          .click('#app-list-item-clickable-inventory-module')
           .wait('#clickable-newinventory')
           .click('#clickable-newinventory')
           .wait('#input_instance_title')
@@ -93,8 +93,8 @@ module.exports.test = function test(uiTestCtx) {
 
       it(`should search "All" for "${fragment}" and find multiple records`, (done) => {
         nightmare
-          .wait('#clickable-inventory-module')
-          .click('#clickable-inventory-module')
+          .wait('#app-list-item-clickable-inventory-module')
+          .click('#app-list-item-clickable-inventory-module')
           .wait('#input-inventory-search')
           .insert('#input-inventory-search', fragment)
           .wait('#clickable-reset-all')


### PR DESCRIPTION
The nav-bar based selectors are going away and will be replaced by what
had been the nav-menu-item-selectors.

Refs [STCOR-377](https://issues.folio.org/browse/STCOR-377)