### PR TITLE
UIIN-679 update integration tests for segments

### DIFF
--- a/src/components/FilterNavigation/FilterNavigation.js
+++ b/src/components/FilterNavigation/FilterNavigation.js
@@ -19,6 +19,7 @@ const FilterNavigation = ({ segment }) => (
           key={`${name}`}
           to={`/inventory/${name}`}
           buttonStyle={`${segment === name ? 'primary' : 'default'}`}
+          id={`segment-navigation-${name}`}
         >
           <FormattedMessage id={`ui-inventory.filters.${name}`} />
         </Button>


### PR DESCRIPTION
Location filters have moved from the default (instance) search segment
to the holdings segment. Likewise, item-status filters have moved to the
items segment.

This refactoring handles those changes and also pulls checkbox-based and
multiselect-based filter tests into their own reusable functions.

Refs [UIIN-679](https://issues.folio.org/browse/UIIN-679)