### PR TITLE
UIIN-1199: Remove "Received" from item status search & filter list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.0.0 (IN PROGRESS)
 
+* removed "recieved" status from search and sort menu.  Addresses UIIN-1199.
 * corrected icon for fast add dropdown option.  Addresses UIIN-907.
 * Add an fast add record button to action menu.  Addresses UIIN-907.
 * Move and confirm items and holdings or items to a new instance. Refs UIIN-1101.

--- a/src/constants.js
+++ b/src/constants.js
@@ -38,7 +38,6 @@ export const itemStatuses = [
   { label: 'ui-inventory.item.status.onOrder', value: 'On order' },
   { label: 'ui-inventory.item.status.paged', value: 'Paged' },
   { label: 'ui-inventory.item.status.declaredLost', value: 'Declared lost' },
-  { label: 'ui-inventory.item.status.received', value: 'Received' },
   { label: 'ui-inventory.item.status.orderClosed', value: 'Order closed' },
   { label: 'ui-inventory.item.status.withdrawn', value: 'Withdrawn' },
   { label: 'ui-inventory.item.status.claimedReturned', value: 'Claimed returned' },

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -450,7 +450,6 @@
   "item.status.onOrder": "On order",
   "item.status.paged": "Paged",
   "item.status.declaredLost": "Declared lost",
-  "item.status.received": "Received",
   "item.status.orderClosed": "Order closed",
   "item.status.withdrawn": "Withdrawn",
   "item.status.claimedReturned": "Claimed returned",


### PR DESCRIPTION
I removed this from the module's list of item statuses, and the label
from the translation file. I did a module-wide search, and no other page
seemed to be using the label.

Refs: https://issues.folio.org/browse/UIIN-1199


