### PR TITLE
UIIN-739: Create one common inventory permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## [1.14.0] (IN PROGRESS)
+
+* Create one common inventory permission "Inventory: All permissions". Refs UIIN-739.
+
 ## [1.13.0](https://github.com/folio-org/ui-inventory/tree/v1.13.0) (2019-12-04)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.12.1...v1.13.0)
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
       },
       {
         "permissionName": "ui-inventory.all-permissions.TEMPORARY",
-        "displayName": " Inventory: All permissions",
+        "displayName": "Inventory: All permissions",
         "description": "Some subperms to support enabling/using the Inventory app",
         "subPermissions": [
           "ui-inventory.instance.view",

--- a/package.json
+++ b/package.json
@@ -79,12 +79,20 @@
       },
       {
         "permissionName": "ui-inventory.all-permissions.TEMPORARY",
-        "displayName": "Inventory: <temporary> all perms including UI",
+        "displayName": " Inventory: All permissions",
         "description": "Some subperms to support enabling/using the Inventory app",
         "subPermissions": [
-          "module.inventory.enabled",
-          "inventory-storage.all",
-          "inventory.all"
+          "ui-inventory.instance.view",
+          "ui-inventory.instance.create",
+          "ui-inventory.holdings.create",
+          "ui-inventory.item.create",
+          "ui-inventory.instance.edit",
+          "ui-inventory.item.edit",
+          "ui-inventory.holdings.edit",
+          "ui-inventory.item.markasmissing",
+          "ui-inventory.item.delete",
+          "ui-inventory.holdings.delete",
+          "ui-inventory.instance.view-staff-suppressed-records"
         ],
         "visible": true
       },


### PR DESCRIPTION
###  Description
Rename permission, add required inventory permissions for possibility to use one general permission
with all Inventory perms

--- 
### Issues
https://issues.folio.org/browse/UIIN-739