### PR TITLE
UIIN-1021: Import stripes-util via stripes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [2.0.1] IN PROGRESS
 
 * Use correct operator when searching by item status and hrid. Fixes UIIN-1048, UIIN-1051, UIIN-1052, UIIN-1053.
+* Import `stripes-util` via `stripes`. Fixes UIIN-1021 and UIIN-1029.
 
 ## [2.0.0](https://github.com/folio-org/ui-inventory/tree/v2.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.1...v2.0.0)

--- a/package.json
+++ b/package.json
@@ -609,7 +609,6 @@
   },
   "dependencies": {
     "@folio/react-intl-safe-html": "^1.0.2",
-    "@folio/stripes-util": "^1.6.0",
     "final-form": "^4.18.2",
     "final-form-arrays": "^3.0.1",
     "lodash": "^4.17.4",

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -34,7 +34,7 @@ import {
   LocationLookup,
   ViewMetaData,
 } from '@folio/stripes/smart-components';
-import { effectiveCallNumber } from '@folio/stripes-util';
+import { effectiveCallNumber } from '@folio/stripes/util';
 
 import RepeatableField from '../../components/RepeatableField';
 import ElectronicAccessFields from '../electronicAccessFields';

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -15,7 +15,7 @@ import Link from 'react-router-dom/Link';
 import { FormattedMessage } from 'react-intl';
 
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
-import { effectiveCallNumber } from '@folio/stripes-util';
+import { effectiveCallNumber } from '@folio/stripes/util';
 
 import {
   Pane,


### PR DESCRIPTION
Correctly import `@folio/stripes-util` (it's a sub-project of `@folio/stripes`).
This also means we'll get the correct/current version of `effectiveCallNumber`.


Refs [UIIN-1021](https://issues.folio.org/browse/UIIN-1021), [UIIN-1029](https://issues.folio.org/browse/UIIN-1029)

