### PR TITLE
UIIN-1040: Add search only by the call number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Fix Edit in quickMARC and View Source options state after instance editing. Refs UIIN-1204.
 * Change request status for `Awaiting delivery` items marked as missing. Fixes UIIN-1206.
 * In transit report does not export name of library. Refs UIIN-1058.
+* `Holdings - Call number, eye readable`. Add search only by the call number. Refs UIIN-1040.
 
 ## [4.0.1](https://github.com/folio-org/ui-inventory/tree/v4.0.1) (2020-07-01)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v4.0.0...v4.0.1)

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -105,7 +105,11 @@ export const holdingIndexes = [
   { label: 'ui-inventory.issn', value: 'issn', queryTemplate: 'identifiers =/@value/@identifierTypeId="<%= identifierTypeId %>" "%{query.query}"' },
   { label: 'ui-inventory.callNumberEyeReadable',
     value: 'callNumberER',
-    queryTemplate: 'holdingsRecords.fullCallNumber=="%{query.query}" OR holdingsRecords.callNumberAndSuffix=="%{query.query}"' },
+    queryTemplate: `
+      holdingsRecords.fullCallNumber=="%{query.query}" 
+      OR holdingsRecords.callNumberAndSuffix=="%{query.query}" 
+      OR holdingsRecords.callNumber=="%{query.query}"
+    ` },
   { label: 'ui-inventory.callNumberNormalized',
     value: 'callNumberNormalized',
     queryTemplate: 'holdingsRecords.fullCallNumberNormalized="%{query.query}" OR holdingsRecords.callNumberAndSuffixNormalized="%{query.query}"' },

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -149,8 +149,10 @@ export default function configure() {
           inst.contributors[0].name.match(right.term));
       }
 
-      if (left?.field === 'holdingsRecords.fullCallNumber') {
-        const holding = holdings.where({ callNumber: left.term }).models[0];
+      // With the addition of a third condition to search for records by 'Holdings. Call number readable by eye" in the CQL query,
+      // cqlParser.tree object gets a deeper structure in the 'left' and 'right' properties.
+      if (left?.left?.field === 'holdingsRecords.fullCallNumber') {
+        const holding = holdings.where({ callNumber: left.left.term }).models[0];
 
         return instances.where({ id: holding.instanceId });
       }


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1040

### Purpose
Add the ability to search for records in the `Holdings - Call number, eye readable` search option directly by the `callNumber` value.

### Approach
This was achieved by adding the condition `callNumber == "$ {value}"` to the `CQL query` string.