### PR TITLE
UIIN-845: Omit Former holdings ID when copying holdings record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Extract item view into a separate route. Fixes UIIN-955.
 * Filter instance, holding and item records by suppress: No. Refs UIIN-967, UIIN-968, UIIN-969, UIIN-970.
 * Filter instance by nature of content. Refs UIIN-824.
+* Omit Former holdings ID when copying holdings record. Refs UIIN-845.
 
 ## [1.13.1](https://github.com/folio-org/ui-inventory/tree/v1.13.1) (2019-12-11)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.0...v1.13.1)

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -192,7 +192,7 @@ class ViewHoldingsRecord extends React.Component {
   onCopy(record) {
     this.setState((state) => {
       const newState = cloneDeep(state);
-      newState.copiedRecord = omit(record, ['id', 'hrid']);
+      newState.copiedRecord = omit(record, ['id', 'hrid', 'formerIds']);
       return newState;
     });
 

--- a/test/bigtest/interactors/inventory.js
+++ b/test/bigtest/interactors/inventory.js
@@ -28,7 +28,7 @@ export default @interactor class InventoryInteractor {
 
   isNoResultsMessageLabelPresent = isPresent('[class*=noResultsMessageLabel]');
 
-  isResourceFilterPresent = isPresent('[data-test-filter-instance-resource]');
+  isResourceFilterPresent = isPresent('#resource');
   isLocationFilterPresent = isPresent('[data-test-filter-instance-location]');
   isEffectiveLocationFilterPresent = isPresent('#effectiveLocation');
   isStaffSuppressFilterPresent = isPresent('[data-test-filter-instance-staff-suppress]');


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-845