### PR TITLE
CHAL-91 show "Load more" button

### DIFF
--- a/package.json
+++ b/package.json
@@ -587,11 +587,11 @@
     "@bigtest/mocha": "^0.5.1",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes": "^2.12.0",
+    "@folio/stripes": "^2.12.2",
     "@folio/stripes-cli": "^1.13.0",
     "@folio/stripes-core": "^3.0.1",
-    "@folio/stripes-smart-components": "^2.12.0",
-    "@folio/stripes-components": "^5.9.0",
+    "@folio/stripes-smart-components": "^2.12.2",
+    "@folio/stripes-components": "^5.9.3",
     "babel-eslint": "^9.0.0",
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
@@ -618,7 +618,7 @@
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {
-    "@folio/stripes": "^2.12.0",
+    "@folio/stripes": "^2.12.2",
     "react": "*",
     "react-router": "^5.0.1",
     "react-router-dom": "^5.0.1"

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -260,6 +260,8 @@ class InstancesView extends React.Component {
             onSelectRow={onSelectRow}
             renderFilters={renderFilters}
             onFilterChange={this.onFilterChangeHandler}
+            pageAmount={100}
+            pagingType="click"
           />
         </div>
         <ErrorModal

--- a/src/routes/HoldingsRoute.js
+++ b/src/routes/HoldingsRoute.js
@@ -45,11 +45,12 @@ function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
 
 class HoldingsRoute extends React.Component {
   static manifest = Object.freeze({
+    resultOffset: { initialValue: 0 },
     records: {
       type: 'okapi',
       records: 'instances',
-      recordsRequired: '%{resultCount}',
-      perRequest: 30,
+      resultOffset: '%{resultOffset}',
+      perRequest: 100,
       path: 'inventory/instances',
       GET: {
         params: { query: buildQuery },

--- a/src/routes/InstancesRoute.js
+++ b/src/routes/InstancesRoute.js
@@ -57,11 +57,12 @@ class InstancesRoute extends React.Component {
   };
 
   static manifest = Object.freeze({
+    resultOffset: { initialValue: 0 },
     records: {
       type: 'okapi',
       records: 'instances',
-      recordsRequired: '%{resultCount}',
-      perRequest: 30,
+      resultOffset: '%{resultOffset}',
+      perRequest: 100,
       path: 'inventory/instances',
       GET: {
         params: { query: buildQuery },

--- a/src/routes/ItemsRoute.js
+++ b/src/routes/ItemsRoute.js
@@ -45,11 +45,12 @@ function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
 
 class ItemsRoute extends React.Component {
   static manifest = Object.freeze({
+    resultOffset: { initialValue: 0 },
     records: {
       type: 'okapi',
       records: 'instances',
-      recordsRequired: '%{resultCount}',
-      perRequest: 30,
+      resultOffset: '%{resultOffset}',
+      perRequest: 100,
       path: 'inventory/instances',
       GET: {
         params: { query: buildQuery },


### PR DESCRIPTION
Replace infinite scroll with a "Load more" button in the results list.
Infinite scroll can behave poorly when results lists are long.

Refs [CHAL-91](https://issues.folio.org/browse/CHAL-91)