### PR TITLE
UIIN-895: Search for items with lost and paid status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * Prevent items with the status `Claimed returned` from being marked missing. Refs UIIN-891.
 * Add ability to search item by `Claimed returned` status. Refs UIIN-957.
 * Add permission for marking an item withdrawn. Refs UIIN-889.
+* Allow users to search & filter for items with the status Lost and paid. Refs UIIN-895.
 
 ## [2.0.0](https://github.com/folio-org/ui-inventory/tree/v2.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v1.13.1...v2.0.0)

--- a/src/constants.js
+++ b/src/constants.js
@@ -16,6 +16,7 @@ export const itemStatusesMap = {
   MISSING: 'Missing',
   WITHDRAWN: 'Withdrawn',
   CLAIMED_RETURNED: 'Claimed returned',
+  LOST_AND_PAID: 'Lost and paid',
 };
 
 export const requestStatuses = {
@@ -40,6 +41,7 @@ export const itemStatuses = [
   { label: 'ui-inventory.item.status.orderClosed', value: 'Order closed' },
   { label: 'ui-inventory.item.status.withdrawn', value: 'Withdrawn' },
   { label: 'ui-inventory.item.status.claimedReturned', value: 'Claimed returned' },
+  { label: 'ui-inventory.item.status.lostAndPaid', value: 'Lost and paid' },
 ];
 
 export const segments = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,6 +48,7 @@ export function canMarkItemAsMissing(item) {
     itemStatusesMap.IN_PROCESS,
     itemStatusesMap.AWAITING_DELIVERY,
     itemStatusesMap.WITHDRAWN,
+    itemStatusesMap.LOST_AND_PAID,
   ], item?.status?.name);
 }
 
@@ -60,7 +61,21 @@ export function canMarkItemAsWithdrawn(item) {
     itemStatusesMap.MISSING,
     itemStatusesMap.AWAITING_DELIVERY,
     itemStatusesMap.PAGED,
+    itemStatusesMap.LOST_AND_PAID,
   ], item?.status?.name);
+}
+
+export function canCreateNewRequest(item, stripes) {
+  return stripes.hasPerm('ui-requests.create') &&
+    includes([
+      itemStatusesMap.IN_PROCESS,
+      itemStatusesMap.AVAILABLE,
+      itemStatusesMap.IN_TRANSIT,
+      itemStatusesMap.AWAITING_PICKUP,
+      itemStatusesMap.MISSING,
+      itemStatusesMap.AWAITING_DELIVERY,
+      itemStatusesMap.PAGED,
+    ], item?.status?.name);
 }
 
 export function getCurrentFilters(filtersStr) {

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -47,6 +47,7 @@ import {
   callNumberLabel,
   canMarkItemAsMissing,
   canMarkItemAsWithdrawn,
+  canCreateNewRequest,
   areAllFieldsEmpty,
   checkIfElementIsEmpty,
   convertArrayToBlocks,
@@ -210,10 +211,10 @@ class ItemView extends React.Component {
     const canEdit = stripes.hasPerm('ui-inventory.item.edit');
     const canMarkAsMissing = stripes.hasPerm('ui-inventory.item.markasmissing');
     const canDelete = stripes.hasPerm('ui-inventory.item.delete');
-    const canCreateNewRequest = stripes.hasPerm('ui-requests.create');
+    const allCreateNewRequest = stripes.hasPerm('ui-requests.create');
     const canWithdrawn = stripes.hasPerm('ui-inventory.items.mark-items-withdrawn');
 
-    if (!canCreate && !canEdit && !canDelete && !canCreateNewRequest && !canWithdrawn) {
+    if (!canCreate && !canEdit && !canDelete && !allCreateNewRequest && !canWithdrawn) {
       return null;
     }
 
@@ -296,7 +297,7 @@ class ItemView extends React.Component {
           </Button>
           )}
         </IfPermission>
-        { canMarkItemAsWithdrawn(firstItem) && canCreateNewRequest && (
+        { canCreateNewRequest(firstItem, stripes) && (
         <Button
           to={newRequestLink}
           buttonStyle="dropdownItem"

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -443,6 +443,7 @@
   "item.status.orderClosed": "Order closed",
   "item.status.withdrawn": "Withdrawn",
   "item.status.claimedReturned": "Claimed returned",
+  "item.status.lostAndPaid": "Lost and paid",
   "item.status.statusUpdatedLabel": "status updated {statusDate}",
   "inTransitReport": "In transit items report (CSV)",
   "saveInstancesUIIDS": "Save instances UUIDs",


### PR DESCRIPTION
### Purpose
Allow users to search & filter for items with the status Lost and paid. Refs UIIN-895

### Link
https://issues.folio.org/browse/UIIN-895


![lost_and_paid](https://user-images.githubusercontent.com/63545/83683205-0338bb00-a5b3-11ea-9db9-480d46132e96.png)
