### PR TITLE
UIIN-1036: Make the string to be wrapped with a space symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Add missing location permissions to `ui-inventory.instance.view`. Fixes UIIN-1056.
 * Item. Remove The Edit pen icon in the top main pane. Fixes UIIN-1026.
 * Holdings. Remove The Edit pen icon in the top main pane. Fixes UIIN-1025.
+* Make the string to be wrapped with a space symbol in Preceding and Succeeding titles. Fixes UIIN-1036.
 
 ## [2.0.0](https://github.com/folio-org/ui-inventory/tree/v2.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.1...v2.0.0)

--- a/src/components/TitlesView/TitlesView.js
+++ b/src/components/TitlesView/TitlesView.js
@@ -49,6 +49,8 @@ const TitlesViews = ({ titles, id, titleKey, label }) => {
   const columnWidths = {
     title: '35%',
     hrid: '25%',
+    isbn: '20%',
+    issn: '20%',
   };
 
   return (

--- a/src/utils.js
+++ b/src/utils.js
@@ -371,7 +371,7 @@ export const getIdentifiers = (identifiers = [], type, identifierTypesById) => {
     }
   });
 
-  return result.join(',');
+  return result.join(', ');
 };
 
 /**


### PR DESCRIPTION
## Purpose
Make the string to be wrapped with a space symbol in Preceding and Succeeding titles.

Story [UIIN-1036](https://issues.folio.org/browse/UIIN-1036).

### Screenshot
![Screen Shot 2020-04-24 at 12 16 21](https://user-images.githubusercontent.com/49517355/80196221-c24d9e00-8625-11ea-8a57-fb9e86ab2272.png)
