### PR TITLE
UIIN-1185: Awaiting pickup is linked on item record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.0.0 (IN PROGRESS)
 
+* removed link around awaiting pickup status in item detail view.  Addresses UIIN-1185.
 * removed "recieved" status from search and sort menu.  Addresses UIIN-1199.
 * corrected icon for fast add dropdown option.  Addresses UIIN-907.
 * Add an fast add record button to action menu.  Addresses UIIN-907.

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -354,14 +354,6 @@ class ItemView extends React.Component {
       borrowerLink = <Link to={`/users/view/${openLoan.userId}`}>{openLoan.borrower.barcode}</Link>;
     }
 
-    if (loanLink === 'Awaiting pickup') {
-      loanLink = (
-        <Link to={requestsUrl}>
-          {loanLink}
-        </Link>
-      );
-    }
-
     const refLookup = (referenceTable, id) => {
       const ref = (referenceTable && id) ? referenceTable.find(record => record.id === id) : {};
 


### PR DESCRIPTION
To address this I just removed the if clause that
modifies the loan status string into a link if the
item status is Awaiting Pickup.  Very simple.

refs: https://issues.folio.org/browse/UIIN-1185
