### PR TITLE
Use Serializer and explicitely state whats included

### DIFF
--- a/test/bigtest/network/serializers/application.js
+++ b/test/bigtest/network/serializers/application.js
@@ -1,3 +1,5 @@
 import { Serializer } from '@bigtest/mirage';
 
-export default Serializer;
+export default Serializer.extend({
+  serializeIds: 'always'
+});

--- a/test/bigtest/network/serializers/application.js
+++ b/test/bigtest/network/serializers/application.js
@@ -1,3 +1,3 @@
-import { RestSerializer } from '@bigtest/mirage';
+import { Serializer } from '@bigtest/mirage';
 
-export default RestSerializer;
+export default Serializer;

--- a/test/bigtest/network/serializers/holding.js
+++ b/test/bigtest/network/serializers/holding.js
@@ -4,11 +4,6 @@ const { isArray } = Array;
 const { assign } = Object;
 
 export default ApplicationSerializer.extend({
-
-  include: [
-    'instance'
-  ],
-
   serialize(object, request) {
     const json = ApplicationSerializer.prototype.serialize.call(this, object, request);
 

--- a/test/bigtest/network/serializers/holding.js
+++ b/test/bigtest/network/serializers/holding.js
@@ -5,6 +5,10 @@ const { assign } = Object;
 
 export default ApplicationSerializer.extend({
 
+  include: [
+    'instance'
+  ],
+
   serialize(object, request) {
     const json = ApplicationSerializer.prototype.serialize.call(this, object, request);
 


### PR DESCRIPTION
## Purpose

In the process of migrating from `@bigtest/mirage` to `miragejs` in #1110, we found that Mirage payloads are missing `instanceId`. `miragejs` migration caused `Instances -> instance segment -> remember search results -> should keep search results around after item is closed` test to fail. 

We dug into why this test is failing and found that navigating from search results to instance view had `undefined` in the url. 

<img width="1392" alt="link-before-2" src="https://user-images.githubusercontent.com/74687/88454501-273fac80-ce3e-11ea-948a-6e2007c322dc.png">

After further investigation, we found that `instanceId` was not being included in the payload in tests. 

<img width="539" alt="payload-before" src="https://user-images.githubusercontent.com/74687/88454258-39b8e680-ce3c-11ea-8553-4ab9ed4a59e2.png">

## Approach

1. `instanceId` is missing because Instance relationship is not being included in the payload. I added `serializeIds: 'always'` to Application serializer so ensure that relationships are always included. 
2. I changed the Application serializer that's used as a base for all serializers to `Serializer` instead of `RestSerializer`. They are very similar but `Serializer` adds `Id` to the relationship property.  

The result is that `instanceId` is now being included in the payload.

<img width="542" alt="payload-after" src="https://user-images.githubusercontent.com/74687/88454333-dbd8ce80-ce3c-11ea-9d96-e7b8a114fdc6.png">

Consequently, the link is generated correctly.

<img width="1312" alt="link-after-2" src="https://user-images.githubusercontent.com/74687/88454505-2dce2400-ce3e-11ea-89a2-60c8798543af.png">

## Learning

* [Serializer#include](https://miragejs.com/api/classes/serializer/#include) - Use this property on a model serializer to specify related models you'd like to include in your JSON payload. (These can be considered default server-side includes.)
* [Serializer#serializeIds](https://miragejs.com/api/classes/serializer/#serialize-ids) - Use this to define how your serializer handles serializing relationship keys.