### PR TITLE
UIIN-963: Add support for connected and connected succeeding titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Migrate to `stripes` `v3.0.0` and move `react-intl` to peerDependencies.
 * Add new options with icons to action menu - `Export instances (MARC)` and `Export instances (JSON)`. UIDEXP-33.
 * Add support for unconnected preceding titles. Refs UIIN-950.
+* Add support for connected and connected succeeding titles. Refs UIIN-962 and UIIN-963.
 
 ## [1.13.1](https://github.com/folio-org/ui-inventory/tree/v1.13.1) (2019-12-11)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.0...v1.13.1)

--- a/src/components/TitleField/TitleField.js
+++ b/src/components/TitleField/TitleField.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  ConnectedTitle,
+  UnconnectedTitle,
+} from '..';
+
+const TitleField = ({ field, index, fields, titleIdKey }) => {
+  const {
+    value,
+    update,
+  } = fields;
+  const instance = value[index];
+  const {
+    precedingInstanceId,
+    succeedingInstanceId,
+    connected,
+  } = instance;
+
+  const isConnected = connected || (precedingInstanceId && succeedingInstanceId);
+
+  const handleSelect = (inst) => {
+    update(index, {
+      ...inst,
+      [titleIdKey]: inst.id,
+      connected: true,
+    });
+  };
+
+  return isConnected ?
+    <ConnectedTitle
+      instance={instance}
+      onSelect={handleSelect}
+    /> :
+    <UnconnectedTitle
+      field={field}
+      onSelect={handleSelect}
+    />;
+};
+
+TitleField.propTypes = {
+  field: PropTypes.object,
+  fields: PropTypes.object,
+  index: PropTypes.number,
+  titleIdKey: PropTypes.string,
+};
+
+export default TitleField;

--- a/src/components/TitleField/index.js
+++ b/src/components/TitleField/index.js
@@ -1,0 +1,1 @@
+export { default } from './TitleField';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -8,5 +8,6 @@ export { default as InstancePlugin } from './InstancePlugin';
 export { default as ConnectedTitle } from './ConnectedTitle';
 export { default as UnconnectedTitle } from './UnconnectedTitle';
 export { default as TitleLabel } from './TitleLabel';
+export { default as TitleField } from './TitleField';
 export { default as TitlesView } from './TitlesView';
 export { PaneLoading, ViewLoading } from './Loading';

--- a/src/edit/precedingTitleFields.js
+++ b/src/edit/precedingTitleFields.js
@@ -5,56 +5,28 @@ import { FieldArray } from 'react-final-form-arrays';
 
 import { RepeatableField } from '@folio/stripes/components';
 
-import {
-  ConnectedTitle,
-  UnconnectedTitle,
-} from '../components';
+import { TitleField } from '../components';
 
-const PrecedingTitles = props => {
-  const {
-    canAdd,
-    canEdit,
-    canDelete,
-  } = props;
-
-  const fieldRenderer = (field, index, fields) => {
-    const {
-      value,
-      update,
-    } = fields;
-    const instance = value[index];
-
-    return instance.precedingInstanceId ?
-      <ConnectedTitle
-        instance={instance}
-        onSelect={inst => update(index, inst)}
-      /> :
-      <UnconnectedTitle
-        field={field}
-        onSelect={inst => update(index, inst)}
-      />;
-  };
-
-  return (
-    <FieldArray
-      addLabel={<FormattedMessage id="ui-inventory.addPrecedingTitle" />}
-      legend={<FormattedMessage id="ui-inventory.precedingTitles" />}
-      id="clickable-add-precedingTitle"
-      component={RepeatableField}
-      name="precedingTitles"
-      canAdd={canAdd}
-      canRemove={canDelete}
-      canEdit={canEdit}
-      renderField={fieldRenderer}
-    />
-  );
-};
+const PrecedingTitles = ({ canAdd, canEdit, canDelete }) => (
+  <FieldArray
+    addLabel={<FormattedMessage id="ui-inventory.addPrecedingTitle" />}
+    legend={<FormattedMessage id="ui-inventory.precedingTitles" />}
+    id="clickable-add-precedingTitle"
+    component={RepeatableField}
+    name="precedingTitles"
+    canAdd={canAdd}
+    canRemove={canDelete}
+    canEdit={canEdit}
+    renderField={(field, index, fields) => <TitleField field={field} index={index} fields={fields} titleIdKey="precedingInstanceId" />}
+  />
+);
 
 PrecedingTitles.propTypes = {
   canAdd: PropTypes.bool,
   canEdit: PropTypes.bool,
   canDelete: PropTypes.bool,
 };
