### PR TITLE
UIDEXP-32: Add Save icon to the Save Instances UUID (#935)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Filter instance by "Call number, eye readable" via holdings segment. Refs UIIN-858.
 * Filter instance by "Call number, eye readable" via items segment. Refs UIIN-990.
 * Enhance preceding connected titles. Refs UIIN-960.
+* Add Save icon to the Save Instances UUIDs option in Action menu. UIDEXP-32.
 
 ## [1.13.1](https://github.com/folio-org/ui-inventory/tree/v1.13.1) (2019-12-11)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.0...v1.13.1)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -15,7 +15,10 @@ import {
 
 import { AppIcon } from '@folio/stripes/core';
 import { SearchAndSort } from '@folio/stripes/smart-components';
-import { Button } from '@folio/stripes/components';
+import {
+  Button,
+  Icon
+} from '@folio/stripes/components';
 
 import FilterNavigation from '../FilterNavigation';
 import packageInfo from '../../../package';
@@ -32,6 +35,8 @@ import {
   InstancesIdReport,
 } from '../../reports';
 import ErrorModal from '../ErrorModal';
+
+import css from './instances.css';
 
 const INITIAL_RESULT_COUNT = 30;
 const RESULT_COUNT_INCREMENT = 30;
@@ -193,6 +198,11 @@ class InstancesView extends React.Component {
             this.generateInstancesIdReport();
           }}
         >
+          <Icon
+            icon="save"
+            size="medium"
+            iconClassName={css.actionIcon}
+          />
           <FormattedMessage id="ui-inventory.saveInstancesUIIDS" />
         </Button>
       </Fragment>

--- a/src/components/InstancesList/instances.css
+++ b/src/components/InstancesList/instances.css
@@ -1,0 +1,3 @@
+.actionIcon {
+  margin-right: 10px;
+}


### PR DESCRIPTION
## Purpose:
Add Save icon to the Save Instances UUIDs option in Action menu

[UIDEXP-32](https://issues.folio.org/browse/UIDEXP-32)

## Screenshot:
![Screenshot 2020-03-10 at 11 17 40](https://user-images.githubusercontent.com/60929399/76297669-e563fe80-62c0-11ea-9049-41413be69ee2.png)
