### PR TITLE
Removed: target_blank in TitlesView component

### DIFF
--- a/src/components/TitlesView/TitlesView.js
+++ b/src/components/TitlesView/TitlesView.js
@@ -21,7 +21,6 @@ const TitlesViews = ({ titles, id, titleKey, label }) => {
   const formatter = {
     title: row => (row[titleKey] ?
       <Link
-        target="_blank"
         to={`/inventory/view/${row[titleKey]}`}
       >
         {row.title}


### PR DESCRIPTION
UIIN-1037 Preceding and Succeeding titles. Clicking on connected titles should not open new window

## Purpose
Currently, when users clicking on connected titles (Preceding and Succeeding titles), a new window will be opened which is incorrect. The new page should be opened in the same window.
JIRA link: https://issues.folio.org/browse/UIIN-1037

## Approach
Remove the target="_blank" in ConnectedTitles and TitlesView component where the url is rendered to the UI

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.
