### PR TITLE
UIIN-1064: Improve buildOptionalBooleanQuery performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Use correct operator when searching by item status and hrid. Fixes UIIN-1048, UIIN-1051, UIIN-1052, UIIN-1053.
 * Register `instanceFormatIds` filter. Fixes UIIN-1057.
 * Add filter for instance date created. Refs UIIN-788.
+* Improve `buildOptionalBooleanQuery` performance by using `cql.allRecords=1` and `==` operator. Fixes UIIN-1064.
 
 ## [2.0.0](https://github.com/folio-org/ui-inventory/tree/v2.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.1...v2.0.0)

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -4,22 +4,10 @@ import {
   itemFilterRenderer,
 } from './components';
 
-import { buildDateRangeQuery } from './utils';
-
-// Function which takes a filter name and returns
-// another function which can be used in filter config
-// to parse a given filter into a CQL manually.
-const parseFilter = name => values => {
-  if (values.length === 2) {
-    return `${name}="*"`;
-  } else if (values.length === 1 && values[0] === 'false') {
-    return `${name}="*" not ${name}="true"`;
-  } else {
-    const joinedValues = values.map(v => `"${v}"`).join(' or ');
-
-    return `${name}=${joinedValues}`;
-  }
-};
+import {
+  buildDateRangeQuery,
+  buildOptionalBooleanQuery,
+} from './utils';
 
 export const instanceFilterConfig = [
   {
@@ -61,13 +49,13 @@ export const instanceFilterConfig = [
     name: 'staffSuppress',
     cql: 'staffSuppress',
     values: [],
-    parse: parseFilter('staffSuppress'),
+    parse: buildOptionalBooleanQuery('staffSuppress'),
   },
   {
     name: 'discoverySuppress',
     cql: 'discoverySuppress',
     values: [],
-    parse: parseFilter('discoverySuppress'),
+    parse: buildOptionalBooleanQuery('discoverySuppress'),
   },
   {
     name: 'createdDate',
@@ -125,7 +113,7 @@ export const holdingFilterConfig = [
     name: 'discoverySuppress',
     cql: 'holdingsRecords.discoverySuppress',
     values: [],
-    parse: parseFilter('holdingsRecords.discoverySuppress'),
+    parse: buildOptionalBooleanQuery('holdingsRecords.discoverySuppress'),
   },
 ];
 
@@ -167,7 +155,7 @@ export const itemFilterConfig = [
     name: 'discoverySuppress',
     cql: 'item.discoverySuppress',
     values: [],
-    parse: parseFilter('item.discoverySuppress'),
+    parse: buildOptionalBooleanQuery('item.discoverySuppress'),
   }
 ];
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -115,6 +115,21 @@ export const buildDateRangeQuery = name => values => {
   return `metadata.${name}>="${startDateString}" and metadata.${name}<="${endDateString}"`;
 };
 
+// Function which takes a filter name and returns
+// another function which can be used in filter config
+// to parse a given filter into a CQL manually.
+export const buildOptionalBooleanQuery = name => values => {
+  if (values.length === 2) {
+    return 'cql.allRecords=1';
+  } else if (values.length === 1 && values[0] === 'false') {
+    return `cql.allRecords=1 not ${name}=="true"`;
+  } else {
+    const joinedValues = values.map(v => `"${v}"`).join(' or ');
+
+    return `${name}==${joinedValues}`;
+  }
+};
+
 export function filterItemsBy(name) {
   return (filter, list) => {
     if (!filter) {


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1064

This PR changes the `buildOptionalBooleanQuery` to use `cql.allRecords=1` in cases when both `yes` and `no` boolean filters are chosen. It also changes the `=` operator to `==` for other cases.

@bohdan-suprun could you please take a look at this and let us know if this looks ok from the server side point of you?