### PR TITLE
UIIN-889: Add additional perm check for mark withdrawn

### DIFF
--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -211,8 +211,9 @@ class ItemView extends React.Component {
     const canMarkAsMissing = stripes.hasPerm('ui-inventory.item.markasmissing');
     const canDelete = stripes.hasPerm('ui-inventory.item.delete');
     const canCreateNewRequest = stripes.hasPerm('ui-requests.create');
+    const canWithdrawn = stripes.hasPerm('ui-inventory.items.mark-items-withdrawn');
 
-    if (!canCreate && !canEdit && !canDelete && !canCreateNewRequest) {
+    if (!canCreate && !canEdit && !canDelete && !canCreateNewRequest && !canWithdrawn) {
       return null;
     }
 


### PR DESCRIPTION
The additional check for `ui-inventory.items.mark-items-withdrawn` had to be added to make sure the actions menu will be visible. This PR is trying to address that.

https://issues.folio.org/browse/UIIN-889