### PR TITLE
UIIN-1100: Restore displaying of Nature of content value in Instance …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## [3.0.0] IN PROGRESS
 
 * Upgrade to `stripes` `4.0`, `react-intl` `4.5`. Refs STRIPES-672.
-* Subheading Related title to be deprecated. Instance (edit view) Fixes UIIN-1032
-* Preceding and Succeeding titles. Make the Connected label less prominent (edit view) Fixes UIIN-1039
-* Item record: "loan type" appears as "loantype" (on detailed view) Fixes UIIN-657
-
+* Subheading Related title to be deprecated. Instance (edit view). Fixes UIIN-1032.
+* Preceding and Succeeding titles. Make the Connected label less prominent (edit view). Fixes UIIN-1039.
+* Item record: "loan type" appears as "loantype" (on detailed view). Fixes UIIN-657.
+* Restore displaying of `Nature of content` value in Instance detailed view. Fixes UIIN-1100.
 
 ## [2.1.0] IN PROGRESS
 * Preceding and Succeeding titles. Clicking on connected titles should open in the same window. Fixes UIIN-1037.

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -1141,7 +1141,7 @@ class ViewInstance extends React.Component {
                 >
                   <KeyValue
                     label={<FormattedMessage id="ui-inventory.natureOfContentTerms" />}
-                    value={convertArrayToBlocks(descriptiveData.natureOfContentTermIds)}
+                    value={convertArrayToBlocks(descriptiveData.natureOfContentTerms)}
                   />
                 </Col>
               </Row>


### PR DESCRIPTION
## Purpose
Fixed the bug caused by refactoring of the accordion condition control, which accidentally removed the term data from Instance Detailed View.

Story [UIIN-1100](https://issues.folio.org/browse/UIIN-1100).