### PR TITLE
UIIN-891: Prevent items with the status  from being marked missing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Add ability to search by `Effective call number (item), normalized` option. Refs UIIN-993.
 * Add ability to search by `Call number, normalized` option via holdings segment. Refs UIIN-983.
 * Show/hide specific options in Actions menu for the `Withdrawn` item. Refs UIIN-818.
+* Prevent items with the status `Claimed returned` from being marked missing. Refs UIIN-891.
 * Add ability to search item by `Claimed returned` status. Refs UIIN-957.
 
 ## [2.0.0](https://github.com/folio-org/ui-inventory/tree/v2.0.0) (2020-03-17)

--- a/src/constants.js
+++ b/src/constants.js
@@ -15,6 +15,7 @@ export const itemStatusesMap = {
   AWAITING_DELIVERY,
   MISSING: 'Missing',
   WITHDRAWN: 'Withdrawn',
+  CLAIMED_RETURNED: 'Claimed returned',
 };
 
 export const requestStatuses = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,6 +48,7 @@ export function canMarkItemAsMissing(item) {
     itemStatusesMap.IN_PROCESS,
     itemStatusesMap.AWAITING_DELIVERY,
     itemStatusesMap.WITHDRAWN,
+    itemStatusesMap.CLAIMED_RETURNED,
   ], item?.status?.name);
 }
 
@@ -60,6 +61,7 @@ export function canMarkItemAsWithdrawn(item) {
     itemStatusesMap.MISSING,
     itemStatusesMap.AWAITING_DELIVERY,
     itemStatusesMap.PAGED,
+    itemStatusesMap.CLAIMED_RETURNED,
   ], item?.status?.name);
 }
 


### PR DESCRIPTION
Prevent items with the status `Claimed returned` from being marked as missing.

https://issues.folio.org/browse/UIIN-891