### PR TITLE
UIIN-1190 Possible error for Source=FOLIO instances has been fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@
 * Show new request action for checked out items. Fixes UIIN-1188.
 * Show new request action for on order items. Fixes UIIN-1187.
 * Add `Edit in quickMARC` link disabled state condition. Refs UIIN-1191
-* Possible error for Source=FOLIO instances has been fixed. Refs UIIN-1190.
 * Action menu view source in split screen instance records. Refs UIIN-1112.
 * Increment `@folio/stripes` to `v5`, plus corresponding dev-dep increments.
+* Possible error for Source=FOLIO instances has been fixed. Refs UIIN-1190.
 
 ## [4.0.1](https://github.com/folio-org/ui-inventory/tree/v4.0.1) (2020-07-01)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v4.0.0...v4.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 * Add Item screen : Incorrect aria label. Refs UIIN-1104.
 * Select and move holdings with items or items to another instance. Refs UIIN-1098.
 * Move items between holdings. Refs UIIN-1097.
-* Disable fields in Preceding/Succeeding section, when Instance is controlled by Source MARC. Refs UIIN-1128.
 * Update Requests to SRS for v4. Refs UIIN-1158.
 * Show two instance records as a split screen. Refs UIIN-1103.
 * Add filter for the instance source. Refs UIIN-1132.
@@ -17,6 +16,7 @@
 * Show new request action for checked out items. Fixes UIIN-1188.
 * Show new request action for on order items. Fixes UIIN-1187.
 * Add `Edit in quickMARC` link disabled state condition. Refs UIIN-1191
+* Possible error for Source=FOLIO instances has been fixed. Refs UIIN-1190.
 * Action menu view source in split screen instance records. Refs UIIN-1112.
 * Increment `@folio/stripes` to `v5`, plus corresponding dev-dep increments.
 

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -102,15 +102,16 @@ class ViewInstance extends React.Component {
     this.calloutRef = createRef();
   }
 
-  componentDidMount() {
-    this.getMARCRecord();
-  }
-
   componentDidUpdate(prevProps) {
-    const { location: prevLocation } = prevProps;
-    const { location } = this.props;
+    const { resources: prevResources } = prevProps;
+    const { resources } = this.props;
+    const instanceRecords = resources.selectedInstance.records;
+    const instanceRecordsId = instanceRecords[0]?.id;
+    const instanceRecordsSource = instanceRecords[0]?.source;
+    const prevInstanceRecordsId = prevResources.selectedInstance.records[0]?.id;
+    const isMarcSource = instanceRecordsSource === 'MARC';
 
-    if (prevLocation === location) return;
+    if (!isMarcSource || instanceRecordsId === prevInstanceRecordsId) return;
     this.getMARCRecord();
   }
 


### PR DESCRIPTION
## Overview
For some time, ui-inventory hits
/source-storage/records/${inventory-id}/formatted?idType=INSTANCE 
even for records with "source": "FOLIO" rather than only those with "source": "MARC". 
It has the effect of logging lots of errors in the browser console.

## Approach
- Delete componentDidMount section;
- Update condition related to the record source in the componentDidUpdate section

## Refs
[UIIN-1190](https://issues.folio.org/browse/UIIN-1190)

## Before
![image](https://user-images.githubusercontent.com/63101175/86902696-fc9fe500-c116-11ea-811d-929b6d808ef7.png)

## After
![tempsnip](https://user-images.githubusercontent.com/63101175/86902976-5e604f00-c117-11ea-9be1-f591d2bd4891.png)
