### PR TITLE
UIIN-486: Add new item status date field support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * Change instance all/keyword search to use new `keyword` index. Completes UIIN-717.
 * Filter all panes by item effective location. Completes UIIN-199.
 * Display "status updated" date/time. Completes UIIN-846.
+* Add new item status date field support. Completes UIIN-486.
 
 ## [1.12.1](https://github.com/folio-org/ui-inventory/tree/v1.12.1) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.12.0...v1.12.1)

--- a/src/ViewItem.js
+++ b/src/ViewItem.js
@@ -140,7 +140,6 @@ class ViewItem extends React.Component {
       },
       loan: null,
       borrower: null,
-      loanStatusDate: null,
       itemMissingModal: false,
       confirmDeleteItemModal: false,
       cannotDeleteItemModal: false,
@@ -162,17 +161,16 @@ class ViewItem extends React.Component {
     if (!loan) return;
 
     const itemStatus = get(loan, 'item.status.name');
-    const loanStatusDate = get(loan, 'metadata.updatedDate');
-    const state = { loanStatusDate };
 
     if (!includes([AVAILABLE, AWAITING_PICKUP, IN_TRANSIT], itemStatus)) {
       const borrowers = await this.fetchBorrowers(loans[0].userId);
+      const state = {
+        loan,
+        borrower: borrowers[0],
+      };
 
-      state.loan = loan;
-      state.borrower = borrowers[0];
+      this.setState(state);
     }
-
-    this.setState(state);
   }
 
   fetchLoans() {
@@ -525,11 +523,7 @@ class ViewItem extends React.Component {
       );
     }
 
-    let itemStatusDate = get(item, ['metadata', 'updatedDate']);
-
-    if (this.state.loanStatusDate && this.state.loanStatusDate > itemStatusDate) {
-      itemStatusDate = this.state.loanStatusDate;
-    }
+    const itemStatusDate = get(item, ['status', 'date']);
 
     const refLookup = (referenceTable, id) => {
       const ref = (referenceTable && id) ? referenceTable.find(record => record.id === id) : {};


### PR DESCRIPTION
## Purposes

Add support of a new field from a server response to maintain the item status date even if item record is edited. [Link](https://issues.folio.org/browse/UIIN-486)

## Screenshots

![different_update_and_status dates](https://user-images.githubusercontent.com/50317804/69327539-5de17980-0c56-11ea-8bf2-82394d95a341.png)


![empty_item_status_date](https://user-images.githubusercontent.com/50317804/69327540-5e7a1000-0c56-11ea-9f07-0011683f10ef.png)
