### PR TITLE
FOLIO-2727 change filter languages

### DIFF
--- a/test/ui-testing/filters.js
+++ b/test/ui-testing/filters.js
@@ -107,7 +107,7 @@ module.exports.test = function uiTest(uiTestCtx) {
       });
 
       describe('Should test instance language filters', () => {
-        const languageFilters = ['English', 'Spanish'];
+        const languageFilters = ['English', 'French'];
 
         it('should navigate to inventory\'s instance segment"', (done) => {
           navigateTo('#segment-navigation-instances', done);


### PR DESCRIPTION
I SWEAR THIS IS TRUE: The list of available languages is generated by
stripes-components and changed in
https://github.com/folio-org/stripes-components/pull/1319 as part of
[UIIN-829](https://issues.folio.org/browse/UIIN-829). It turns out the [ISO-639 languages](https://www.loc.gov/standards/iso639-2/ascii_8bits.html), as of 2020-08-19, do not
include simple `Spanish` but only `Spanish; Castilian` which is sort of
non-sensical to me becuase Folio itself is offered in more than one
Spanish dialect/locale (Spanish and Latin American Spanish).

The old filters test used `English` and `Spanish` as test filters, but
since `Spanish` is no longer a legit value, the test failed. Maintenant,
nous parlons Français.

Refs [FOLIO-2727](https://issues.folio.org/browse/FOLIO-2727)