### PR TITLE
UIIN-1037 don't open links in new windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-inventory
 
 ## [2.1.0] IN PROGRESS
+* Preceding and Succeeding titles. Clicking on connected titles should open in the same window. Fixes UIIN-1037.
 * Display instance status date with status. Refs UIIN-1007.
 * Import `stripes-util` via `stripes`. Fixes UIIN-1021 and UIIN-1029.
 * Rewrite accordion state control. Fixes UIIN-921.

--- a/src/components/ConnectedTitle/ConnectedTitle.js
+++ b/src/components/ConnectedTitle/ConnectedTitle.js
@@ -43,7 +43,6 @@ const ConnectedTitle = ({ instance, onSelect, titleIdKey }) => {
           value={
             <Link
               data-test-connected-instance-title
-              target="_blank"
               to={`/inventory/view/${instance[titleIdKey]}`}
             >
               {title}


### PR DESCRIPTION
UIIN-1037 Preceding and Succeeding titles. Clicking on connected titles should not open new window

## Purpose

Currently, when users clicking on connected titles (Preceding and Succeeding titles), a new window will be opened which is incorrect. The new page should be opened in the same window. 
JIRA link: https://issues.folio.org/browse/UIIN-1037


## Approach

Remove the target="_blank" in ConnectedTitles component where the url is rendered to the UI



## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.
