### PR TITLE
UIIN-1006 list "Aged to lost" in filters

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -28,6 +28,7 @@ export const requestStatuses = {
 };
 
 export const itemStatuses = [
+  { label: 'ui-inventory.item.status.agedToLost', value: 'Aged to lost' },
   { label: 'ui-inventory.item.status.available', value: 'Available' },
   { label: 'ui-inventory.item.status.awaitingPickup', value: 'Awaiting pickup' },
   { label: 'ui-inventory.item.status.awaitingDelivery', value: 'Awaiting delivery' },

--- a/test/bigtest/interactors/routes/items-route.js
+++ b/test/bigtest/interactors/routes/items-route.js
@@ -20,6 +20,8 @@ export default @interactor class ItemsRouteInteractor {
   permLocationFilter = scoped('#holdingsPermanentLocationAccordion', MultiSelectFilterInteractor);
   itemStatusFilter = scoped('#itemFilterAccordion', CheckboxFilterInteractor);
 
+  itemStatusFilterClickMissing = clickable('#itemFilterAccordion input[name="Missing"]');
+
   rows = collection('#list-inventory [data-row-index]');
 
   isDiscoverySuppressFilterPresent = isPresent('[data-test-filter-item-discovery-suppress]');

--- a/test/bigtest/tests/filters/items/item-status-filter-test.js
+++ b/test/bigtest/tests/filters/items/item-status-filter-test.js
@@ -16,10 +16,9 @@ describe('ItemStatusFilter', () => {
   beforeEach(function () {
     this.visit('/inventory?segment=items');
   });
-
   describe('choose item status', () => {
     beforeEach(async () => {
-      await itemsRoute.itemStatusFilter.checkboxes.dataOptions(6).click();
+      await itemsRoute.itemStatusFilterClickMissing();
     });
 
     it('finds instances by chosen item status', () => {

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -440,6 +440,7 @@
   "marc": "MARC",
   "unknownNoteType": "Unknown note type",
   "item.status": "Item status",
+  "item.status.agedToLost": "Aged to lost",
   "item.status.available": "Available",
   "item.status.awaitingPickup": "Awaiting pickup",
   "item.status.awaitingDelivery": "Awaiting delivery",


### PR DESCRIPTION
There is more than one place where item-statuses are listed because not
all statuses are available under all circumstances. I missed adding it
to the item-status-filter in #1122.

Refs [UIIN-1006](https://issues.folio.org/browse/UIIN-1006)