### PR TITLE
UIIN-1204: Fix Edit in quickMARC and View Source options state after instance editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Possible error for Source=FOLIO instances has been fixed. Refs UIIN-1190.
 * Action menu edit in split screen instance records. Refs UIIN-1116.
 * Validate presence of resources before accessing them. Refs UIIN-1203, STCON-111.
+* Fix Edit in quickMARC and View Source options state after instance editing. Refs UIIN-1204.
 
 ## [4.0.1](https://github.com/folio-org/ui-inventory/tree/v4.0.1) (2020-07-01)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v4.0.0...v4.0.1)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -91,18 +91,34 @@ class ViewInstance extends React.Component {
     this.calloutRef = createRef();
   }
 
+  componentDidMount() {
+    const isMARCSource = this.isMARCSource();
+
+    if (isMARCSource) {
+      this.getMARCRecord();
+    }
+  }
+
   componentDidUpdate(prevProps) {
     const { resources: prevResources } = prevProps;
     const { resources } = this.props;
     const instanceRecords = resources?.selectedInstance?.records;
     const instanceRecordsId = instanceRecords[0]?.id;
-    const instanceRecordsSource = instanceRecords[0]?.source;
     const prevInstanceRecordsId = prevResources?.selectedInstance?.records[0]?.id;
-    const isMarcSource = instanceRecordsSource === 'MARC';
+    const isMARCSource = this.isMARCSource();
 
-    if (!isMarcSource || instanceRecordsId === prevInstanceRecordsId) return;
-    this.getMARCRecord();
+    if (isMARCSource && instanceRecordsId !== prevInstanceRecordsId) {
+      this.getMARCRecord();
+    }
   }
+
+  isMARCSource = () => {
+    const { resources } = this.props;
+    const instanceRecords = resources?.selectedInstance?.records;
+    const instanceRecordsSource = instanceRecords?.[0]?.source;
+
+    return instanceRecordsSource === 'MARC';
+  };
 
   getMARCRecord = () => {
     const { mutator } = this.props;


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
`Edit in quickMARC` and `View Source` options become grayed out after instance editing.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Get MARC record data after component mounted. When component updated, check if instance record id changed and update MARC record data.

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
