### PR TITLE
UIIN-954: Delete columnWidths prop due to the overlapped headers

### DIFF
--- a/src/Items.js
+++ b/src/Items.js
@@ -174,15 +174,6 @@ class Items extends React.Component {
                     'volume': intl.formatMessage({ id: 'ui-inventory.volume' }),
                     'yearCaption': intl.formatMessage({ id: 'ui-inventory.yearCaption' }),
                   }}
-                  columnWidths={{
-                    'barcode': '21%',
-                    'status': '13%',
-                    'materialType': '17%',
-                    'enumeration': '13%',
-                    'chronology': '12%',
-                    'volume': '8%',
-                    'yearCaption': '17%',
-                  }}
                   ariaLabel={ariaLabel}
                   containerRef={ref => { this.resultsList = ref; }}
                   interactive={false}


### PR DESCRIPTION
### Purpose
Delete columnWidths property due to the overlapped headers in Item detailed list. [Source](https://issues.folio.org/browse/UIIN-954?focusedCommentId=70320&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-70320).