### PR TITLE
UIIN-1057: Register instanceFormatIds format (#970)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change history for ui-inventory
 
+
+## [2.0.2](https://github.com/folio-org/ui-inventory/tree/v2.0.2) (2020-04-09)
+[Full Changelog](https://github.com/folio-org/ui-inventory/compare/v2.0.1...v2.0.2)
+
+* Register `instanceFormatIds` filter. Fixes UIIN-1057.
+
 ## [2.0.1](https://github.com/folio-org/ui-inventory/tree/v2.0.1) (2020-04-02)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v2.0.0...v2.0.1)
 

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -31,6 +31,11 @@ export const instanceFilterConfig = [
     values: [],
   },
   {
+    name: 'format',
+    cql: 'instanceFormatIds',
+    values: [],
+  },
+  {
     name: 'resource',
     cql: 'instanceTypeId',
     values: [],


### PR DESCRIPTION
Register `instanceFormatIds` filter. 

Fixes [UIIN-1057](https://issues.folio.org/browse/UIIN-1057).