### PR TITLE
Holdings record. Add space between: Suppress from Discovery and HRID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [3.0.0] IN PROGRESS
 
+* Holdings record. Add space between: Suppress from Discovery and HRID. Fixes UIIN-477
 * Upgrade to `stripes` `4.0`, `react-intl` `4.5`. Refs STRIPES-672.
 * Subheading Related title to be deprecated. Instance (edit view) Fixes UIIN-1032
 * Preceding and Succeeding titles. Make the Connected label less prominent (edit view) Fixes UIIN-1039

--- a/src/edit/holdings/HoldingsForm.js
+++ b/src/edit/holdings/HoldingsForm.js
@@ -358,6 +358,7 @@ class HoldingsForm extends React.Component {
                   />
                 </Col>
               </Row>
+              <br />
               <Row>
                 <Col sm={4}>
                   <Field


### PR DESCRIPTION
UIIN-477 Holdings record. Add space between: Suppress from Discovery and HRID

## Purpose
https://issues.folio.org/browse/UIIN-477
One line space is missing between 'Suppress from Discovery' and the holdings HRID element.

## Approach
Add `<br>` code between 'Suppress from Discovery' and the holdings HRID element.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.
