### PR TITLE
Use instance url with the correct search segment. Fixes UIIN-886

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * Reorder item search options. Completes UIIN-849.
 * Instance record's item-record columns should not be clipped. Refs UIIN-865.
 * Display effective location at top of item record. Completes UIIN-863.
+* Use instance url with the correct search segment. Fixes UIIN-886.
 
 ## [1.12.1](https://github.com/folio-org/ui-inventory/tree/v1.12.1) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.12.0...v1.12.1)

--- a/src/Items.js
+++ b/src/Items.js
@@ -77,9 +77,10 @@ class Items extends React.Component {
   render() {
     const {
       resources: { items },
-      instance,
       holdingsRecord,
       getSearchParams,
+      location: { pathname },
+
     } = this.props;
 
     if (!items || !items.hasLoaded) return null;
@@ -98,7 +99,7 @@ class Items extends React.Component {
         return (
           <React.Fragment>
             <Link
-              to={`/inventory/view/${instance.id}/${holdingsRecord.id}/${item.id}?${getSearchParams()}`}
+              to={`${pathname}/${holdingsRecord.id}/${item.id}?${getSearchParams()}`}
               data-test-item-link
             >
               <span data-test-items-app-icon>
@@ -168,7 +169,7 @@ Items.propTypes = {
     }),
     query: PropTypes.object,
   }),
-  instance: PropTypes.object,
+  location: PropTypes.object,
   holdingsRecord: PropTypes.object.isRequired,
   getSearchParams: PropTypes.func.isRequired,
 };

--- a/src/ItemsPerHoldingsRecord.js
+++ b/src/ItemsPerHoldingsRecord.js
@@ -77,8 +77,8 @@ class ItemsPerHoldingsRecord extends React.Component {
 
   renderButtonsGroup = () => {
     const {
-      instance,
       holdingsRecord,
+      location: { pathname },
     } = this.props;
 
     return (
@@ -86,7 +86,7 @@ class ItemsPerHoldingsRecord extends React.Component {
         <Button
           id="clickable-view-holdings"
           data-test-view-holdings
-          to={{ pathname: `/inventory/view/${instance.id}/${holdingsRecord.id}` }}
+          to={{ pathname: `${pathname}/${holdingsRecord.id}` }}
           style={{ marginRight: '5px' }}
         >
           <FormattedMessage id="ui-inventory.viewHoldings" />
@@ -199,6 +199,7 @@ class ItemsPerHoldingsRecord extends React.Component {
 
 ItemsPerHoldingsRecord.propTypes = {
   instance: PropTypes.object,
+  location: PropTypes.object,
   holdingsRecord: PropTypes.object.isRequired,
   mutator: PropTypes.shape({
     items: PropTypes.shape({

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -234,8 +234,20 @@ class ViewInstance extends React.Component {
 
   closeViewItem = (e) => {
     if (e) e.preventDefault();
-    const { goTo, getSearchParams, match: { params: { id } } } = this.props;
-    goTo(`/inventory/view/${id}?${getSearchParams()}`);
+
+    const {
+      goTo,
+      getSearchParams,
+      match: {
+        params: { id },
+      },
+      location: { pathname }
+    } = this.props;
+
+    // extract instance url with a correct segment
+    const [path] = pathname.match(new RegExp(`(.*)${id}`));
+
+    goTo(`${path}?${getSearchParams()}`);
   };
 
   closeViewMarc = (e) => {


### PR DESCRIPTION
It looks like there were couple places where the search `segment` was lost when navigating between views. This was causing issues described in  UIIN-886. This PR should fix it.

https://issues.folio.org/browse/UIIN-886