### PR TITLE
UIDEXP-13, UIDEXP-2: Add instances CQL query report generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [2.0.1] IN PROGRESS
 
 * Import `stripes-util` via `stripes`. Fixes UIIN-1021 and UIIN-1029.
+* Add CQL query report generation to search instances. UIDEXP-13 and UIDEXP-2
 
 ## [2.0.0](https://github.com/folio-org/ui-inventory/tree/v2.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.1...v2.0.0)

--- a/src/reports/exportStringToCSV.js
+++ b/src/reports/exportStringToCSV.js
@@ -1,0 +1,14 @@
+import moment from 'moment';
+
+import { exportCsv } from '@folio/stripes/util';
+
+const exportStringToCSV = str => {
+  const record = [{ str }];
+
+  exportCsv(record, {
+    header: false,
+    filename: 'SearchInstanceCQLQuery' + moment().format(),
+  });
+};
+
+export default exportStringToCSV;

--- a/src/reports/index.js
+++ b/src/reports/index.js
@@ -1,2 +1,3 @@
 export { default as InTransitItemReport } from './InTransitItemReport';
 export { default as InstancesIdReport } from './InstancesIdReport';
+export { default as exportStringToCSV } from './exportStringToCSV';

--- a/src/routes/InstancesRoute.js
+++ b/src/routes/InstancesRoute.js
@@ -10,7 +10,7 @@ import { InstancesView } from '../views';
 import {
   getFilterConfig,
 } from '../filterConfig';
-import buildManifestObject from './buildManifestObject';
+import { buildManifestObject } from './buildManifestObject';
 import DataContext from '../contexts/DataContext';
 
 class InstancesRoute extends React.Component {

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -12,10 +12,10 @@ import {
 
 const INITIAL_RESULT_COUNT = 100;
 
-function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
+export function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
   const { indexes, sortMap, filters } = getFilterConfig(queryParams.segment);
   const query = { ...resourceData.query };
-  const queryIndex = get(queryParams, 'qindex', 'all');
+  const queryIndex = queryParams?.qindex ?? 'all';
   const queryValue = get(queryParams, 'query', '');
   let queryTemplate = getQueryTemplate(queryIndex, indexes);
 
@@ -38,7 +38,7 @@ function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
   )(queryParams, pathComponents, resourceData, logger, props);
 }
 
-export default function buildManifestObject() {
+export function buildManifestObject() {
   return {
     numFiltersLoaded: { initialValue: 1 }, // will be incremented as each filter loads
     query: {

--- a/test/bigtest/interactors/inventory.js
+++ b/test/bigtest/interactors/inventory.js
@@ -8,6 +8,7 @@ import {
   isPresent,
   isVisible,
   property,
+  Interactor,
 } from '@bigtest/interactor';
 
 import {
@@ -21,6 +22,9 @@ import {
   saveInstancesUIIDsBtnIsVisible = isVisible('#dropdown-clickable-get-items-uiids');
   isSaveInstancesUIIDsBtnDisabled = property('#dropdown-clickable-get-items-uiids', 'disabled');
   isSaveInstancesUIIDsIconPresent = isPresent('#dropdown-clickable-get-items-uiids [class*=icon-save]');
+  saveInstancesCQLQueryBtn = new Interactor('#dropdown-clickable-get-cql-query');
+  isSaveInstancesCQLQueryDisabled = property('#dropdown-clickable-get-cql-query', 'disabled');
+  isSaveInstancesCQLQueryIconPresent = isPresent('#dropdown-clickable-get-cql-query [class*=icon-search]');
   isTransitItemsReportIconPresent = isPresent('#dropdown-clickable-get-report [class*=icon-report]');
   exportInstancesMARCBtnIsVisible = isVisible('#dropdown-clickable-export-marc');
   isExportInstancesMARCBtnDisabled = property('#dropdown-clickable-export-marc', 'disabled');
@@ -65,4 +69,8 @@ export default @interactor class InventoryInteractor {
   resourceTypeFilter = scoped('#resource', MultiSelectFilterInteractor);
   formatFilter = scoped('#format', MultiSelectFilterInteractor);
   modeFilter = scoped('#mode', MultiSelectFilterInteractor);
+
+  whenLoaded() {
+    return this.when(() => this.isLoaded);
+  }
 }

--- a/test/bigtest/tests/export-to-csv-test.js
+++ b/test/bigtest/tests/export-to-csv-test.js
@@ -35,6 +35,22 @@ describe('Instances', () => {
     it('should enable action button for saving instances UIIDs if there are items in search result', () => {
       expect(inventory.headerDropdownMenu.isSaveInstancesUIIDsBtnDisabled).to.be.false;
     });
+
+    it('should enable action button for saving instances CQL query if there are items in search result', () => {
+      expect(inventory.headerDropdownMenu.isSaveInstancesCQLQueryDisabled).to.be.false;
+    });
+
+    describe('clicking saving instances CQL query button', () => {
+      beforeEach(async function () {
+        // Timeout to skip enabling animation
+        await new Promise((resolve) => { setTimeout(() => resolve(), 3000); });
+        await inventory.headerDropdownMenu.saveInstancesCQLQueryBtn.click();
+      });
+
+      it('should hide action items', () => {
+        expect(inventory.headerDropdownMenu.saveInstancesCQLQueryBtn.isVisible).to.be.false;
+      });
+    });
   });
 
   describe('clicking on header dropdown button', () => {
@@ -62,6 +78,14 @@ describe('Instances', () => {
 
     it('should disable action button for saving instances UIIDs if there are not items in search result', () => {
       expect(inventory.headerDropdownMenu.isSaveInstancesUIIDsBtnDisabled).to.be.true;
+    });
+
+    it('should display correct icon for saving instances CQL query to csv', () => {
+      expect(inventory.headerDropdownMenu.isSaveInstancesCQLQueryIconPresent).to.be.true;
+    });
+
+    it('should disable action button for saving instances CQL query if there are no items in search result', () => {
+      expect(inventory.headerDropdownMenu.isSaveInstancesCQLQueryDisabled).to.be.true;
     });
 
     it('should display action button for export instances (MARC)', () => {

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -436,6 +436,7 @@
   "item.status.orderClosed": "Order closed",
   "inTransitReport": "In transit items report (CSV)",
   "saveInstancesUIIDS": "Save instances UUIDs",
+  "saveInstancesCQLQuery": "Save instances CQL query",
   "exportInstancesInMARC": "Export instances (MARC)",
   "exportInstancesInJSON": "Export instances (JSON)",
   "reports.inTransitItem.barcode": "Item barcode",


### PR DESCRIPTION
## Purposes

- Add CQL search query report generation. [Story](https://issues.folio.org/browse/UIDEXP-2) 
- Add the added action item disabling if there are not instances in the search result. [Story](https://issues.folio.org/browse/UIDEXP-13)

## Screenshots
![Screen Shot 2020-03-19 at 18 09 38](https://user-images.githubusercontent.com/50317804/77088422-19e86080-6a0d-11ea-9132-17df222cb5a0.png)

![Screen Shot 2020-03-19 at 18 09 59](https://user-images.githubusercontent.com/50317804/77088428-1bb22400-6a0d-11ea-90d8-e0e8bf6b4996.png)

![Screen Shot 2020-03-19 at 18 10 20](https://user-images.githubusercontent.com/50317804/77088429-1ce35100-6a0d-11ea-80f5-2dddee4db0ff.png)


