### PR TITLE
UIIN-946 retrieve up to 1000 material-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add ability to search by Item HRID (Item segment). Refs UIIN-901.
 * Add ability to search by Holdings HRID (Holdings segment). Refs UIIN-900.
 * Disable saving instances UIIDs option if there are not items in search result. Refs UIDEXP-12.
+* Retrieve up to 1000 material types on the item-edit screen. Refs UIIN-946.
 
 ## [1.13.1](https://github.com/folio-org/ui-inventory/tree/v1.13.1) (2019-12-11)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.0...v1.13.1)

--- a/src/ItemsPerHoldingsRecord.js
+++ b/src/ItemsPerHoldingsRecord.js
@@ -37,6 +37,10 @@ class ItemsPerHoldingsRecord extends React.Component {
     materialTypes: {
       type: 'okapi',
       path: 'material-types',
+      params: {
+        query: 'cql.allRecords=1 sortby name',
+        limit: '1000',
+      },
       records: 'mtypes',
     },
     loanTypes: {


### PR DESCRIPTION
The `limit` clause was missing from the `material-types` resource on the
item-edit page, causing it to retrieve only 10 records (the default) at
a time.

Refs [UIIN-946](https://issues.folio.org/browse/UIIN-946)