### PR TITLE
UIIN-1041: Item segment - Add search only by the call number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * In transit report does not export name of library. Refs UIIN-1058.
 * `Holdings - Call number, eye readable`. Add search only by the call number. Refs UIIN-1040.
 * Replace `bigtest/mirage` with `miragejs`.
+* `Item - Effective call number (item), eye readable`. Add search only by the call number. Refs UIIN-1041.
 
 ## [4.0.1](https://github.com/folio-org/ui-inventory/tree/v4.0.1) (2020-07-01)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v4.0.0...v4.0.1)

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -146,7 +146,11 @@ export const itemIndexes = [
   { label: 'ui-inventory.issn', value: 'issn', queryTemplate: 'identifiers =/@value/@identifierTypeId="<%= identifierTypeId %>" "%{query.query}"' },
   { label: 'ui-inventory.itemEffectiveCallNumberEyeReadable',
     value: 'itemCallNumberER',
-    queryTemplate: 'item.fullCallNumber=="%{query.query}" OR item.callNumberAndSuffix=="%{query.query}"' },
+    queryTemplate: `
+      item.fullCallNumber=="%{query.query}" 
+      OR item.callNumberAndSuffix=="%{query.query}" 
+      OR item.effectiveCallNumberComponents.callNumber=="%{query.query}"
+    ` },
   { label: 'ui-inventory.itemEffectiveCallNumberNormalized',
     value: 'itemCallNumberNorm',
     queryTemplate: 'item.fullCallNumberNormalized="%{query.query}" OR item.callNumberAndSuffixNormalized="%{query.query}"' },

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -170,8 +170,10 @@ export default function configure() {
         return instances.where({ id: holding?.instanceId });
       }
 
-      if (left?.field === 'item.fullCallNumber') {
-        const item = items.where({ callNumber: left.term }).models[0];
+      // With the addition of a third condition to search for records by 'Item. Effective call number eye readable" in the CQL query,
+      // cqlParser.tree object gets a deeper structure in the 'left' and 'right' properties.
+      if (left?.left?.field === 'item.fullCallNumber') {
+        const item = items.where({ callNumber: left.left.term }).models[0];
         const holding = holdings.where({ id: item.holdingsRecordId }).models[0];
 
         return instances.where({ id: holding.instanceId });


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1041

### Purpose
Add the ability to search for records in the `Item - Effective call number (item), eye readable` search option directly by the `callNumber` value.

### Approach
This was achieved by adding the condition `effectiveCallNumberComponents.callNumber == "${value}"` to the `CQL query` string.