### PR TITLE
pin moment to ~2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Make the string to be wrapped with a space symbol in Preceding and Succeeding titles. Fixes UIIN-1036.
 * Show error callout when saving file with the instance UUIDs fails. UIDEXP-55.
 * Add filter for instance date updated. Refs UIIN-790.
+* Pin `moment` at `~2.24.0` in light of multiple issues with `2.25.0` ([5489](https://github.com/moment/moment/issues/5489), [5472](https://github.com/moment/moment/issues/5472)).
 
 ## [2.0.0](https://github.com/folio-org/ui-inventory/tree/v2.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.1...v2.0.0)

--- a/package.json
+++ b/package.json
@@ -627,7 +627,7 @@
     "react-hot-loader": "^4.3.12",
     "react-router-prop-types": "^1.0.4",
     "redux-form": "^7.0.3",
-    "moment": "^2.22.2"
+    "moment": "~2.24.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -639,5 +639,8 @@
   "optionalDependencies": {
     "@folio/plugin-find-instance": "^2.0.0",
     "@folio/quick-marc": "^1.0.0"
+  }, 
+  "resolutions": {
+    "moment": "~2.24.0"
   }
 }


### PR DESCRIPTION
Pin `moment` at `~2.24.0` in light of multiple issues with `2.25.0` ([5489](https://github.com/moment/moment/issues/5489), [5472](https://github.com/moment/moment/issues/5472)).
