### PR TITLE
UIIN-1191

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Continue working in Inventory after moving holding(s) and/or item(s). Refs UIIN-1111.
 * Show new request action for checked out items. Fixes UIIN-1188.
 * Show new request action for on order items. Fixes UIIN-1187.
+* Add `Edit in quickMARC` link disabled state condition. Refs UIIN-1191
 
 ## [3.0.2](https://github.com/folio-org/ui-inventory/tree/v3.0.2) (2020-06-23)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v3.0.1...v3.0.2)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -326,6 +326,7 @@ class ViewInstance extends React.Component {
                 <Button
                   id="edit-instance-marc"
                   buttonStyle="dropdownItem"
+                  disabled={!marcRecord}
                   onClick={() => {
                     onToggle();
                     this.editInstanceMarc();


### PR DESCRIPTION
## Overview
Edit in quickMARC should be grayed out when View Source is grayed out

## Approach
Add 'Edit in quickMARC' link disabled state condition as for 'view source' link

## Refs
[UIIN-1191](https://issues.folio.org/browse/UIIN-1191)