### PR TITLE
UIDEXP-1: Fix timestamp format in file name of instances UIIDs report

### DIFF
--- a/package.json
+++ b/package.json
@@ -629,7 +629,8 @@
     "react-hot-loader": "^4.3.12",
     "react-intl": "^2.3.0",
     "react-router-prop-types": "^1.0.4",
-    "redux-form": "^7.0.3"
+    "redux-form": "^7.0.3",
+    "moment": "^2.22.2"
   },
   "peerDependencies": {
     "@folio/stripes": "^2.13.0",

--- a/src/reports/InstancesIdReport.js
+++ b/src/reports/InstancesIdReport.js
@@ -1,4 +1,5 @@
 import { get } from 'lodash';
+import moment from 'moment';
 
 import { exportCsv } from '@folio/stripes/util';
 
@@ -18,7 +19,7 @@ class InstancesIdReport {
 
     exportCsv(parsedRecords, {
       header: false,
-      filename: 'SearchInstanceUUIDs' + new Date().toISOString(),
+      filename: 'SearchInstanceUUIDs' + moment().format(),
     });
   }
 }


### PR DESCRIPTION
## Purposes

Fix timestamp format in file name of instances UIIDs report. [Issue](https://issues.folio.org/browse/UIDEXP-1).