### PR TITLE
Hide an empty list when there are no items in `Holdings` record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Moving holdings and items permissions. Refs UIIN-1120.
 * Drag and drop accessibility. UIIN-1127.
 * Confirm items before moving to different holdings and/or instances. UIIN-1226.
+* Hide an empty list when there are no items in `Holdings` record. Refs UIIN-1076.
 
 ## [4.0.1](https://github.com/folio-org/ui-inventory/tree/v4.0.1) (2020-07-01)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v4.0.0...v4.0.1)

--- a/src/Instance/HoldingsList/Holding/Holding.js
+++ b/src/Instance/HoldingsList/Holding/Holding.js
@@ -2,6 +2,7 @@ import React, {
   useMemo,
   useCallback,
   useContext,
+  useState,
 } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
@@ -50,6 +51,10 @@ const Holding = ({
   const { locationsById } = referenceData;
   const labelLocation = holding.permanentLocationId ? locationsById[holding.permanentLocationId].name : '';
   const withMoveDropdown = draggable || isDraggable;
+
+  const [open, setOpen] = useState(false);
+
+  const handleAccordionToggle = () => setOpen(!open);
 
   const viewHoldings = useCallback(() => {
     onViewHolding();
@@ -114,7 +119,8 @@ const Holding = ({
       }
       <Accordion
         id={holding.id}
-        closedByDefault={false}
+        open={open}
+        onToggle={handleAccordionToggle}
         label={(
           <FormattedMessage
             id="ui-inventory.holdingsHeader"
@@ -125,12 +131,14 @@ const Holding = ({
           />
         )}
         displayWhenOpen={holdingButtonsGroup}
+        displayWhenClosed={holdingButtonsGroup}
       >
         <Row>
           <Col sm={12}>
             <ItemsListContainer
               key={`items_${holding.id}`}
               holding={holding}
+              setOpen={setOpen}
 
               draggable={draggable}
               droppable={droppable}

--- a/src/Instance/ItemsList/ItemsList.js
+++ b/src/Instance/ItemsList/ItemsList.js
@@ -9,6 +9,7 @@ import {
   FormattedMessage,
   useIntl,
 } from 'react-intl';
+import { isEmpty } from 'lodash';
 
 import {
   Checkbox,
@@ -164,6 +165,9 @@ const ItemsList = ({
 
     setItemsSorting(newItemsSorting);
   }, [itemsSorting]);
+
+  if (!draggable && isEmpty(items)) return null;
+
   return (
     <DropZone
       isItemsDropable={isItemsDropable}

--- a/src/Instance/ItemsList/ItemsListContainer.js
+++ b/src/Instance/ItemsList/ItemsListContainer.js
@@ -3,12 +3,13 @@ import React, {
   useState,
 } from 'react';
 import PropTypes from 'prop-types';
+import { isEmpty } from 'lodash';
 
 import { stripesConnect } from '@folio/stripes/core';
 
 import ItemsList from './ItemsList';
 
-const ItemsListContainer = ({ holding, mutator, ...rest }) => {
+const ItemsListContainer = ({ holding, mutator, setOpen, ...rest }) => {
   const [items, setItems] = useState();
   const [isLoading, setIsLoading] = useState(true);
 
@@ -16,7 +17,10 @@ const ItemsListContainer = ({ holding, mutator, ...rest }) => {
     setIsLoading(true);
 
     mutator.instanceHoldingItems.GET()
-      .then(setItems)
+      .then(data => {
+        setItems(data);
+        if (!isEmpty(data)) setOpen(true);
+      })
       .finally(() => {
         setIsLoading(false);
       });
@@ -50,6 +54,7 @@ ItemsListContainer.manifest = Object.freeze({
 ItemsListContainer.propTypes = {
   mutator: PropTypes.object.isRequired,
   holding: PropTypes.object.isRequired,
+  setOpen: PropTypes.func.isRequired,
 };
 
 export default stripesConnect(ItemsListContainer);


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1076

## Purpose
Do not show an empty list if there are no items in the given `Holdings` record, and the draggable mode is deactivated.

### Demo

![Hide_empty_list](https://user-images.githubusercontent.com/49517355/91312556-0a8bf100-e7bd-11ea-9ff3-63dae8ba960f.gif)
