### PR TITLE
UIIN-961: Display succeeding/preceding titles on connected and unconnected instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Filter instance by "Call number, eye readable" via items segment. Refs UIIN-990.
 * Enhance preceding connected titles. Refs UIIN-960.
 * Add Save icon to the Save Instances UUIDs option in Action menu. UIDEXP-32.
+* Display succeeding/preceding titles on instance view. Refs UIIN-952, UIIN-961 and UIIN-964.
 
 ## [1.13.1](https://github.com/folio-org/ui-inventory/tree/v1.13.1) (2019-12-11)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.0...v1.13.1)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -66,6 +66,8 @@ import ViewHoldingsRecord from './ViewHoldingsRecord';
 import ViewMarc from './ViewMarc';
 import makeConnectedInstance from './ConnectedInstance';
 import withLocation from './withLocation';
+
+import { TitlesView } from './components';
 import {
   wrappingCell,
   noValue,
@@ -624,16 +626,13 @@ class ViewInstance extends React.Component {
       alternativeTitles: get(instance, ['alternativeTitles'], []),
       indexTitle: get(instance, ['indexTitle'], '-'),
       series: get(instance, ['series'], []),
-      precedingTitles: get(instance, ['precedingTitles'], []),
-      succeedingTitles: get(instance, ['succeedingTitles'], []),
     };
+    const {
+      precedingTitles,
+      succeedingTitles,
+    } = instance;
 
     const seriesContent = !isEmpty(titleData.series) ? titleData.series.map(x => ({ value: x })) : emptyList;
-
-    const precedingTitlesContent = !isEmpty(titleData.precedingTitles) ? formatters.precedingTitlesFormatter(instance, location) : noValue;
-
-    const succeedingTitlesContent = !isEmpty(titleData.succeedingTitles) ? formatters.succeedingTitlesFormatter(instance, location) : noValue;
-
     const identifiers = get(instance, 'identifiers', []).map(x => ({
       identifierType: this.refLookup(referenceTables.identifierTypes, get(x, 'identifierTypeId')).name,
       value: x.value,
@@ -1037,9 +1036,11 @@ class ViewInstance extends React.Component {
               data-test-preceding-titles
               xs={12}
             >
-              <KeyValue
+              <TitlesView
+                id="precedingTitles"
+                titleKey="precedingInstanceId"
                 label={<FormattedMessage id="ui-inventory.precedingTitles" />}
-                value={precedingTitlesContent}
+                titles={isEmpty(precedingTitles) ? emptyList : precedingTitles}
               />
             </Col>
           </Row>
@@ -1048,9 +1049,11 @@ class ViewInstance extends React.Component {
               data-test-succeeding-titles
               xs={12}
             >
-              <KeyValue
+              <TitlesView
+                id="succeedingTitles"
+                titleKey="succeedingInstanceId"
                 label={<FormattedMessage id="ui-inventory.succeedingTitles" />}
-                value={succeedingTitlesContent}
+                titles={isEmpty(succeedingTitles) ? emptyList : succeedingTitles}
               />
             </Col>
           </Row>

--- a/src/components/TitlesView/TitlesView.js
+++ b/src/components/TitlesView/TitlesView.js
@@ -1,0 +1,77 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import Link from 'react-router-dom/Link';
+
+import {
+  MultiColumnList,
+  KeyValue,
+} from '@folio/stripes/components';
+
+import { getIdentifiers } from '../../utils';
+import { indentifierTypeNames } from '../../constants';
+import DataContext from '../../contexts/DataContext';
+
+const TitlesViews = ({ titles, id, titleKey, label }) => {
+  const { identifierTypesById } = useContext(DataContext);
+  const {
+    ISSN,
+    ISBN,
+  } = indentifierTypeNames;
+  const formatter = {
+    title: row => (row[titleKey] ?
+      <Link
+        target="_blank"
+        to={`/inventory/view/${row[titleKey]}`}
+      >
+        {row.title}
+      </Link> :
+      row.title || '-'),
+    hrid: row => row.hrid || '-',
+    issn: row => getIdentifiers(row.identifiers, ISSN, identifierTypesById) || '-',
+    isbn: row => getIdentifiers(row.identifiers, ISBN, identifierTypesById) || '-',
+  };
+
+  const visibleColumns = [
+    'title',
+    'hrid',
+    'isbn',
+    'issn',
+  ];
+
+  const columnMapping = {
+    title: <FormattedMessage id="ui-inventory.instances.columns.title" />,
+    hrid: <FormattedMessage id="ui-inventory.instanceHrid" />,
+    issn: <FormattedMessage id="ui-inventory.issn" />,
+    isbn: <FormattedMessage id="ui-inventory.isbn" />,
+  };
+
+  const columnWidths = {
+    title: '35%',
+    hrid: '25%',
+  };
+
+  return (
+    <KeyValue label={label}>
+      <MultiColumnList
+        id={id}
+        contentData={titles}
+        visibleColumns={visibleColumns}
+        columnMapping={columnMapping}
+        columnWidths={columnWidths}
+        formatter={formatter}
+        ariaLabel={label}
+        interactive={false}
+      />
+    </KeyValue>
+  );
+};
+
+TitlesViews.propTypes = {
+  id: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
+  titles: PropTypes.arrayOf(PropTypes.object).isRequired,
+  titleKey: PropTypes.string.isRequired,
+};
+
+export default TitlesViews;

--- a/src/components/TitlesView/index.js
+++ b/src/components/TitlesView/index.js
@@ -1,0 +1,1 @@
+export { default } from './TitlesView';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -8,4 +8,5 @@ export { default as InstancePlugin } from './InstancePlugin';
 export { default as ConnectedTitle } from './ConnectedTitle';
 export { default as UnconnectedTitle } from './UnconnectedTitle';
 export { default as TitleLabel } from './TitleLabel';
+export { default as TitlesView } from './TitlesView';
 export { PaneLoading, ViewLoading } from './Loading';

--- a/test/bigtest/interactors/instance-view-page.js
+++ b/test/bigtest/interactors/instance-view-page.js
@@ -62,8 +62,9 @@ import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumn
   accordion = new AccordionInteractor('#acc02');
   expandAll = scoped('[data-test-expand-all] button');
   hasExpandAll = isPresent('[data-test-expand-all] button');
-  hasPrecedingTitles = isPresent('[data-test-preceding-titles]');
-  hasSucceedingTitles = isPresent('[data-test-succeeding-titles]');
+  precedingTitles = new MultiColumnListInteractor('#precedingTitles');
+  succeedingTitles = new MultiColumnListInteractor('#succeedingTitles');
+
   notes = collection('[id^="list-instance-notes"]', MultiColumnListInteractor);
 
   getCellContent(row, cell) {

--- a/test/bigtest/tests/instance-view-page-test.js
+++ b/test/bigtest/tests/instance-view-page-test.js
@@ -480,21 +480,19 @@ describe('InstanceViewPage', () => {
   describe('Preceding and succeding titles', () => {
     setupApplication();
     beforeEach(async function () {
-      this.server.create('instanceRelationshipType', {
-        'id': '7531246',
-        'name': 'preceding-succeeding',
-      });
       const instance = this.server.create('instance', {
         title: 'ADVANCING RESEARCH',
-        parentInstances: [{
-          id: '10101010101',
-          superInstanceId: '130400000',
-          instanceRelationshipTypeId: '7531246',
+        precedingTitles: [{
+          id: 'da672352-7856-4241-ac06-ae62f0bade4c',
+          precedingInstanceId: '5bf370e0-8cca-4d9c-82e4-5170ab2a0a39',
+          title: 'A semantic web primer',
+          hrid: 'inst000000000022',
         }],
-        childInstances: [{
-          id: '10101010101',
-          subInstanceId: '130400000',
-          instanceRelationshipTypeId: '7531246',
+        succeedingTitles: [{
+          id: '668b93f1-4821-4eb0-8a2b-d507434965f4',
+          succeedingInstanceId: '5bf370e0-8cca-4d9c-82e4-5170ab2a0a39',
+          title: 'Bridget Jones\'s Baby: the diaries',
+          hrid: 'inst000000000022',
         }],
       });
 
@@ -503,10 +501,10 @@ describe('InstanceViewPage', () => {
     });
 
     it('should show preceding title', () => {
-      expect(InstanceViewPage.hasPrecedingTitles).to.be.true;
+      expect(InstanceViewPage.precedingTitles.rowCount).to.be.equal(1);
     });
     it('should show succeding title', () => {
-      expect(InstanceViewPage.hasSucceedingTitles).to.be.true;
+      expect(InstanceViewPage.succeedingTitles.rowCount).to.be.equal(1);
     });
   });
 


### PR DESCRIPTION
### Purpose 
Display succeeding/preceding titles on instance view. Refs UIIN-961, UIIN-964 and UIIN-952.

https://issues.folio.org/browse/UIIN-952
https://issues.folio.org/browse/UIIN-961
https://issues.folio.org/browse/UIIN-964

### Screenshots
![titles](https://user-images.githubusercontent.com/63545/76257355-eac13a80-6227-11ea-805b-7c65e0a2f038.png)
