### PR TITLE
UIIN-949 always refresh settings' code-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add ability to search by Item HRID (Item segment). Refs UIIN-901.
 * Add ability to search by Holdings HRID (Holdings segment). Refs UIIN-900.
 * Disable saving instances UIIDs option if there are not items in search result. Refs UIDEXP-12.
+* Always retrieve fresh statistical-code-types in settings. Refs UIIN-949.
 
 ## [1.13.1](https://github.com/folio-org/ui-inventory/tree/v1.13.1) (2019-12-11)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.0...v1.13.1)

--- a/src/settings/StatisticalCodeSettings.js
+++ b/src/settings/StatisticalCodeSettings.js
@@ -16,7 +16,7 @@ class StatisticalCodeSettings extends React.Component {
       type: 'okapi',
       path: 'statistical-code-types',
       records: 'statisticalCodeTypes',
-      accumulate: 'true',
+      shouldRefresh: true,
       throwErrors: false,
       GET: {
         path: 'statistical-code-types?query=cql.allRecords=1 &limit=500'


### PR DESCRIPTION
When editing statistical codes, always refresh the code-types resource
in order to make sure newly-created types are available.

Refs [UIIN-949](https://issues.folio.org/browse/UIIN-949)