### PR TITLE
UIIN-788: Add filter for instance date created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add validation for notes in inventory, holdings, item forms. Refs UIIN-994.
 * Use correct operator when searching by item status and hrid. Fixes UIIN-1048, UIIN-1051, UIIN-1052, UIIN-1053.
 * Register `instanceFormatIds` filter. Fixes UIIN-1057.
+* Add filter for instance date created. Refs UIIN-788.
 
 ## [2.0.0](https://github.com/folio-org/ui-inventory/tree/v2.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.1...v2.0.0)

--- a/src/components/InstanceFilters/InstanceFilters.js
+++ b/src/components/InstanceFilters/InstanceFilters.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+
 import {
   Accordion,
   FilterAccordionHeader,
@@ -8,10 +9,16 @@ import {
 import {
   CheckboxFilter,
   MultiSelectionFilter,
+  DateRangeFilter,
 } from '@folio/stripes/smart-components';
 
 import languages from '../../data/languages';
-import { filterItemsBy } from '../../utils';
+import {
+  filterItemsBy,
+  retrieveDatesFromDateRangeFilterString,
+  makeDateRangeFilterString,
+} from '../../utils';
+import { DATE_FORMAT } from '../../constants';
 
 export default class InstanceFilters extends React.Component {
   static propTypes = {
@@ -40,6 +47,7 @@ export default class InstanceFilters extends React.Component {
         natureOfContent = [],
         discoverySuppress = [],
         staffSuppress = [],
+        createdDate = [],
       },
       data: {
         locations,
@@ -223,6 +231,23 @@ export default class InstanceFilters extends React.Component {
             dataOptions={suppressedOptions}
             selectedValues={discoverySuppress}
             onChange={onChange}
+          />
+        </Accordion>
+        <Accordion
+          label={<FormattedMessage id="ui-inventory.createdDate" />}
+          id="createdDate"
+          name="createdDate"
+          closedByDefault
+          header={FilterAccordionHeader}
+          displayClearButton={createdDate.length > 0}
+          onClearFilter={() => onClear('createdDate')}
+        >
+          <DateRangeFilter
+            name="createdDate"
+            dateFormat={DATE_FORMAT}
+            selectedValues={retrieveDatesFromDateRangeFilterString(createdDate[0])}
+            onChange={onChange}
+            makeFilterString={makeDateRangeFilterString}
           />
         </Accordion>
       </React.Fragment>

--- a/src/constants.js
+++ b/src/constants.js
@@ -79,3 +79,5 @@ export const indentifierTypeNames = {
   ISBN: 'ISBN',
   ISSN: 'ISSN',
 };
+
+export const DATE_FORMAT = 'YYYY-MM-DD';

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -4,6 +4,8 @@ import {
   itemFilterRenderer,
 } from './components';
 
+import { buildDateRangeQuery } from './utils';
+
 // Function which takes a filter name and returns
 // another function which can be used in filter config
 // to parse a given filter into a CQL manually.
@@ -66,6 +68,12 @@ export const instanceFilterConfig = [
     cql: 'discoverySuppress',
     values: [],
     parse: parseFilter('discoverySuppress'),
+  },
+  {
+    name: 'createdDate',
+    cql: 'metadata.createdDate',
+    values: [],
+    parse: buildDateRangeQuery('createdDate'),
   },
 ];
 

--- a/test/bigtest/interactors/inventory.js
+++ b/test/bigtest/interactors/inventory.js
@@ -11,6 +11,8 @@ import {
   Interactor,
 } from '@bigtest/interactor';
 
+import DateRangeFilterInteractor from '@folio/stripes-smart-components/lib/SearchAndSort/components/DateRangeFilter/tests/interactor';
+
 import {
   MultiSelectFilterInteractor,
 } from './filters';
@@ -32,6 +34,14 @@ import {
   exportInstancesJSONBtnIsVisible = isVisible('#dropdown-clickable-export-json');
   isExportInstancesJSONBtnDisabled = property('#dropdown-clickable-export-json', 'disabled');
   isExportInstancesJSONIconPresent = isPresent('#dropdown-clickable-export-json [class*=icon-download]');
+}
+
+@interactor class CreatedDateFilterInteractor {
+  static defaultScope = '#createdDate';
+
+  clear = clickable('button[icon="times-circle-solid"]');
+  open = clickable('[id*="accordion-toggle-button-"]');
+  filter = new DateRangeFilterInteractor();
 }
 
 export default @interactor class InventoryInteractor {
@@ -69,6 +79,7 @@ export default @interactor class InventoryInteractor {
   resourceTypeFilter = scoped('#resource', MultiSelectFilterInteractor);
   formatFilter = scoped('#format', MultiSelectFilterInteractor);
   modeFilter = scoped('#mode', MultiSelectFilterInteractor);
+  createdDate = new CreatedDateFilterInteractor();
 
   whenLoaded() {
     return this.when(() => this.isLoaded);

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -122,6 +122,16 @@ export default function configure() {
         right,
       } = cqlParser.tree;
 
+      if (left?.field === 'metadata.createdDate' && right?.field === 'metadata.createdDate') {
+        return instances.all().filter(inst => {
+          const createdDate = new Date(inst.metadata.createdDate);
+          const from = new Date(left.term);
+          const to = new Date(right.term);
+
+          return createdDate >= from && createdDate < to;
+        });
+      }
+
       if (left?.field === 'title' && right?.field === 'contributors') {
         return instances.all().filter(inst => inst.title.match(left.term) &&
           inst.contributors[0].name.match(right.term));

--- a/test/bigtest/network/factories/instance.js
+++ b/test/bigtest/network/factories/instance.js
@@ -8,6 +8,7 @@ import Factory from './application';
 const {
   lorem,
   name,
+  date,
 } = faker;
 
 export default Factory.extend({
@@ -28,6 +29,10 @@ export default Factory.extend({
   parentInstances: () => [],
   statisticalCodeIds: () => [],
   hrid: i => `in0000000000${i + 1}`,
+  metadata: {
+    createdDate: date.between('2019-01-01', '2020-01-01'),
+    updatedDate: date.between('2019-01-01', '2020-01-01'),
+  },
 
   afterCreate(instance, server) {
     instance.identifiers.forEach(identifier => {

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -469,6 +469,7 @@
   "updatedSource": "Updated source",
   "createdDateAndTime": "Created date and time",
   "createdSource": "Created source",
+  "createdDate": "Date created",
   "precedingTitle": "Preceding title",
   "succeedingTitle": "Succeeding title",
   "identifierType": "Identifier type",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Add the ability to filter instances by date created. Story [UIIN-788](https://issues.folio.org/browse/UIIN-788).
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
 -->

## Approach
The `Date created` filter implementation was based on the use of the DateRangeFilter component from the `stripes-smart-components` module.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

### Screenshot
![Screen Shot 2020-03-31 at 20 51 52](https://user-images.githubusercontent.com/49517355/78061388-d93a0100-7395-11ea-9a23-88ccc511b5ee.png)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
