### PR TITLE
UIIN-1022: Display the value in the 'Nature of content' field instead…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * Add support for unconnected preceding titles. Refs UIIN-950.
 * Add support for connected and connected succeeding titles. Refs UIIN-962 and UIIN-963.
 * Add `parse` to `discoverySuppress` and `staffSuppress` filters. Refs STCOM-654.
+* Display the value in the 'Nature of content' field instead of the UUID. Fixes UIIN-1022.
 
 ## [1.13.1](https://github.com/folio-org/ui-inventory/tree/v1.13.1) (2019-12-11)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.0...v1.13.1)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -679,6 +679,9 @@ class ViewInstance extends React.Component {
 
     const contributors = get(instance, ['contributors'], []);
 
+    const natureOfContentTerms = get(instance, 'natureOfContentTermIds', [])
+      .map(termId => this.refLookup(referenceTables.natureOfContentTerms, termId).name);
+
     const descriptiveData = {
       publication: get(instance, ['publication'], []),
       editions: get(instance, ['editions'], []),
@@ -686,7 +689,7 @@ class ViewInstance extends React.Component {
       resourceTypeTerm: this.refLookup(referenceTables.instanceTypes, get(instance, ['instanceTypeId'])).name || '-',
       resourceTypeCode: this.refLookup(referenceTables.instanceTypes, get(instance, ['instanceTypeId'])).code || '-',
       resourceTypeSource: this.refLookup(referenceTables.instanceTypes, get(instance, ['instanceTypeId'])).source || '-',
-      natureOfContentTermIds: get(instance, ['natureOfContentTermIds'], []),
+      natureOfContentTerms: natureOfContentTerms || [],
       instanceFormatIds: get(instance, ['instanceFormatIds'], []),
       languages: get(instance, ['languages'], []),
       publicationFrequency: get(instance, ['publicationFrequency'], []),
@@ -1239,10 +1242,13 @@ class ViewInstance extends React.Component {
           </Row>
 
           <Row>
-            <Col xs={3}>
+            <Col
+              data-test-nature-of-content-terms
+              xs={3}
+            >
               <KeyValue
                 label={<FormattedMessage id="ui-inventory.natureOfContentTerms" />}
-                value={convertArrayToBlocks(descriptiveData.natureOfContentTermIds)}
+                value={convertArrayToBlocks(descriptiveData.natureOfContentTerms)}
               />
             </Col>
           </Row>

--- a/test/bigtest/interactors/KeyValue.js
+++ b/test/bigtest/interactors/KeyValue.js
@@ -1,0 +1,11 @@
+import {
+  interactor,
+  scoped,
+} from '@bigtest/interactor';
+
+@interactor class KeyValue {
+  label = scoped('div');
+  value = scoped('div:nth-child(2)');
+}
+
+export default KeyValue;

--- a/test/bigtest/interactors/instance-view-page.js
+++ b/test/bigtest/interactors/instance-view-page.js
@@ -13,6 +13,8 @@ import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tes
 // eslint-disable-next-line import/no-extraneous-dependencies
 import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumnList/tests/interactor';
 
+import KeyValue from './KeyValue';
+
 @interactor class HeaderDropdown {
   click = clickable('button');
 }
@@ -64,6 +66,7 @@ import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumn
   hasExpandAll = isPresent('[data-test-expand-all] button');
   precedingTitles = new MultiColumnListInteractor('#precedingTitles');
   succeedingTitles = new MultiColumnListInteractor('#succeedingTitles');
+  natureOfContent = scoped('[data-test-nature-of-content-terms] div', KeyValue);
 
   notes = collection('[id^="list-instance-notes"]', MultiColumnListInteractor);
 

--- a/test/bigtest/network/factories/nature-of-content-term.js
+++ b/test/bigtest/network/factories/nature-of-content-term.js
@@ -1,0 +1,3 @@
+import ApplicationFactory from './application';
+
+export default ApplicationFactory.extend();

--- a/test/bigtest/tests/instance-view-page-test.js
+++ b/test/bigtest/tests/instance-view-page-test.js
@@ -508,6 +508,23 @@ describe('InstanceViewPage', () => {
     });
   });
 
+  describe('Nature of content field', () => {
+    setupApplication();
+
+    const name = 'audiobook';
+
+    beforeEach(async function () {
+      const natureOfContentTerm = this.server.create('nature-of-content-term', { name });
+      const instance = this.server.create('instance', { natureOfContentTermIds: [natureOfContentTerm.id] });
+      this.visit(`/inventory/view/${instance.id}`);
+      await InstanceViewPage.whenLoaded();
+    });
+
+    it('should display nature of content value', () => {
+      expect(InstanceViewPage.natureOfContent.value.text).to.equal(name);
+    });
+  });
+
   describe('Empty fields', () => {
     setupApplication({ scenarios: ['fetch-items-success'] });
 
@@ -564,6 +581,12 @@ describe('InstanceViewPage', () => {
 
       it('has correct value - dash', () => {
         expect(InstanceViewPage.subjectsList.rows(0).cells(0).content).to.be.equal('-');
+      });
+    });
+
+    describe('Nature of content field', () => {
+      it('should display dash', () => {
+        expect(InstanceViewPage.natureOfContent.value.text).to.equal('-');
       });
     });
   });


### PR DESCRIPTION
## Purpose
Display the value in the 'Nature of content' field instead of the UUID. Story [UIIN-1022](https://issues.folio.org/browse/UIIN-1022).

**What was done**
- fixed a bug that caused to display of UUID in the 'Nature of content' field instead of the name;
- added tests for the 'Nature of content' field.

### Screenshots

**Before**

![Before](https://user-images.githubusercontent.com/49517355/77564680-c7ef8100-6ecb-11ea-90d9-0e3a5ca37cc8.png)

**After**

![Screen Shot 2020-03-25 at 17 05 19](https://user-images.githubusercontent.com/49517355/77563658-392e3480-6eca-11ea-8b35-1a40920ba0ba.png)
