### PR TITLE
UIIN-957: Fix filtering by claimed returned status

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -39,7 +39,7 @@ export const itemStatuses = [
   { label: 'ui-inventory.item.status.received', value: 'Received' },
   { label: 'ui-inventory.item.status.orderClosed', value: 'Order closed' },
   { label: 'ui-inventory.item.status.withdrawn', value: 'Withdrawn' },
-  { label: 'ui-inventory.item.status.claimedReturned', value: ' Claimed returned' },
+  { label: 'ui-inventory.item.status.claimedReturned', value: 'Claimed returned' },
 ];
 
 export const segments = {


### PR DESCRIPTION
It looks like there was an extra space added in "Claimed returned" status causing the search not to work correctly. This PR should address it.

https://issues.folio.org/browse/UIIN-957