### PR TITLE
UIIN-829: Fix problem with use of useIntl() in stripes-components

### DIFF
--- a/src/Instance/InstanceDetails/InstanceDescriptiveView/InstanceDescriptiveView.js
+++ b/src/Instance/InstanceDetails/InstanceDescriptiveView/InstanceDescriptiveView.js
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import {
   Accordion,
@@ -39,6 +39,7 @@ const InstanceDescriptiveView = ({
 
     return (instance.natureOfContentTermIds || []).map(termId => natureOfContentTermsMap[termId]);
   }, [instance, natureOfContentTerms]);
+  const intl = useIntl();
 
   return (
     <Accordion
@@ -108,7 +109,7 @@ const InstanceDescriptiveView = ({
         <Col xs={12}>
           <KeyValue
             label={<FormattedMessage id="ui-inventory.language" />}
-            value={formatLanguages(instance.languages)}
+            value={formatLanguages(instance.languages, intl)}
           />
         </Col>
       </Row>

--- a/src/Instance/InstanceDetails/InstanceDescriptiveView/utils.js
+++ b/src/Instance/InstanceDetails/InstanceDescriptiveView/utils.js
@@ -1,8 +1,8 @@
 import { formattedLanguageName } from '@folio/stripes/components';
 
 // eslint-disable-next-line
-export const formatLanguages = (languages = []) => {
+export const formatLanguages = (languages = [], intl) => {
   return languages
-    .map(languageCode => formattedLanguageName(languageCode))
+    .map(languageCode => formattedLanguageName(languageCode, intl))
     .join(', ');
 };

--- a/src/components/InstanceFilters/InstanceFilters.js
+++ b/src/components/InstanceFilters/InstanceFilters.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { sortBy } from 'lodash';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import {
   Accordion,
@@ -97,7 +97,7 @@ const InstanceFilters = props => {
 
   let languageOptions = languages.map(l => (
     {
-      label: formattedLanguageName(l.alpha3),
+      label: formattedLanguageName(l.alpha3, useIntl()),
       value: l.alpha3,
     }
   ));

--- a/src/edit/languageFields.js
+++ b/src/edit/languageFields.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'react-final-form';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { sortBy } from 'lodash';
 
 import {
@@ -50,10 +50,11 @@ const LanguageFields = props => {
     canEdit,
     canDelete,
   } = props;
+  const intl = useIntl();
 
   let languageOptions = languages.map(l => (
     {
-      label: formattedLanguageName(l.alpha3),
+      label: formattedLanguageName(l.alpha3, intl),
       value: l.alpha3,
     }
   ));


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-829

My previous solution to localizing language names caused a problem in stripes-components that I overlooked: even though the code worked, the linter complained about the way that I was using useIntl(). This addresses that problem.