### PR TITLE
increment plugin-find-instance to v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## 3.0.1 (IN PROGRESS)
+
+* Increment `@folio/plugin-find-instance` to `v3.0` for `@folio/stripes` `v4` compatibility.
+
 ## [3.0.0](https://github.com/folio-org/ui-inventory/tree/v3.0.0) (2020-06-16)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v2.0.0...v3.0.0)
 

--- a/package.json
+++ b/package.json
@@ -648,7 +648,7 @@
     "react-router-dom": "^5.0.1"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-instance": "^2.0.0",
+    "@folio/plugin-find-instance": "^3.0.0",
     "@folio/quick-marc": "^1.0.0"
   },
   "resolutions": {


### PR DESCRIPTION
Increment `@folio/plugin-find-instance` version to `^3` for
compatibility with `@folio/stripes` `4.0`.