### PR TITLE
UIIN-1093: Holdings record. Actions menu - make order of actions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.0.0 (IN PROGRESS)
 
+* changed order of items on holdings record action menu.  Addresses UIIN-1093.
 * removed "recieved" status from search and sort menu.  Addresses UIIN-1199.
 * corrected icon for fast add dropdown option.  Addresses UIIN-907.
 * Add an fast add record button to action menu.  Addresses UIIN-907.

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -197,23 +197,6 @@ class ViewHoldingsRecord extends React.Component {
     return (
       <Fragment>
         {
-          canDelete &&
-          <Button
-            id="clickable-delete-holdingsrecord"
-            onClick={() => {
-              onToggle();
-              this.setState(this.canDeleteHoldingsRecord(firstRecordOfHoldings) ?
-                { confirmHoldingsRecordDeleteModal: true } : { noHoldingsRecordDeleteModal: true });
-            }}
-            buttonStyle="dropdownItem"
-            data-test-inventory-delete-holdingsrecord-action
-          >
-            <Icon icon="trash">
-              <FormattedMessage id="ui-inventory.deleteHoldingsRecord" />
-            </Icon>
-          </Button>
-        }
-        {
           canEdit &&
           <Button
             id="edit-holdings"
@@ -241,6 +224,23 @@ class ViewHoldingsRecord extends React.Component {
           >
             <Icon icon="duplicate">
               <FormattedMessage id="ui-inventory.duplicateHoldings" />
+            </Icon>
+          </Button>
+        }
+        {
+          canDelete &&
+          <Button
+            id="clickable-delete-holdingsrecord"
+            onClick={() => {
+              onToggle();
+              this.setState(this.canDeleteHoldingsRecord(firstRecordOfHoldings) ?
+                { confirmHoldingsRecordDeleteModal: true } : { noHoldingsRecordDeleteModal: true });
+            }}
+            buttonStyle="dropdownItem"
+            data-test-inventory-delete-holdingsrecord-action
+          >
+            <Icon icon="trash">
+              <FormattedMessage id="ui-inventory.deleteHoldingsRecord" />
             </Icon>
           </Button>
         }


### PR DESCRIPTION

I rearranged the items in the holdings screen action menu to make them
consistent with the ordering of items on the other action menus.

Refs: https://issues.folio.org/browse/UIIN-1093

