### PR TITLE
UIIN-818: Show/hide specific options in Actions menu for the `Withdra…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Purge `intlShape` in prep for `react-intl` `v4` migration. Refs STRIPES-672.
 * Add ability to search by `Effective call number (item), normalized` option. Refs UIIN-993.
 * Add ability to search by `Call number, normalized` option via holdings segment. Refs UIIN-983.
+* Show/hide specific options in Actions menu for the `Withdrawn` item. Refs UIIN-818.
 
 ## [2.0.0](https://github.com/folio-org/ui-inventory/tree/v2.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.1...v2.0.0)

--- a/src/utils.js
+++ b/src/utils.js
@@ -47,6 +47,7 @@ export function canMarkItemAsMissing(item) {
     itemStatusesMap.PAGED,
     itemStatusesMap.IN_PROCESS,
     itemStatusesMap.AWAITING_DELIVERY,
+    itemStatusesMap.WITHDRAWN,
   ], item?.status?.name);
 }
 

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -292,7 +292,7 @@ class ItemView extends React.Component {
           </Icon>
         </Button>
         )}
-        { canCreateNewRequest && (
+        { canMarkItemAsWithdrawn(firstItem) && canCreateNewRequest && (
         <Button
           to={newRequestLink}
           buttonStyle="dropdownItem"

--- a/test/bigtest/network/factories/instance.js
+++ b/test/bigtest/network/factories/instance.js
@@ -164,10 +164,10 @@ export default Factory.extend({
     }
   }),
 
-  withHoldingAndInProcessItem: trait({
+  withHoldingAndItemStatus: trait({
     afterCreate(instance, server) {
       const holding = server.create('holding');
-      const item = server.create('item', { status: { name: 'In process' } });
+      const item = server.create('item', { status: { name: instance.itemStatus } });
 
       holding.items = [item];
       holding.save();

--- a/test/bigtest/tests/item-view-page-test.js
+++ b/test/bigtest/tests/item-view-page-test.js
@@ -211,9 +211,10 @@ describe('ItemViewPage', () => {
       beforeEach(async function () {
         const instance = this.server.create(
           'instance',
-          'withHoldingAndInProcessItem',
+          'withHoldingAndItemStatus',
           {
             title: 'ADVANCING RESEARCH',
+            itemStatus: 'In process',
           }
         );
         const holding = this.server.schema.instances.first().holdings.models[0];
@@ -230,6 +231,42 @@ describe('ItemViewPage', () => {
 
         it('should open a missing confirmation modal', () => {
           expect(ItemViewPage.hasMarkAsMissingModal).to.exist;
+        });
+      });
+    });
+
+    describe('visiting the withdrawn item view page', () => {
+      beforeEach(async function () {
+        const instance = this.server.create(
+          'instance',
+          'withHoldingAndItemStatus',
+          {
+            title: 'ADVANCING RESEARCH',
+            itemStatus: 'Withdrawn',
+          }
+        );
+        const holding = this.server.schema.instances.first().holdings.models[0];
+        const item = holding.items.models[0].attrs;
+
+        this.visit(`/inventory/view/${instance.id}/${holding.id}/${item.id}`);
+        await ItemViewPage.whenLoaded();
+      });
+
+      describe('clicking pane header dropdown menu', () => {
+        beforeEach(async () => {
+          await ItemViewPage.headerDropdown.click();
+        });
+
+        it('should show a mark as missing item', () => {
+          expect(ItemViewPage.headerDropdownMenu.hasMarkAsMissing).to.be.true;
+        });
+
+        it('should not show a mark as withdrawn item', () => {
+          expect(ItemViewPage.headerDropdownMenu.hasMarkAsWithdrawn).to.be.false;
+        });
+
+        it('should not show a new request item', () => {
+          expect(ItemViewPage.headerDropdownMenu.hasNewRequestItem).to.be.false;
         });
       });
     });


### PR DESCRIPTION
## Purpose
According to [UIIN-818](https://issues.folio.org/browse/UIIN-818), it's required to show some options in the `Actions` menu and hide others when the item has the status `Withdrawn`.

### Screenshot
![Screen Shot 2020-05-14 at 19 18 28](https://user-images.githubusercontent.com/49517355/81959097-a3846b00-9617-11ea-8f24-b9af6e443a1d.png)
