### PR TITLE
increment @folio/stripes to v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-inventory
 
-## 3.1.0 (IN PROGRESS)
+## 5.0.0 (IN PROGRESS)
 
 * Add Item screen : Incorrect aria label. Refs UIIN-1104.
 * Select and move holdings with items or items to another instance. Refs UIIN-1098.
@@ -17,6 +17,18 @@
 * Show new request action for on order items. Fixes UIIN-1187.
 * Add `Edit in quickMARC` link disabled state condition. Refs UIIN-1191
 * Action menu view source in split screen instance records. Refs UIIN-1112.
+* Increment `@folio/stripes` to `v5`, plus corresponding dev-dep increments.
+
+## [4.0.1](https://github.com/folio-org/ui-inventory/tree/v4.0.1) (2020-07-01)
+[Full Changelog](https://github.com/folio-org/ui-inventory/compare/v4.0.0...v4.0.1)
+
+* Show new request action for on order items. Fixes UIIN-1187.
+* Show new request action for checked out items. Fixes UIIN-1188.
+
+## [4.0.0](https://github.com/folio-org/ui-inventory/tree/v4.0.0) (2020-06-25)
+[Full Changelog](https://github.com/folio-org/ui-inventory/compare/v3.0.2...v4.0.0)
+
+* Update Requests to SRS for v4. Refs UIIN-1158.
 
 ## [3.0.2](https://github.com/folio-org/ui-inventory/tree/v3.0.2) (2020-06-23)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v3.0.1...v3.0.2)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/inventory",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Inventory manager",
   "repository": "folio-org/ui-inventory",
   "publishConfig": {
@@ -609,11 +609,11 @@
     "@bigtest/mocha": "^0.5.1",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes": "^4.0.0",
+    "@folio/stripes": "^5.0.0",
     "@folio/stripes-cli": "^1.13.0",
-    "@folio/stripes-components": "^7.0.0",
-    "@folio/stripes-core": "^5.0.0",
-    "@folio/stripes-smart-components": "^4.0.0",
+    "@folio/stripes-components": "^8.0.0",
+    "@folio/stripes-core": "^6.0.0",
+    "@folio/stripes-smart-components": "^5.0.0",
     "babel-eslint": "^9.0.0",
     "chai": "^4.2.0",
     "core-js": "^3.6.4",
@@ -643,7 +643,7 @@
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {
-    "@folio/stripes": "^4.0.0",
+    "@folio/stripes": "^5.0.0",
     "react": "*",
     "react-intl": "^4.5.3",
     "react-router": "^5.0.1",


### PR DESCRIPTION
Increment the `@folio/stripes` peer-dep to `^5.0.0` for `react-router`
`5.2.0` compatibility, and therefore increment other `@folio/stripes-*`
dev-deps as well.

