### PR TITLE
UIIN-1064: Improve boolean filter performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change history for ui-inventory
 
-
 ## [2.0.2](https://github.com/folio-org/ui-inventory/tree/v2.0.2) (2020-04-09)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v2.0.1...v2.0.2)
 
 * Register `instanceFormatIds` filter. Fixes UIIN-1057.
+* Improve `buildOptionalBooleanQuery` performance by using `cql.allRecords=1` and `==` operator. Fixes UIIN-1064.
 
 ## [2.0.1](https://github.com/folio-org/ui-inventory/tree/v2.0.1) (2020-04-02)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v2.0.0...v2.0.1)

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -4,20 +4,9 @@ import {
   itemFilterRenderer,
 } from './components';
 
-// Function which takes a filter name and returns
-// another function which can be used in filter config
-// to parse a given filter into a CQL manually.
-const parseFilter = name => values => {
-  if (values.length === 2) {
-    return `${name}="*"`;
-  } else if (values.length === 1 && values[0] === 'false') {
-    return `${name}="*" not ${name}="true"`;
-  } else {
-    const joinedValues = values.map(v => `"${v}"`).join(' or ');
-
-    return `${name}=${joinedValues}`;
-  }
-};
+import {
+  buildOptionalBooleanQuery,
+} from './utils';
 
 export const instanceFilterConfig = [
   {
@@ -59,13 +48,13 @@ export const instanceFilterConfig = [
     name: 'staffSuppress',
     cql: 'staffSuppress',
     values: [],
-    parse: parseFilter('staffSuppress'),
+    parse: buildOptionalBooleanQuery('staffSuppress'),
   },
   {
     name: 'discoverySuppress',
     cql: 'discoverySuppress',
     values: [],
-    parse: parseFilter('discoverySuppress'),
+    parse: buildOptionalBooleanQuery('discoverySuppress'),
   },
 ];
 
@@ -117,7 +106,7 @@ export const holdingFilterConfig = [
     name: 'discoverySuppress',
     cql: 'holdingsRecords.discoverySuppress',
     values: [],
-    parse: parseFilter('holdingsRecords.discoverySuppress'),
+    parse: buildOptionalBooleanQuery('holdingsRecords.discoverySuppress'),
   },
 ];
 
@@ -159,7 +148,7 @@ export const itemFilterConfig = [
     name: 'discoverySuppress',
     cql: 'item.discoverySuppress',
     values: [],
-    parse: parseFilter('item.discoverySuppress'),
+    parse: buildOptionalBooleanQuery('item.discoverySuppress'),
   }
 ];
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -74,6 +74,21 @@ export function parseFiltersToStr(filters) {
   return newFilters.join(',');
 }
 
+// Function which takes a filter name and returns
+// another function which can be used in filter config
+// to parse a given filter into a CQL manually.
+export const buildOptionalBooleanQuery = name => values => {
+  if (values.length === 2) {
+    return 'cql.allRecords=1';
+  } else if (values.length === 1 && values[0] === 'false') {
+    return `cql.allRecords=1 not ${name}=="true"`;
+  } else {
+    const joinedValues = values.map(v => `"${v}"`).join(' or ');
+
+    return `${name}==${joinedValues}`;
+  }
+};
+
 export function filterItemsBy(name) {
   return (filter, list) => {
     if (!filter) {


### PR DESCRIPTION
This PR changes the `buildOptionalBooleanQuery` to use `cql.allRecords=1`
in cases when both yes and no boolean filters are chosen. It also changes
the `=` operator to `==` for other cases.

Fixes [UIIN-1064](https://issues.folio.org/browse/UIIN-1064)
