### PR TITLE
Replace deprecated babel dependencies. Refs UIIN-956, STCOR-381.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Retrieve up to 2000 statistical codes. Refs UIIN-819.
 * Retrieve up to 1000 material types on the item-edit screen. Refs UIIN-946.
 * Always retrieve fresh statistical-code-types in settings. Refs UIIN-949.
+* Replace deprecated babel dependencies. Refs UIIN-956, STCOR-381.
 
 ## [1.13.1](https://github.com/folio-org/ui-inventory/tree/v1.13.1) (2019-12-11)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.0...v1.13.1)

--- a/package.json
+++ b/package.json
@@ -607,11 +607,12 @@
     "@folio/stripes-smart-components": "^2.12.0",
     "@folio/stripes-components": "^5.9.0",
     "babel-eslint": "^9.0.0",
-    "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
+    "core-js": "^3.6.4", 
     "eslint": "^5.5.0",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
+    "regenerator-runtime": "^0.13.3", 
     "sinon": "^7.0.0"
   },
   "dependencies": {

--- a/test/bigtest/index.js
+++ b/test/bigtest/index.js
@@ -1,4 +1,5 @@
-import 'babel-polyfill';
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 import turnOffWarnings from './helpers/turn-off-warnings';
 


### PR DESCRIPTION
I have run the tests four times after making these changes. The tests now run, but none of the runs was clean, yielding three, five, ten and seven errors respectively. I don't know what can be done about that.