### PR TITLE
UIIN-983: Search by call number normalized from holdings segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Pin `moment` at `~2.24.0` in light of multiple issues with `2.25.0` ([5489](https://github.com/moment/moment/issues/5489), [5472](https://github.com/moment/moment/issues/5472)).
 * Purge `intlShape` in prep for `react-intl` `v4` migration. Refs STRIPES-672.
 * Add ability to search by `Effective call number (item), normalized` option. Refs UIIN-993.
+* Add ability to search by `Call number, normalized` option via holdings segment. Refs UIIN-983.
 
 ## [2.0.0](https://github.com/folio-org/ui-inventory/tree/v2.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.1...v2.0.0)

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -100,6 +100,9 @@ export const holdingIndexes = [
   { label: 'ui-inventory.callNumberEyeReadable',
     value: 'callNumberER',
     queryTemplate: 'holdingsRecords.fullCallNumber=="%{query.query}" OR holdingsRecords.callNumberAndSuffix=="%{query.query}"' },
+  { label: 'ui-inventory.callNumberNormalized',
+    value: 'callNumberNormalized',
+    queryTemplate: 'holdingsRecords.fullCallNumberNormalized="%{query.query}" OR holdingsRecords.callNumberAndSuffixNormalized="%{query.query}"' },
   { label: 'ui-inventory.holdingsHrid', value: 'hrid', queryTemplate: 'holdingsRecords.hrid=="%{query.query}"' },
   { label: 'ui-inventory.querySearch', value: 'querySearch', queryTemplate: '%{query.query}' },
 ];

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -153,6 +153,19 @@ export default function configure() {
         return instances.where({ id: holding.instanceId });
       }
 
+      if (left?.field === 'holdingsRecords.fullCallNumberNormalized') {
+        const normalize = value => value.replace(/\W/g, '').toLowerCase();
+
+        const normalizedHoldings = holdings.all().models.map(holding => {
+          const { instanceId, callNumber, callNumberPrefix } = holding;
+          return { instanceId, callNumber: normalize(callNumberPrefix + callNumber) };
+        });
+
+        const holding = normalizedHoldings.find(h => h.callNumber === normalize(left.term));
+
+        return instances.where({ id: holding?.instanceId });
+      }
+
       if (left?.field === 'item.fullCallNumber') {
         const item = items.where({ callNumber: left.term }).models[0];
         const holding = holdings.where({ id: item.holdingsRecordId }).models[0];

--- a/test/bigtest/network/factories/holding.js
+++ b/test/bigtest/network/factories/holding.js
@@ -16,7 +16,9 @@ export default Factory.extend({
   permanentLocationId: 'fcd64ce1-6995-48f0-840e-89ffa2288371',
   hrid: i => `ho0000000000${i + 1}`,
   electronicAccess: () => [],
+  callNumberPrefix: () => `prefix - ${random.uuid()}`,
   callNumber: () => `callNumber - ${random.uuid()}`,
+  callNumberSuffix: () => `suffix - ${random.uuid()}`,
   formerIds: [],
   holdingsItems: [],
   holdingsStatements: [

--- a/test/bigtest/network/factories/instance.js
+++ b/test/bigtest/network/factories/instance.js
@@ -174,5 +174,19 @@ export default Factory.extend({
       instance.holdings = [holding];
       instance.save();
     }
+  }),
+
+  withFullCallNumber: trait({
+    afterCreate(instance, server) {
+      const holding = server.create(
+        'holding',
+        { callNumber: 'Call Number',
+          callNumberPrefix: 'Prefix',
+          callNumberSuffix: 'Suffix' },
+      );
+
+      instance.holdings = [holding];
+      instance.save();
+    }
   })
 });

--- a/test/bigtest/tests/filters/holdings/search-field-filter-test.js
+++ b/test/bigtest/tests/filters/holdings/search-field-filter-test.js
@@ -97,6 +97,20 @@ describe('Holdings SearchFieldFilter', () => {
     });
   });
 
+  describe('selecting "Call number, normalized" option', function () {
+    beforeEach(async function () {
+      this.server.create('instance', {}, 'withFullCallNumber');
+
+      await holdingsRoute.searchFieldFilter.searchField.selectIndex('Call number, normalized');
+      await holdingsRoute.searchFieldFilter.searchField.fillInput('prefix - callNumber()');
+      await holdingsRoute.searchFieldFilter.clickSearch();
+    });
+
+    it('finds instances by Call number - normalized', () => {
+      expect(holdingsRoute.rows().length).to.equal(1);
+    });
+  });
+
   describe('selecting the Holdings HRID search option', function () {
     beforeEach(async () => {
       await holdingsRoute.searchFieldFilter.searchField.selectIndex('Holdings HRID');

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -160,6 +160,7 @@
   "isbnNormalized": "ISBN, normalized",
   "issn": "ISSN",
   "callNumberEyeReadable": "Call number, eye readable",
+  "callNumberNormalized": "Call number, normalized",
   "itemEffectiveCallNumberEyeReadable": "Effective call number (item), eye readable",
   "itemEffectiveCallNumberNormalized": "Effective call number (item), normalized",
   "search.all": "Keyword (title, contributor, identifier)",


### PR DESCRIPTION
## Purpose
Add ability to search by `Call number, normalized` option via holdings segment. Story [UIIN-983](https://issues.folio.org/browse/UIIN-983).

### Screenshot
![Screen Shot 2020-05-13 at 12 59 33](https://user-images.githubusercontent.com/49517355/81799298-ccbed180-9519-11ea-8c83-20b5448370ed.png)
