### PR TITLE
UIDEXP-28: Change endpoint to request instances UIIDs for report generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Add Save icon to the Save Instances UUIDs option in Action menu. UIDEXP-32.
 * Display succeeding/preceding titles on instance view. Refs UIIN-952, UIIN-961 and UIIN-964.
 * Rename the filter `Effective location` to `Effective location (item)`. Refs UIIN-1008.
+* Change endpoint to request instances UIIDs for report generation. UIDEXP-28.
 
 ## [1.13.1](https://github.com/folio-org/ui-inventory/tree/v1.13.1) (2019-12-11)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.0...v1.13.1)

--- a/package.json
+++ b/package.json
@@ -423,7 +423,8 @@
           "inventory-storage.loan-types.collection.get",
           "inventory-storage.service-points.get",
           "inventory-storage.service-points.collection.get",
-          "inventory-storage.hrid-settings.item.get"
+          "inventory-storage.hrid-settings.item.get",
+          "inventory-storage.instance-bulk.ids.get"
         ],
         "visible": true
       },

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -186,6 +186,11 @@ class InstancesView extends React.Component {
             this.startInTransitReportGeneration();
           }}
         >
+          <Icon
+            icon="reports"
+            size="medium"
+            iconClassName={css.actionIcon}
+          />
           <FormattedMessage id="ui-inventory.inTransitReport" />
         </Button>
         <Button

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -63,14 +63,14 @@ export default function buildManifestObject() {
     },
     recordsToExportIDs: {
       type: 'okapi',
-      records: 'instances',
+      records: 'ids',
       accumulate: true,
       fetch: false,
-      path: 'inventory/instances',
+      path: 'instance-bulk/ids',
       GET: {
         params: {
           query: buildQuery,
-          limit: '30',
+          limit: '2147483647',
         },
         staticFallback: { params: {} },
       },

--- a/test/bigtest/interactors/inventory.js
+++ b/test/bigtest/interactors/inventory.js
@@ -19,8 +19,9 @@ import {
   itemsInTransitReportBtnIsVisible = isVisible('#dropdown-clickable-get-report');
   clickSaveInstancesUIIDsBtn = clickable('#dropdown-clickable-get-items-uiids');
   saveInstancesUIIDsBtnIsVisible = isVisible('#dropdown-clickable-get-items-uiids');
-  saveInstancesUIIDsBtnIsVisible = isVisible('#dropdown-clickable-get-items-uiids');
   isSaveInstancesUIIDsBtnDisabled = property('#dropdown-clickable-get-items-uiids', 'disabled');
+  isSaveInstancesUIIDsIconPresent = isPresent('#dropdown-clickable-get-items-uiids [class*=icon-save]');
+  isTransitItemsReportIconPresent = isPresent('#dropdown-clickable-get-report [class*=icon-report]');
 }
 
 export default @interactor class InventoryInteractor {
@@ -53,7 +54,7 @@ export default @interactor class InventoryInteractor {
   openItem = clickable('[data-test-items] a');
   closeItem = clickable('[data-test-item-view-page] button:first-child');
 
-  headerDropdown = scoped('[class*=paneHeaderCenterInner---] [class*=dropdown---] button');
+  headerDropdown = scoped('[data-test-pane-header-actions-button]');
   headerDropdownMenu = new InventoryHeaderDropdownMenu();
 
   resourceTypeFilter = scoped('#resource', MultiSelectFilterInteractor);

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -128,7 +128,7 @@ export default function configure() {
       }
 
 
-      if (left.field === 'holdingsRecords.fullCallNumber') {
+      if (left?.field === 'holdingsRecords.fullCallNumber') {
         const holding = holdings.where({ callNumber: left.term }).models[0];
 
         return instances.where({ id: holding.instanceId });

--- a/test/bigtest/tests/export-to-csv-test.js
+++ b/test/bigtest/tests/export-to-csv-test.js
@@ -48,8 +48,16 @@ describe('Instances', () => {
       expect(inventory.headerDropdownMenu.itemsInTransitReportBtnIsVisible).to.be.true;
     });
 
+    it('should display correct icon for saving items in transit to csv', () => {
+      expect(inventory.headerDropdownMenu.isTransitItemsReportIconPresent).to.be.true;
+    });
+
     it('should display action button for saving instances UIIDs to csv', () => {
       expect(inventory.headerDropdownMenu.saveInstancesUIIDsBtnIsVisible).to.be.true;
+    });
+
+    it('should display correct icon for saving instances UIIDs to csv', () => {
+      expect(inventory.headerDropdownMenu.isSaveInstancesUIIDsIconPresent).to.be.true;
     });
 
     it('should disable action button for saving instances UIIDs if there are not items in search result', () => {
@@ -83,8 +91,8 @@ describe('Instances', () => {
         expect(requests.length).to.equal(0);
       });
 
-      it('should hide action items', () => {
-        expect(inventory.headerDropdownMenu.saveInstancesUIIDsBtnIsVisible).to.be.false;
+      it('should not hide action items', () => {
+        expect(inventory.headerDropdownMenu.saveInstancesUIIDsBtnIsVisible).to.be.true;
       });
     });
   });


### PR DESCRIPTION
## Purposes

Migrate to a new endpoint to request instances UIIDs to add more IDs to the request file.

Also, there are some extra changes:

- Fixed broken changes to fix tests executions for our purposes (Report and request file generation)

- Added icon for the action item "In transit items report"

- Covered by tests icons display