### PR TITLE
UIIN-1033: Make the title element required for preceding and succeeding titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Register `instanceFormatIds` filter. Fixes UIIN-1057.
 * Add filter for instance date created. Refs UIIN-788.
 * Improve `buildOptionalBooleanQuery` performance by using `cql.allRecords=1` and `==` operator. Fixes UIIN-1064.
+* Make the title element required for preceding and succeeding titles. Fixes UIIN-1033 and UIIN-1034.
 * Display item status date with status. Refs UIIN-984.
 
 ## [2.0.0](https://github.com/folio-org/ui-inventory/tree/v2.0.0) (2020-03-17)

--- a/src/components/InstancePlugin/InstancePlugin.css
+++ b/src/components/InstancePlugin/InstancePlugin.css
@@ -1,0 +1,3 @@
+.marginTop {
+  margin-top: 30px;
+}

--- a/src/components/InstancePlugin/InstancePlugin.js
+++ b/src/components/InstancePlugin/InstancePlugin.js
@@ -4,17 +4,21 @@ import { FormattedMessage } from 'react-intl';
 
 import { Pluggable } from '@folio/stripes/core';
 
+import css from './InstancePlugin.css';
+
 const InstancePlugin = ({ onSelect }) => (
-  <Pluggable
-    aria-haspopup="true"
-    dataKey="instances"
-    searchButtonStyle="default"
-    searchLabel="+"
-    selectInstance={onSelect}
-    type="find-instance"
-  >
-    <span><FormattedMessage id="ui-inventory.findInstancePluginNotFound" /></span>
-  </Pluggable>
+  <div className={css.marginTop}>
+    <Pluggable
+      aria-haspopup="true"
+      dataKey="instances"
+      searchButtonStyle="default"
+      searchLabel="+"
+      selectInstance={onSelect}
+      type="find-instance"
+    >
+      <span><FormattedMessage id="ui-inventory.findInstancePluginNotFound" /></span>
+    </Pluggable>
+  </div>
 );
 
 InstancePlugin.propTypes = {

--- a/src/components/UnconnectedTitle/UnconnectedTitle.js
+++ b/src/components/UnconnectedTitle/UnconnectedTitle.js
@@ -14,7 +14,7 @@ import InstancePlugin from '../InstancePlugin';
 import TitleLabel from '../TitleLabel';
 
 const UnconnectedTitle = ({ field, onSelect }) => (
-  <Row bottom="xs">
+  <Row>
     <Col xs>
       <Field
         component={TextField}

--- a/src/edit/InstanceForm.js
+++ b/src/edit/InstanceForm.js
@@ -53,6 +53,7 @@ import {
   psTitleRelationshipId,
   validateOptionalField,
 } from '../utils';
+import { validateTitles } from '../validation';
 
 function validate(values) {
   const errors = {};
@@ -128,6 +129,9 @@ function validate(values) {
       errors[listProps.list] = listErrors;
     }
   });
+
+  validateTitles(values, 'preceding', errors, requiredTextMessage);
+  validateTitles(values, 'succeeding', errors, requiredTextMessage);
 
   return errors;
 }

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,0 +1,17 @@
+export const validateTitles = (instance, type, errors, message) => {
+  const titleAttr = `${type}Titles`;
+  const errorList = [];
+
+  instance[titleAttr] = (instance?.[titleAttr] ?? []).forEach((inst, index) => {
+    const { title } = inst;
+    if (!title) {
+      errorList[index] = { title: message };
+    }
+  });
+
+  if (errorList.length) {
+    errors[titleAttr] = errorList;
+  }
+};
+
+export default {};

--- a/test/bigtest/tests/instance-edit-page-test.js
+++ b/test/bigtest/tests/instance-edit-page-test.js
@@ -228,6 +228,17 @@ describe('InstanceEditPage', () => {
       expect(InstanceEditPage.succeedingTitles.succeedingTitlesCount).to.be.gt(prevCount);
     });
 
+    describe('saving without title', () => {
+      beforeEach(async () => {
+        await InstanceEditPage.selectInstanceType('still image');
+        await InstanceEditPage.saveInstance();
+      });
+
+      it('should not save instance without missing title', function () {
+        expect(this.location.search).to.include('layer=edit');
+      });
+    });
+
     describe('saving unconnected titles', () => {
       beforeEach(async () => {
         await InstanceEditPage.succeedingTitles.fillTitleField('title 1');


### PR DESCRIPTION
### Purpose
Make the title element required for preceding and succeeding titles.

### Links
https://issues.folio.org/browse/UIIN-1033
https://issues.folio.org/browse/UIIN-1034

### Screenshot

![please_fill](https://user-images.githubusercontent.com/63545/78750483-550bee80-793e-11ea-8273-75aa2db3de87.png)
 

