### PR TITLE
UIIN-1046: Maintain default title sort when searching or filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Restore displaying of `Nature of content` value in Instance detailed view. Fixes UIIN-1100.
 * Prefer `stripes.actsAs` to the deprecated `stripes.type` in `package.json`. Refs STCOR-148.
 * Instance record. Relabel in the UI the Metadata source to Source (View and Edit) Fixes UIIN-1133
+* Maintain default title sort when searching or filtering. Fixes UIIN-1046.
 
 ## [2.1.0] IN PROGRESS
 * Preceding and Succeeding titles. Clicking on connected titles should open in the same window. Fixes UIIN-1037.

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -25,6 +25,9 @@ export function buildQuery(queryParams, pathComponents, resourceData, logger, pr
 
   if (queryIndex === 'querySearch' && queryValue.match('sortby')) {
     query.sort = '';
+  } else if (!query.sort) {
+    // Default sort for filtering/searching instances/holdings/items should be by title (UIIN-1046)
+    query.sort = 'title';
   }
 
   resourceData.query = { ...query, qindex: '' };


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1046

This is intended to preserve the default sort order of instances, holdings, or item records when sorting or filtering. If no sort order is specified, the query sort order is set to 'title' during the query build.