### PR TITLE
refactor `it` blocks in filter test

### DIFF
--- a/test/ui-testing/filters.js
+++ b/test/ui-testing/filters.js
@@ -1,120 +1,66 @@
 /* global describe it before after Nightmare */
-
 module.exports.test = function uiTest(uiTestCtx) {
   describe('Module test: inventory:filters', function modTest() {
     const { config, helpers: { login, openApp, logout }, meta: { testVersion } } = uiTestCtx;
     const nightmare = new Nightmare(config.nightmare);
-
     this.timeout(Number(config.test_timeout));
-    // Resource type filter test disabled as new resource types are being loaded.
-    // const filters = ['resource-books', 'resource-serials', 'resource-ebooks', 'language-english', 'language-spanish', 'location-annex'];
-    const languageFilters = ['English', 'Spanish'];
-    const locationFilters = ['Annex', 'Main Library'];
-    const itemStatusFilters = ['itemStatus-available', 'itemStatus-checked-out'];
 
-    /**
-     * Navigate to the given segment, then choose each of the elements
-     * on the list from the multi-select filter in the given accordion,
-     * validating that one or more results was returned by the presence of
-     * `#list-inventory[data-total-count]`.
-     *
-     * @param {string} segmentName label for the segment we are testing
-     * @param {string} segmentSelector selector for the segment we are testing
-     * @param {string} accordionSelector selector for the accordion containing the filters
-     * @param {string[]} list option-values
-     */
-    const multiSelectFilterTest = (segmentName, segmentSelector, accordionSelector, list) => {
-      it(`should click "${segmentName}" to navigate there`, (done) => {
-        nightmare
-          .wait(segmentSelector)
-          .click(segmentSelector)
-          .wait('#paneHeaderpane-results-subtitle')
-          .wait('span[class^="noResultsMessageLabel"]')
-          .then(done)
-          .catch(done);
-      });
-
-      it('should find "no results" message with no filters applied', (done) => {
-        nightmare
-          .wait('#paneHeaderpane-results-subtitle')
-          .wait('span[class^="noResultsMessageLabel"]')
-          .then(done)
-          .catch(done);
-      });
-
-      list.forEach((filter) => {
-        it(`should click ${filter} and find hit count`, (done) => {
-          nightmare
-            .wait('#input-inventory-search')
-            .type('#input-inventory-search', 0)
-            .wait('#clickable-reset-all')
-            .click('#clickable-reset-all')
-            .wait(`section#${accordionSelector} [class^=multiSelect] [role=option]`)
-            .evaluate((value, accordionId) => {
-              return Array.from(document.querySelectorAll(`section#${accordionId} [class^=multiSelect] [role=option] [class^=optionSegment]`)).findIndex(e => e.textContent === value) + 1;
-            }, filter, accordionSelector)
-            .then((filterIndex) => {
-              nightmare
-                .wait(`section#${accordionSelector} [class^=multiSelect] [role=option]:nth-of-type(${filterIndex})`)
-                .click(`section#${accordionSelector} [class^=multiSelect] [role=option]:nth-of-type(${filterIndex})`)
-                .wait('#list-inventory[data-total-count]')
-                .click('#clickable-reset-all')
-                .wait('#paneHeaderpane-results-subtitle')
-                .wait('span[class^="noResultsMessageLabel"]')
-                .then(done)
-                .catch(done);
-            })
-            .catch(done);
-        });
-      });
+    const navigateTo = (segmentSelector, done) => {
+      nightmare
+        .wait(segmentSelector)
+        .click(segmentSelector)
+        .wait('#paneHeaderpane-results-subtitle')
+        .wait('span[class^="noResultsMessageLabel"]')
+        .then(done)
+        .catch(done);
     };
 
-    /**
-     * Navigate to the given segment, then tick and untick each of the
-     * checkboxes in the list, validating that one or more results was
-     * returned by the presence of `#list-inventory[data-total-count]`.
-     *
-     * @param {string} segmentName label for the segment we are testing
-     * @param {string} segmentSelector selector for the segment we are testing
-     * @param {string} accordionSelector selector for the accordion containing the filters
-     * @param {string[]} list filter ids to be concatenated onto '#clickable-filter-'
-     */
-    const checkboxFilterTest = (segmentName, segmentSelector, accordionSelector, list) => {
-      it(`should click "${segmentName}" to navigate there`, (done) => {
-        nightmare
-          .wait(segmentSelector)
-          .click(segmentSelector)
-          .wait('#paneHeaderpane-results-subtitle')
-          .wait('span[class^="noResultsMessageLabel"]')
-          .then(done)
-          .catch(done);
-      });
+    const findNoResults = (done) => {
+      nightmare
+        .wait('#paneHeaderpane-results-subtitle')
+        .wait('span[class^="noResultsMessageLabel"]')
+        .then(done)
+        .catch(done);
+    };
 
-      it('should find "no results" message with no filters applied', (done) => {
-        nightmare
-          .wait('#paneHeaderpane-results-subtitle')
-          .wait('span[class^="noResultsMessageLabel"]')
-          .then(done)
-          .catch(done);
-      });
-
-      list.forEach((filter) => {
-        it(`should click ${filter} and find hit count`, (done) => {
-          nightmare
-            .wait('#input-inventory-search')
-            .type('#input-inventory-search', 0)
-            .wait('#clickable-reset-all')
-            .click('#clickable-reset-all')
-            .wait(`#${accordionSelector} #clickable-filter-${filter}`)
-            .click(`#${accordionSelector} #clickable-filter-${filter}`)
+    const findMultiSelectFilteredResults = (accordionSelector, filter, done) => {
+      nightmare
+        .wait('#input-inventory-search')
+        .type('#input-inventory-search', 0)
+        .wait('#clickable-reset-all')
+        .click('#clickable-reset-all')
+        .wait(`section#${accordionSelector} [class^=multiSelect] [role=option]`)
+        .evaluate((value, accordionId) => {
+          return Array.from(document.querySelectorAll(`section#${accordionId} [class^=multiSelect] [role=option] [class^=optionSegment]`)).findIndex(e => e.textContent === value) + 1;
+        }, filter, accordionSelector)
+        .then((filterIndex) => {
+          return nightmare
+            .wait(`section#${accordionSelector} [class^=multiSelect] [role=option]:nth-of-type(${filterIndex})`)
+            .click(`section#${accordionSelector} [class^=multiSelect] [role=option]:nth-of-type(${filterIndex})`)
             .wait('#list-inventory[data-total-count]')
             .click('#clickable-reset-all')
             .wait('#paneHeaderpane-results-subtitle')
             .wait('span[class^="noResultsMessageLabel"]')
             .then(done)
             .catch(done);
-        });
-      });
+        })
+        .catch(done);
+    };
+
+    const findCheckboxFilteredResults = (accordionSelector, filter, done) => {
+      nightmare
+        .wait('#input-inventory-search')
+        .type('#input-inventory-search', 0)
+        .wait('#clickable-reset-all')
+        .click('#clickable-reset-all')
+        .wait(`#${accordionSelector} #clickable-filter-${filter}`)
+        .click(`#${accordionSelector} #clickable-filter-${filter}`)
+        .wait('#list-inventory[data-total-count]')
+        .click('#clickable-reset-all')
+        .wait('#paneHeaderpane-results-subtitle')
+        .wait('span[class^="noResultsMessageLabel"]')
+        .then(done)
+        .catch(done);
     };
 
     describe('Login > Open module "Inventory" > Get hit counts > Click filters > Logout', () => {
@@ -133,25 +79,57 @@ module.exports.test = function uiTest(uiTestCtx) {
       });
 
       describe('Should test instance language filters', () => {
-        multiSelectFilterTest('instance', '#segment-navigation-instances', 'language', languageFilters);
+        const languageFilters = ['English', 'Spanish'];
+
+        it('should navigate to inventory\'s instance segment"', (done) => {
+          navigateTo('#segment-navigation-instances', done);
+        });
+
+        it('should find no results', (done) => {
+          findNoResults(done);
+        });
+
+        languageFilters.forEach((language) => {
+          it(`should filter results by language (${language})`, (done) => {
+            findMultiSelectFilteredResults('language', language, done);
+          });
+        });
       });
 
-      describe('Should test holdings location filters', () => {
-        multiSelectFilterTest('holdings', '#segment-navigation-holdings', 'holdingsPermanentLocation', locationFilters);
+      describe('Should test holdings permanent location filters', () => {
+        const filters = ['Annex', 'Main Library'];
+
+        it('should navigate to inventory\'s holdings segment"', (done) => {
+          navigateTo('#segment-navigation-holdings', done);
+        });
+
+        it('should find no results', (done) => {
+          findNoResults(done);
+        });
+
+        filters.forEach((filter) => {
+          it(`should filter results by location (${filter})`, (done) => {
+            findMultiSelectFilteredResults('holdingsPermanentLocationAccordion', filter, done);
+          });
+        });
       });
 
       describe('Should test items item-status filters', () => {
-        checkboxFilterTest('items', '#segment-navigation-items', 'itemFilterAccordion', itemStatusFilters);
-      });
+        const filters = ['itemStatus-available', 'itemStatus-checked-out'];
 
-      it('should click the "item" segment filter', (done) => {
-        nightmare
-          .wait('#segment-navigation-items')
-          .click('#segment-navigation-items')
-          .wait('#paneHeaderpane-results-subtitle')
-          .wait('span[class^="noResultsMessageLabel"]')
-          .then(done)
-          .catch(done);
+        it('should navigate to inventory\'s items segment"', (done) => {
+          navigateTo('#segment-navigation-items', done);
+        });
+
+        it('should find no results', (done) => {
+          findNoResults(done);
+        });
+
+        filters.forEach((filter) => {
+          it(`should filter results by location (${filter})`, (done) => {
+            findCheckboxFilteredResults('itemFilterAccordion', filter, done);
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
Previous versions contained `it` blocks in functions called by multiple
tests. This test failed in CI although it ran just fine in other
environments. This refactoring changes the test structure a bit so that
functions called by multiple tests do not contain `it` blocks.

Maybe we'll get lucky and Nightmare will be happy about that?