### PR TITLE
UIIN-993: Search by call number normalized from item segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Add filter for instance date updated. Refs UIIN-790.
 * Pin `moment` at `~2.24.0` in light of multiple issues with `2.25.0` ([5489](https://github.com/moment/moment/issues/5489), [5472](https://github.com/moment/moment/issues/5472)).
 * Purge `intlShape` in prep for `react-intl` `v4` migration. Refs STRIPES-672.
+* Add ability to search by `Effective call number (item), normalized` option. Refs UIIN-993.
 
 ## [2.0.0](https://github.com/folio-org/ui-inventory/tree/v2.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.1...v2.0.0)

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -134,8 +134,12 @@ export const itemIndexes = [
   { label: 'ui-inventory.itemEffectiveCallNumberEyeReadable',
     value: 'itemCallNumberER',
     queryTemplate: 'item.fullCallNumber=="%{query.query}" OR item.callNumberAndSuffix=="%{query.query}"' },
+  { label: 'ui-inventory.itemEffectiveCallNumberNormalized',
+    value: 'itemCallNumberNorm',
+    queryTemplate: 'item.fullCallNumberNormalized="%{query.query}" OR item.callNumberAndSuffixNormalized="%{query.query}"' },
   { label: 'ui-inventory.itemHrid', value: 'hrid', queryTemplate: 'item.hrid=="%{query.query}"' },
   { label: 'ui-inventory.querySearch', value: 'querySearch', queryTemplate: '%{query.query}' },
+
 ];
 
 export const itemFilterConfig = [

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -160,6 +160,13 @@ export default function configure() {
         return instances.where({ id: holding.instanceId });
       }
 
+      if (left?.field === 'item.fullCallNumberNormalized') {
+        const item = items.where({ callNumber: left.term }).models[0];
+        const holding = holdings.where({ id: item.holdingsRecordId }).models[0];
+
+        return instances.where({ id: holding.instanceId });
+      }
+
       if (field === 'identifiers') {
         const idType = identifierTypes.where({ name: term }).models[0];
 

--- a/test/bigtest/tests/filters/items/search-field-filter-test.js
+++ b/test/bigtest/tests/filters/items/search-field-filter-test.js
@@ -90,6 +90,21 @@ describe('Items SearchFieldFilter', () => {
     });
   });
 
+  describe('Call number, normalized', function () {
+    beforeEach(async function () {
+      const instance = this.server.create('instance', {}, 'withHoldingAndItem');
+      const item = instance.holdings.models[0].items.models[0];
+
+      await itemsRoute.searchFieldFilter.searchField.selectIndex('Effective call number (item), normalized');
+      await itemsRoute.searchFieldFilter.searchField.fillInput(item.callNumber);
+      await itemsRoute.searchFieldFilter.clickSearch();
+    });
+
+    it('finds instances by call number (item), normalized', () => {
+      expect(itemsRoute.rows().length).to.equal(1);
+    });
+  });
+
   describe('selecting the "ISBN, normalized" search option', function () {
     beforeEach(async function () {
       const isbnIdentifierType = this.server.create('identifier-type', { name: 'ISBN' });

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -161,6 +161,7 @@
   "issn": "ISSN",
   "callNumberEyeReadable": "Call number, eye readable",
   "itemEffectiveCallNumberEyeReadable": "Effective call number (item), eye readable",
+  "itemEffectiveCallNumberNormalized": "Effective call number (item), normalized",
   "search.all": "Keyword (title, contributor, identifier)",
   "title": "Title (all)",
   "indexTitle": "Index title",


### PR DESCRIPTION
### Purpose
Add ability to search by `Effective call number (item), normalized` option. Refs UIIN-993.

Based on the comments under UIIN-993 the full normalization happens on the backend which made this much easier to setup (Thank you @bohdan-suprun!).

### Link
https://issues.folio.org/browse/UIIN-993

### Screenshot
![callnum](https://user-images.githubusercontent.com/63545/81705795-6cf2f880-943d-11ea-8680-6a0a772a578a.png)
