### PR TITLE
Allow for searching title with words out of order. Part of UIIN-602

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Display empty elements with the dashes. Refs UIIN-826.
 * Filter item records by material type. Part of UIIN-777.
 * Filter item records by item status. Part of UIIN-771.
+* Allow for searching title with words out of order. Part of UIIN-602.
 
 ## [1.12.1](https://github.com/folio-org/ui-inventory/tree/v1.12.1) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.12.0...v1.12.1)

--- a/src/constants.js
+++ b/src/constants.js
@@ -57,7 +57,7 @@ export const instanceIndexes = [
   { label: 'ui-inventory.search.all', value: 'all', queryTemplate: 'title="%{query.query}" or contributors =/@name "%{query.query}" or identifiers =/@value "%{query.query}"' },
   { label: 'ui-inventory.barcode', value: 'item.barcode', queryTemplate: 'item.barcode=="%{query.query}"' },
   { label: 'ui-inventory.instanceId', value: 'id', queryTemplate: 'id="%{query.query}"' },
-  { label: 'ui-inventory.title', value: 'title', queryTemplate: 'title="%{query.query}"' },
+  { label: 'ui-inventory.title', value: 'title', queryTemplate: 'title all "%{query.query}"' },
   { label: 'ui-inventory.identifier', value: 'identifier', queryTemplate: 'identifiers =/@value "%{query.query}"' },
   { label: 'ui-inventory.isbn', prefix: '- ', value: 'isbn', queryTemplate: 'identifiers =/@value/@identifierTypeId="<%= identifierTypeId %>" "%{query.query}"' },
   { label: 'ui-inventory.issn', prefix: '- ', value: 'issn', queryTemplate: 'identifiers =/@value/@identifierTypeId="<%= identifierTypeId %>" "%{query.query}"' },

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -110,7 +110,7 @@ export default function configure() {
       cqlParser.parse(request.queryParams.query);
       const { field, term } = cqlParser.tree;
 
-      if (!term) return [];
+      if (!term) return instances.all();
 
       if (field === 'item.barcode') {
         const item = items.where({ barcode: term }).models[0];


### PR DESCRIPTION
This PR changes the `=` CQL relation to `all` relation in order to support searching for "Title" with words out of order.

https://issues.folio.org/browse/UIIN-602