### PR TITLE
UIIN-1008: Rename the filter `Effective location` to `Effective locat…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Enhance preceding connected titles. Refs UIIN-960.
 * Add Save icon to the Save Instances UUIDs option in Action menu. UIDEXP-32.
 * Display succeeding/preceding titles on instance view. Refs UIIN-952, UIIN-961 and UIIN-964.
+* Rename the filter `Effective location` to `Effective location (item)`. Refs UIIN-1008.
 
 ## [1.13.1](https://github.com/folio-org/ui-inventory/tree/v1.13.1) (2019-12-11)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.0...v1.13.1)

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -417,7 +417,7 @@
   "filters.instances": "Instance",
   "filters.holdings": "Holdings",
   "filters.items": "Item",
-  "filters.effectiveLocation": "Effective location",
+  "filters.effectiveLocation": "Effective location (item)",
   "yes": "Yes",
   "no": "No",
   "unknownNoteType": "Unknown note type",


### PR DESCRIPTION
### Purpose
Rename the filter `Effective location` to `Effective location (item)`. [Story](https://issues.folio.org/browse/UIIN-1008).

**Screenshot**
![Screen Shot 2020-03-10 at 21 07 05](https://user-images.githubusercontent.com/49517355/76349818-62b85f00-6313-11ea-9688-22e90f8c715c.png)