+
 PrecedingTitles.defaultProps = {
   canAdd: true,
   canEdit: true,

--- a/src/edit/succeedingTitleFields.js
+++ b/src/edit/succeedingTitleFields.js
@@ -1,45 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { FieldArray } from 'react-final-form-arrays';
 
-import { TextField } from '@folio/stripes/components';
+import { RepeatableField } from '@folio/stripes/components';
 
-import RepeatableField from '../components/RepeatableField';
+import { TitleField } from '../components';
 
-const SucceedingTitles = props => {
-  const {
-    canAdd,
-    canEdit,
-    canDelete,
-  } = props;
-
-  return (
-    <RepeatableField
-      name="succeedingTitles"
-      label={<FormattedMessage id="ui-inventory.succeedingTitles" />}
-      addLabel={<FormattedMessage id="ui-inventory.addSucceedingTitle" />}
-      addButtonId="clickable-add-succeedingTitle"
-      template={[
-        {
-          name: 'subInstanceId',
-          label: 'FOLIO ID',
-          component: TextField,
-          required: true,
-          disabled: !canEdit
-        },
-      ]}
-      newItemTemplate={{ subInstanceId: '' }}
-      canAdd={canAdd}
-      canDelete={canDelete}
-    />
-  );
-};
+const SucceedingTitles = ({ canAdd, canEdit, canDelete }) => (
+  <FieldArray
+    addLabel={<FormattedMessage id="ui-inventory.addSucceedingTitle" />}
+    legend={<FormattedMessage id="ui-inventory.succeedingTitles" />}
+    id="clickable-add-succeedingTitle"
+    component={RepeatableField}
+    name="succeedingTitles"
+    canAdd={canAdd}
+    canRemove={canDelete}
+    canEdit={canEdit}
+    renderField={(field, index, fields) => <TitleField field={field} index={index} fields={fields} titleIdKey="succeedingInstanceId" />}
+  />
+);
 
 SucceedingTitles.propTypes = {
   canAdd: PropTypes.bool,
   canEdit: PropTypes.bool,
   canDelete: PropTypes.bool,
 };
+
 SucceedingTitles.defaultProps = {
   canAdd: true,
   canEdit: true,

--- a/src/utils.js
+++ b/src/utils.js
@@ -354,7 +354,6 @@ export const marshalTitles = (instance, identifierTypesByName, type) => {
 
   instance[titleAttr] = (instance?.[titleAttr] ?? []).map((inst) => {
     const {
-      id,
       title,
       hrid,
     } = inst;
@@ -362,7 +361,7 @@ export const marshalTitles = (instance, identifierTypesByName, type) => {
 
     return inst[titleIdKey] ?
       // connected title
-      { [titleIdKey]: id } :
+      { [titleIdKey]: inst[titleIdKey] } :
       // unconnected title
       {
         title,
@@ -392,10 +391,8 @@ export const marshalInstance = (instance, identifierTypesByName) => {
  *
  */
 export const unmarshalInstance = (instance, identifierTypesById) => {
-  const inst = cloneDeep(instance);
+  unmarshalTitles(instance, identifierTypesById, 'preceding');
+  unmarshalTitles(instance, identifierTypesById, 'succeeding');
 
-  unmarshalTitles(inst, identifierTypesById, 'preceding');
-  unmarshalTitles(inst, identifierTypesById, 'succeeding');
-
-  return inst;
+  return instance;
 };

--- a/test/bigtest/interactors/instance-edit-page.js
+++ b/test/bigtest/interactors/instance-edit-page.js
@@ -51,6 +51,17 @@ import {
   fillISSNField = fillable('[name="precedingTitles[0].issn"]');
 }
 
+@interactor class SucceedingTitles {
+  succeedingTitlesCount = count('[data-test-repeater-field-row]');
+  clickAddSucceedingTitle = clickable('#clickable-add-succeedingTitle-add-button');
+  clickAddInstance = clickable('[data-test-plugin-find-record-button]');
+  instanceName = text('[data-test-connected-instance-title]');
+
+  fillTitleField = fillable('[name="succeedingTitles[0].title"]');
+  fillISBNField = fillable('[name="succeedingTitles[0].isbn"]');
+  fillISSNField = fillable('[name="succeedingTitles[0].issn"]');
+}
+
 @interactor class Foo { }
 
 @interactor class InstanceEditPage {
@@ -83,6 +94,7 @@ import {
 
   contributors = new Contributors();
   precedingTitles = new PrecedingTitles();
+  succeedingTitles = new SucceedingTitles();
 
   // The BigTest documentation shows examples like
   //   let input = new Interactor('input');

--- a/test/bigtest/tests/instance-edit-page-test.js
+++ b/test/bigtest/tests/instance-edit-page-test.js
@@ -216,4 +216,40 @@ describe('InstanceEditPage', () => {
       });
     });
   });
+
+  describe('clicking on "add succeeding title"', () => {
+    const prevCount = InstanceEditPage.succeedingTitles.succeedingTitlesCount;
+
+    beforeEach(async () => {
+      await InstanceEditPage.succeedingTitles.clickAddSucceedingTitle();
+    });
+
+    it('should increase number of succeeding title"', () => {
+      expect(InstanceEditPage.succeedingTitles.succeedingTitlesCount).to.be.gt(prevCount);
+    });
+
+    describe('saving unconnected titles', () => {
+      beforeEach(async () => {
+        await InstanceEditPage.succeedingTitles.fillTitleField('title 1');
+        await InstanceEditPage.succeedingTitles.fillISBNField('isbn1');
+        await InstanceEditPage.succeedingTitles.fillISSNField('issn1');
+        await InstanceEditPage.selectInstanceType('still image');
+        await InstanceEditPage.saveInstance();
+      });
+
+      it('should save instance and go back to instance view', function () {
+        expect(this.location.search).to.not.include('layer=edit');
+      });
+    });
+
+    describe('clicking add instance', () => {
+      beforeEach(async () => {
+        await InstanceEditPage.succeedingTitles.clickAddInstance();
+      });
+
+      it('should add instance', () => {
+        expect(InstanceEditPage.succeedingTitles.instanceName).to.be.equal('Fake instance');
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Purpose
Add support for connected and connected succeeding titles.

### Screenshot
![succeeding_titles](https://user-images.githubusercontent.com/63545/76555855-d3c05980-646e-11ea-80de-f78716b9d435.png)

### Links
https://issues.folio.org/browse/UIIN-962
https://issues.folio.org/browse/UIIN-963