### PR TITLE
STSMACOM-194: Add test to check if the sort terms are reset to defaul…

### DIFF
--- a/test/bigtest/interactors/inventory.js
+++ b/test/bigtest/interactors/inventory.js
@@ -78,6 +78,7 @@ export default @interactor class InventoryInteractor {
   updatedDate = new DateRangeFilterInteractor('#updatedDate');
   source = new CheckboxFilterInteractor('#source');
   callout = new CalloutInteractor();
+  resetAll = clickable('#clickable-reset-all');
 
   whenLoaded() {
     return this.when(() => this.isLoaded);

--- a/test/bigtest/interactors/routes/instances-route.js
+++ b/test/bigtest/interactors/routes/instances-route.js
@@ -13,4 +13,5 @@ export default @interactor class InstancesRouteInteractor {
 
   searchFieldFilter = scoped('#pane-filter', SearchFieldFilterInteractor);
   rows = collection('#list-inventory [data-row-index]');
+  headers = collection('#list-inventory [data-test-clickable-header]');
 }

--- a/test/bigtest/tests/filters/instances/instance-filters-test.js
+++ b/test/bigtest/tests/filters/instances/instance-filters-test.js
@@ -135,15 +135,20 @@ describe('Instance filters', () => {
     });
   });
 
-  describe('setting filters', () => {
+  describe('setting filters and sorting', () => {
     beforeEach(async function () {
       await inventory.clickSelectStaffSuppressFilter();
       await inventory.clickSelectDiscoverySuppressFilter();
+      await instancesRoute.headers(1).click();
     });
 
     it('adds filters to the URL', function () {
       expect(this.location.search).to.include('staffSuppress.true');
       expect(this.location.search).to.include('discoverySuppress.true');
+    });
+
+    it('selected sorting should be set in URL', function () {
+      expect(this.location.search).to.include('sort=contributors');
     });
 
     describe('clearing filters', () => {
@@ -155,6 +160,16 @@ describe('Instance filters', () => {
       it('removes filters from the URL', function () {
         expect(this.location.search).to.not.include('staffSuppress.true');
         expect(this.location.search).to.not.include('discoverySuppress.true');
+      });
+    });
+
+    describe('clicking Reset all button', () => {
+      beforeEach(async function () {
+        await inventory.resetAll();
+      });
+
+      it('default sorting should be set in URL', function () {
+        expect(this.location.search).to.include('sort=title');
       });
     });
   });


### PR DESCRIPTION
Created to test changes https://github.com/folio-org/stripes-smart-components/pull/880.
Scope of https://issues.folio.org/browse/STSMACOM-194

### Purpose
Add a test to check if the sort terms are reset to the default value when clicking the `Reset all` button.