### PR TITLE
UIIN-984: Show item status date with status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Register `instanceFormatIds` filter. Fixes UIIN-1057.
 * Add filter for instance date created. Refs UIIN-788.
 * Improve `buildOptionalBooleanQuery` performance by using `cql.allRecords=1` and `==` operator. Fixes UIIN-1064.
+* Display item status date with status. Refs UIIN-984.
 
 ## [2.0.0](https://github.com/folio-org/ui-inventory/tree/v2.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.1...v2.0.0)

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -396,8 +396,6 @@ class ItemView extends React.Component {
       );
     }
 
-    const itemStatusDate = get(item, ['status', 'date']);
-
     const refLookup = (referenceTable, id) => {
       const ref = (referenceTable && id) ? referenceTable.find(record => record.id === id) : {};
 
@@ -563,7 +561,7 @@ class ItemView extends React.Component {
       permanentLoanType: get(item, ['permanentLoanType', 'name'], '-'),
       temporaryLoanType: get(item, ['temporaryLoanType', 'name'], '-'),
       itemStatus: loanLink,
-      itemStatusDate: getDateWithTime(itemStatusDate),
+      itemStatusDate: getDateWithTime(item?.status?.date),
       requestLink: !isEmpty(requestRecords) ? <Link to={requestsUrl}>{requestRecords.length}</Link> : 0,
       borrower: borrowerLink,
       loanDate: openLoan ? getDateWithTime(openLoan.loanDate) : '-',
@@ -1075,15 +1073,13 @@ class ItemView extends React.Component {
                     <KeyValue
                       label={<FormattedMessage id="ui-inventory.item.availability.itemStatus" />}
                       value={checkIfElementIsEmpty(loanAndAvailability.itemStatus)}
+                      subValue={
+                        <FormattedMessage
+                          id="ui-inventory.item.status.statusUpdatedLabel"
+                          values={{ statusDate: loanAndAvailability.itemStatusDate }}
+                        />
+                      }
                     />
-                  </Col>
-                  <Col
-                    smOffset={0}
-                    sm={4}
-                  >
-                    <KeyValue label={<FormattedMessage id="ui-inventory.item.availability.itemStatusDate" />}>
-                      {checkIfElementIsEmpty(loanAndAvailability.itemStatusDate)}
-                    </KeyValue>
                   </Col>
                   <Col
                     smOffset={0}

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -434,6 +434,7 @@
   "item.status.declaredLost": "Declared lost",
   "item.status.received": "Received",
   "item.status.orderClosed": "Order closed",
+  "item.status.statusUpdatedLabel": "status updated {statusDate}",
   "inTransitReport": "In transit items report (CSV)",
   "saveInstancesUIIDS": "Save instances UUIDs",
   "saveInstancesCQLQuery": "Save instances CQL query",


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-984

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Chalmers reports that 'When looking at an item record the staff finds the field "Item status date" confusing.' They would like it to be associated directly with the item status.

Fixes #984

<img width="1038" alt="Screen Shot 2020-04-07 at 2 11 56 PM" src="https://user-images.githubusercontent.com/1322242/78705120-feb99400-78da-11ea-8c01-9f63529499b9.png">

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x ] Duplications on new code is 3% or less
  - [x ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x ] There are no breaking changes in this PR.
