### PR TITLE
UIDEXP-33: Add options to action menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Rename the filter `Effective location` to `Effective location (item)`. Refs UIIN-1008.
 * Change endpoint to request instances UIIDs for report generation. UIDEXP-28.
 * Migrate to `stripes` `v3.0.0` and move `react-intl` to peerDependencies.
+* Add new options with icons to action menu - `Export instances (MARC)` and `Export instance (JSON)`. UIDEXP-33.
 
 ## [1.13.1](https://github.com/folio-org/ui-inventory/tree/v1.13.1) (2019-12-11)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.0...v1.13.1)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -187,7 +187,7 @@ class InstancesView extends React.Component {
           }}
         >
           <Icon
-            icon="reports"
+            icon="report"
             size="medium"
             iconClassName={css.actionIcon}
           />
@@ -209,6 +209,36 @@ class InstancesView extends React.Component {
             iconClassName={css.actionIcon}
           />
           <FormattedMessage id="ui-inventory.saveInstancesUIIDS" />
+        </Button>
+        <Button
+          disabled
+          buttonStyle="dropdownItem"
+          id="dropdown-clickable-export-marc"
+          onClick={() => {
+            onToggle();
+          }}
+        >
+          <Icon
+            icon="download"
+            size="medium"
+            iconClassName={css.actionIcon}
+          />
+          <FormattedMessage id="ui-inventory.exportInstancesMARC" />
+        </Button>
+        <Button
+          disabled
+          buttonStyle="dropdownItem"
+          id="dropdown-clickable-export-json"
+          onClick={() => {
+            onToggle();
+          }}
+        >
+          <Icon
+            icon="download"
+            size="medium"
+            iconClassName={css.actionIcon}
+          />
+          <FormattedMessage id="ui-inventory.exportInstancesJSON" />
         </Button>
       </Fragment>
     );

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -214,9 +214,6 @@ class InstancesView extends React.Component {
           disabled
           buttonStyle="dropdownItem"
           id="dropdown-clickable-export-marc"
-          onClick={() => {
-            onToggle();
-          }}
         >
           <Icon
             icon="download"
@@ -229,9 +226,6 @@ class InstancesView extends React.Component {
           disabled
           buttonStyle="dropdownItem"
           id="dropdown-clickable-export-json"
-          onClick={() => {
-            onToggle();
-          }}
         >
           <Icon
             icon="download"

--- a/test/bigtest/interactors/inventory.js
+++ b/test/bigtest/interactors/inventory.js
@@ -22,6 +22,14 @@ import {
   isSaveInstancesUIIDsBtnDisabled = property('#dropdown-clickable-get-items-uiids', 'disabled');
   isSaveInstancesUIIDsIconPresent = isPresent('#dropdown-clickable-get-items-uiids [class*=icon-save]');
   isTransitItemsReportIconPresent = isPresent('#dropdown-clickable-get-report [class*=icon-report]');
+  clickExportInstancesMARCBtnIsVisible = clickable('#dropdown-clickable-export-marc');
+  exportInstancesMARCBtnIsVisible = isVisible('#dropdown-clickable-export-marc');
+  isExportInstancesMARCBtnDisabled = property('#dropdown-clickable-export-marc', 'disabled');
+  isExportInstancesMARCIconPresent = isPresent('#dropdown-clickable-export-marc [class*=icon-download]');
+  clickExportInstancesJSONBtnIsVisible = clickable('#dropdown-clickable-export-marc');
+  exportInstancesJSONBtnIsVisible = isVisible('#dropdown-clickable-export-json');
+  isExportInstancesJSONBtnDisabled = property('#dropdown-clickable-export-json', 'disabled');
+  isExportInstancesJSONIconPresent = isPresent('#dropdown-clickable-export-json [class*=icon-download]');
 }
 
 export default @interactor class InventoryInteractor {

--- a/test/bigtest/interactors/inventory.js
+++ b/test/bigtest/interactors/inventory.js
@@ -22,11 +22,9 @@ import {
   isSaveInstancesUIIDsBtnDisabled = property('#dropdown-clickable-get-items-uiids', 'disabled');
   isSaveInstancesUIIDsIconPresent = isPresent('#dropdown-clickable-get-items-uiids [class*=icon-save]');
   isTransitItemsReportIconPresent = isPresent('#dropdown-clickable-get-report [class*=icon-report]');
-  clickExportInstancesMARCBtnIsVisible = clickable('#dropdown-clickable-export-marc');
   exportInstancesMARCBtnIsVisible = isVisible('#dropdown-clickable-export-marc');
   isExportInstancesMARCBtnDisabled = property('#dropdown-clickable-export-marc', 'disabled');
   isExportInstancesMARCIconPresent = isPresent('#dropdown-clickable-export-marc [class*=icon-download]');
-  clickExportInstancesJSONBtnIsVisible = clickable('#dropdown-clickable-export-marc');
   exportInstancesJSONBtnIsVisible = isVisible('#dropdown-clickable-export-json');
   isExportInstancesJSONBtnDisabled = property('#dropdown-clickable-export-json', 'disabled');
   isExportInstancesJSONIconPresent = isPresent('#dropdown-clickable-export-json [class*=icon-download]');

--- a/test/bigtest/tests/export-to-csv-test.js
+++ b/test/bigtest/tests/export-to-csv-test.js
@@ -11,7 +11,7 @@ import setupApplication from '../helpers/setup-application';
 import InventoryInteractor from '../interactors/inventory';
 import InstancesRouteInteractor from '../interactors/routes/instances-route';
 
-describe.only('Instances', () => {
+describe('Instances', () => {
   setupApplication({ scenarios: ['instances-filters'] });
 
   const inventory = new InventoryInteractor({

--- a/test/bigtest/tests/export-to-csv-test.js
+++ b/test/bigtest/tests/export-to-csv-test.js
@@ -11,7 +11,7 @@ import setupApplication from '../helpers/setup-application';
 import InventoryInteractor from '../interactors/inventory';
 import InstancesRouteInteractor from '../interactors/routes/instances-route';
 
-describe('Instances', () => {
+describe.only('Instances', () => {
   setupApplication({ scenarios: ['instances-filters'] });
 
   const inventory = new InventoryInteractor({
@@ -62,6 +62,30 @@ describe('Instances', () => {
 
     it('should disable action button for saving instances UIIDs if there are not items in search result', () => {
       expect(inventory.headerDropdownMenu.isSaveInstancesUIIDsBtnDisabled).to.be.true;
+    });
+
+    it('should display action button for export instances (MARC)', () => {
+      expect(inventory.headerDropdownMenu.exportInstancesMARCBtnIsVisible).to.be.true;
+    });
+
+    it('should display correct icon for export instances (MARC)', () => {
+      expect(inventory.headerDropdownMenu.isExportInstancesMARCIconPresent).to.be.true;
+    });
+
+    it('should disable action button for export instances (MARC) if there are not items in search result', () => {
+      expect(inventory.headerDropdownMenu.isExportInstancesMARCBtnDisabled).to.be.true;
+    });
+
+    it('should display action button for export instances (JSON)', () => {
+      expect(inventory.headerDropdownMenu.exportInstancesJSONBtnIsVisible).to.be.true;
+    });
+
+    it('should display correct icon for export instances (JSON)', () => {
+      expect(inventory.headerDropdownMenu.isExportInstancesJSONIconPresent).to.be.true;
+    });
+
+    it('should disable action button for export instances (JSON) if there are not items in search result', () => {
+      expect(inventory.headerDropdownMenu.isExportInstancesJSONBtnDisabled).to.be.true;
     });
 
     describe('clicking Items in transit report button', () => {

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -436,6 +436,8 @@
   "item.status.orderClosed": "Order closed",
   "inTransitReport": "In transit items report (CSV)",
   "saveInstancesUIIDS": "Save instances UUIDs",
+  "exportInstancesMARC": "Export instances (MARC)",
+  "exportInstancesJSON": "Export instance (JSON)",
   "reports.inTransitItem.barcode": "Item barcode",
   "reports.inTransitItem.title": "Title",
   "reports.inTransitItem.library": "Library",


### PR DESCRIPTION
## Purpose:
Add new options with icons to action menu - _Export instances (MARC)_ and _Export instance (JSON)_
Add unit tests

Task: [UIDEXP-33](https://issues.folio.org/browse/UIDEXP-33)

## Screenshot:
![Screenshot 2020-03-12 at 10 39 33](https://user-images.githubusercontent.com/60929399/76504487-7b7a5f00-6450-11ea-8896-26c851c45a84.png)
