### PR TITLE
UIIN-907 Fast add record. Access New fast add template from Inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.0.0 (IN PROGRESS)
 
+* corrected icon for fast add dropdown option.  Addresses UIIN-907.
 * Add an fast add record button to action menu.  Addresses UIIN-907.
 * Move and confirm items and holdings or items to a new instance. Refs UIIN-1101.
 * Add Item screen : Incorrect aria label. Refs UIIN-1104.

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -268,7 +268,7 @@ class InstancesView extends React.Component {
         </IfPermission>
         {this.getActionItem({
           id: 'new-fast-add-record',
-          icon: 'plus-sign',
+          icon: 'lightning',
           messageId: 'ui-inventory.newFastAddRecord',
           onClickHandler: buildOnClickHandler(this.toggleNewFastAddModal),
         })}


### PR DESCRIPTION
I was asked to change the icon for the fast-add option in the dropdown menu.

Refs: https://issues.folio.org/browse/UIIN-907