### PR TITLE
Default initialValues to empty object. Part of UIIN-875

### DIFF
--- a/src/edit/InstanceForm.js
+++ b/src/edit/InstanceForm.js
@@ -249,7 +249,7 @@ class InstanceForm extends React.Component {
       pristine,
       submitting,
       onCancel,
-      initialValues = {},
+      initialValues,
       referenceTables,
       copy,
     } = this.props;
@@ -787,6 +787,7 @@ InstanceForm.propTypes = {
 };
 InstanceForm.defaultProps = {
   instanceSource: 'FOLIO',
+  initialValues: {},
 };
 
 export default stripesFinalForm({

--- a/src/edit/InstanceForm.js
+++ b/src/edit/InstanceForm.js
@@ -249,7 +249,7 @@ class InstanceForm extends React.Component {
       pristine,
       submitting,
       onCancel,
-      initialValues,
+      initialValues = {},
       referenceTables,
       copy,
     } = this.props;

--- a/src/edit/holdings/HoldingsForm.js
+++ b/src/edit/holdings/HoldingsForm.js
@@ -66,6 +66,10 @@ class HoldingsForm extends React.Component {
     }),
   };
 
+  static defaultProps = {
+    initialValues: {},
+  };
+
   constructor(props) {
     super(props);
 

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -952,6 +952,10 @@ ItemForm.propTypes = {
   }).isRequired,
 };
 
+ItemForm.defaultProps = {
+  initialValues: {},
+};
+
 export default stripesFinalForm({
   validate,
   mutators,


### PR DESCRIPTION
The exception we currently see in folio-testing is related to the fact that the `initialValues` are not present during the first render. This PR sets `initialValues` to an empty object by default.

Based on the findings from @zburke it looks like platform-core#snapshot uses different versions of final-form / react-final-form which causes this issue. Let's try to provide default value for `initialValues` first to see if this helps. If not we may need to lock the versions.