### PR TITLE
UIDEXP-12: Disable saving instances UIIDs option if there are not items in search result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add saving instances UIIDs of the inventory search result to csv file. Refs UIDEXP-1.
 * Add ability to search by Item HRID (Item segment). Refs UIIN-901.
 * Add ability to search by Holdings HRID (Holdings segment). Refs UIIN-900.
+* Disable saving instances UIIDs option if there are not items in search result. Refs UIDEXP-12.
 
 ## [1.13.1](https://github.com/folio-org/ui-inventory/tree/v1.13.1) (2019-12-11)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.0...v1.13.1)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -1,6 +1,5 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-
 import {
   omit,
   get,
@@ -169,6 +168,8 @@ class InstancesView extends React.Component {
   };
 
   getActionMenu = ({ onToggle }) => {
+    const { parentResources } = this.props;
+
     return (
       <Fragment>
         <Button
@@ -183,6 +184,7 @@ class InstancesView extends React.Component {
           <FormattedMessage id="ui-inventory.inTransitReport" />
         </Button>
         <Button
+          disabled={isEmpty(get(parentResources, ['records', 'records'], []))}
           buttonStyle="dropdownItem"
           id="dropdown-clickable-get-items-uiids"
           onClick={() => {

--- a/test/bigtest/interactors/inventory.js
+++ b/test/bigtest/interactors/inventory.js
@@ -7,6 +7,7 @@ import {
   clickable,
   isPresent,
   isVisible,
+  property,
 } from '@bigtest/interactor';
 
 import {
@@ -18,6 +19,8 @@ import {
   itemsInTransitReportBtnIsVisible = isVisible('#dropdown-clickable-get-report');
   clickSaveInstancesUIIDsBtn = clickable('#dropdown-clickable-get-items-uiids');
   saveInstancesUIIDsBtnIsVisible = isVisible('#dropdown-clickable-get-items-uiids');
+  saveInstancesUIIDsBtnIsVisible = isVisible('#dropdown-clickable-get-items-uiids');
+  isSaveInstancesUIIDsBtnDisabled = property('#dropdown-clickable-get-items-uiids', 'disabled');
 }
 
 export default @interactor class InventoryInteractor {

--- a/test/bigtest/tests/export-to-csv-test.js
+++ b/test/bigtest/tests/export-to-csv-test.js
@@ -9,9 +9,10 @@ import sinon from 'sinon';
 
 import setupApplication from '../helpers/setup-application';
 import InventoryInteractor from '../interactors/inventory';
+import InstancesRouteInteractor from '../interactors/routes/instances-route';
 
 describe('Instances', () => {
-  setupApplication();
+  setupApplication({ scenarios: ['instances-filters'] });
 
   const inventory = new InventoryInteractor({
     timeout: 5000,
@@ -20,6 +21,21 @@ describe('Instances', () => {
 
   let xhr;
   let requests = [];
+
+  describe('searching by instance HRID to fill items list', function () {
+    beforeEach(async function () {
+      this.visit('/inventory');
+      const instancesRoute = new InstancesRouteInteractor();
+      await instancesRoute.searchFieldFilter.searchField.selectIndex('Instance HRID');
+      await instancesRoute.searchFieldFilter.searchField.fillInput('in00000000009');
+      await instancesRoute.searchFieldFilter.clickSearch();
+      await inventory.headerDropdown.click();
+    });
+
+    it('should enable action button for saving instances UIIDs if there are items in search result', () => {
+      expect(inventory.headerDropdownMenu.isSaveInstancesUIIDsBtnDisabled).to.be.false;
+    });
+  });
 
   describe('clicking on header dropdown button', () => {
     beforeEach(async function () {
@@ -34,6 +50,10 @@ describe('Instances', () => {
 
     it('should display action button for saving instances UIIDs to csv', () => {
       expect(inventory.headerDropdownMenu.saveInstancesUIIDsBtnIsVisible).to.be.true;
+    });
+
+    it('should disable action button for saving instances UIIDs if there are not items in search result', () => {
+      expect(inventory.headerDropdownMenu.isSaveInstancesUIIDsBtnDisabled).to.be.true;
     });
 
     describe('clicking Items in transit report button', () => {


### PR DESCRIPTION
## Purposes

Disable saving instances UIIDs option if there are not items in search result in the scope of the [ticket](https://issues.folio.org/browse/UIDEXP-12).

## Screenshots
![disabled_save_UIIDs_button](https://user-images.githubusercontent.com/50317804/73073037-22199900-3ebf-11ea-81de-81f98160039d.png)

![enabled_save_UIIDs_button](https://user-images.githubusercontent.com/50317804/73073039-22b22f80-3ebf-11ea-8a0a-02d0aca2a32c.png)
