### PR TITLE
UIIN-829: Improve handling of language names

### DIFF
--- a/src/Instance/InstanceDetails/InstanceDescriptiveView/InstanceDescriptiveView.js
+++ b/src/Instance/InstanceDetails/InstanceDescriptiveView/InstanceDescriptiveView.js
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
 
+import { useStripes } from '@folio/stripes/core';
 import {
   Accordion,
   Row,
@@ -39,6 +40,8 @@ const InstanceDescriptiveView = ({
 
     return (instance.natureOfContentTermIds || []).map(termId => natureOfContentTermsMap[termId]);
   }, [instance, natureOfContentTerms]);
+
+  const { locale } = useStripes();
   const intl = useIntl();
 
   return (
@@ -109,7 +112,7 @@ const InstanceDescriptiveView = ({
         <Col xs={12}>
           <KeyValue
             label={<FormattedMessage id="ui-inventory.language" />}
-            value={formatLanguages(instance.languages, intl)}
+            value={formatLanguages(instance.languages, intl, locale)}
           />
         </Col>
       </Row>

--- a/src/Instance/InstanceDetails/InstanceDescriptiveView/utils.js
+++ b/src/Instance/InstanceDetails/InstanceDescriptiveView/utils.js
@@ -1,8 +1,8 @@
 import { formattedLanguageName } from '@folio/stripes/components';
 
 // eslint-disable-next-line
-export const formatLanguages = (languages = [], intl) => {
+export const formatLanguages = (languages = [], intl, locale) => {
   return languages
-    .map(languageCode => formattedLanguageName(languageCode, intl))
+    .map(languageCode => formattedLanguageName(languageCode, intl, locale))
     .join(', ');
 };

--- a/src/components/InstanceFilters/InstanceFilters.js
+++ b/src/components/InstanceFilters/InstanceFilters.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { sortBy } from 'lodash';
 import { FormattedMessage, useIntl } from 'react-intl';
 
+import { useStripes } from '@folio/stripes/core';
 import {
   Accordion,
   FilterAccordionHeader,
-  formattedLanguageName,
-  languages,
+  languageOptions,
 } from '@folio/stripes/components';
 import {
   CheckboxFilter,
@@ -95,13 +94,9 @@ const InstanceFilters = props => {
     },
   ];
 
-  let languageOptions = languages.map(l => (
-    {
-      label: formattedLanguageName(l.alpha3, useIntl()),
-      value: l.alpha3,
-    }
-  ));
-  languageOptions = sortBy(languageOptions, ['label']);
+  const intl = useIntl();
+  const stripes = useStripes();
+  const langOptions = languageOptions(intl, stripes.locale);
 
   return (
     <React.Fragment>
@@ -133,7 +128,7 @@ const InstanceFilters = props => {
       >
         <MultiSelectionFilter
           name="language"
-          dataOptions={languageOptions}
+          dataOptions={langOptions}
           selectedValues={language}
           onChange={onChange}
         />

--- a/src/edit/languageFields.js
+++ b/src/edit/languageFields.js
@@ -2,17 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'react-final-form';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { sortBy } from 'lodash';
 
+import { useStripes } from '@folio/stripes/core';
 import {
-  formattedLanguageName,
-  languages,
+  languageOptions,
   Select,
 } from '@folio/stripes/components';
 
 import RepeatableField from '../components/RepeatableField';
 
-const renderLanguageField = ({ field, fieldIndex, canEdit, languageOptions }) => {
+const renderLanguageField = ({ field, fieldIndex, canEdit, langOptions }) => {
   const label = fieldIndex === 0 ? <FormattedMessage id="ui-inventory.language" /> : null;
 
   return (
@@ -23,7 +22,7 @@ const renderLanguageField = ({ field, fieldIndex, canEdit, languageOptions }) =>
           name={field}
           component={Select}
           placeholder={placeholder}
-          dataOptions={languageOptions}
+          dataOptions={langOptions}
           required
           data-test-language-field-count={fieldIndex}
           disabled={!canEdit}
@@ -37,11 +36,11 @@ renderLanguageField.propTypes = {
   field: PropTypes.object,
   fieldIndex: PropTypes.number,
   canEdit: PropTypes.bool,
-  languageOptions: PropTypes.arrayOf(PropTypes.object),
+  langOptions: PropTypes.arrayOf(PropTypes.object),
 };
 renderLanguageField.defaultProps = {
   canEdit: true,
-  languageOptions: [],
+  langOptions: [],
 };
 
 const LanguageFields = props => {
@@ -50,15 +49,10 @@ const LanguageFields = props => {
     canEdit,
     canDelete,
   } = props;
-  const intl = useIntl();
 
-  let languageOptions = languages.map(l => (
-    {
-      label: formattedLanguageName(l.alpha3, intl),
-      value: l.alpha3,
-    }
-  ));
-  languageOptions = sortBy(languageOptions, ['label']);
+  const intl = useIntl();
+  const stripes = useStripes();
+  const langOptions = languageOptions(intl, stripes.locale);
 
   return (
     <RepeatableField
@@ -67,7 +61,7 @@ const LanguageFields = props => {
       addLabel={<FormattedMessage id="ui-inventory.addLanguage" />}
       addButtonId="clickable-add-language"
       template={[{
-        render(fieldObj) { return renderLanguageField({ ...fieldObj, canEdit, languageOptions }); },
+        render(fieldObj) { return renderLanguageField({ ...fieldObj, canEdit, langOptions }); },
       }]}
       canAdd={canAdd}
       canDelete={canDelete}


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-829

This PR simplifies the language-name-handling code based on the reworking of the stripes-components languages file (see https://github.com/folio-org/stripes-components/pull/1342)