### PR TITLE
UIIN-994: Remove 'validate on blur' param from ItemForm

### DIFF
--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -993,6 +993,5 @@ ItemForm.defaultProps = {
 export default stripesFinalForm({
   validate,
   mutators,
-  validateOnBlur: true,
   navigationCheck: true,
 })(ItemForm);


### PR DESCRIPTION
This makes validation behavior for item form consistent with instance and holdings forms. 