### PR TITLE
UIIN-1257: Add permission for editing the Fast add settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * Hide an empty list when there are no items in `Holdings` record. Refs UIIN-1076.
 * Add settings page for fast add. Refs UIIN-1211.
 * Increment `react-intl` to `v5`. Refs UIIN-1252.
+* Create permission for Settings -> Inventory -> Fast add. Refs UIIN-1257.
 
 ## [4.0.1](https://github.com/folio-org/ui-inventory/tree/v4.0.1) (2020-07-01)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v4.0.0...v4.0.1)

--- a/package.json
+++ b/package.json
@@ -368,6 +368,18 @@
         "visible": true
       },
       {
+        "permissionName": "ui-inventory.settings.fast-add",
+        "displayName": "Settings (Inventory): Edit fast add settings",
+        "subPermissions": [
+          "inventory-storage.instance-statuses.collection.get",
+          "configuration.entries.collection.get",
+          "configuration.entries.item.post",
+          "configuration.entries.item.put",
+          "settings.inventory.enabled"
+        ],
+        "visible": true
+      },
+      {
         "permissionName": "ui-inventory.settings.hrid-handling",
         "displayName": "Settings (Inventory): Create, edit and delete HRID handling",
         "subPermissions": [
@@ -595,7 +607,8 @@
           "inventory-storage.holdings-note-types.item.get",
           "inventory-storage.item-note-types.collection.get",
           "inventory-storage.item-note-types.item.get",
-          "inventory-storage.hrid-settings.item.get"
+          "inventory-storage.hrid-settings.item.get",
+          "configuration.entries.collection.get"
         ],
         "visible": true
       },

--- a/src/settings/FastAdd/FastAddSettings.js
+++ b/src/settings/FastAdd/FastAddSettings.js
@@ -63,11 +63,18 @@ class FastAddSettings extends Component {
   }
 
   render() {
-    const { label, resources } = this.props;
+    const {
+      label,
+      resources,
+      stripes,
+    } = this.props;
+
     const instanceStatuses = get(resources, 'instanceStatuses.records', []).map(({ code, name }) => ({
       label: name,
       value: code,
     }));
+
+    const canEdit = stripes.hasPerm('ui-inventory.settings.fast-add');
 
     if (resources.instanceStatuses.isPending) return <LoadingPane />;
 
@@ -96,6 +103,7 @@ class FastAddSettings extends Component {
                         fullWidth
                         label={<FormattedMessage id="ui-inventory.defaultInstanceStatus" />}
                         name="instanceStatusCode"
+                        readOnly={!canEdit}
                       />
                     )}
                   </FormattedMessage>
@@ -121,6 +129,7 @@ class FastAddSettings extends Component {
                     fullWidth
                     label={<FormattedMessage id="ui-inventory.defaultDiscoverySuppress" />}
                     name="defaultDiscoverySuppress"
+                    readOnly={!canEdit}
                   />
                 </Col>
               </Row>

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -149,6 +149,7 @@ class InventorySettings extends React.Component {
             route: 'fastAdd',
             label: <FormattedMessage id="ui-inventory.fastAdd" />,
             component: FastAddSettings,
+            perm: this.addPerm('ui-inventory.settings.fast-add'),
           },
           {
             route: 'hridHandling',

--- a/test/bigtest/interactors/settings/fast-add/fast-add.js
+++ b/test/bigtest/interactors/settings/fast-add/fast-add.js
@@ -12,6 +12,8 @@ import SelectInteractor from '@folio/stripes-components/lib/Select/tests/interac
   cancelFormButtonDisabled = property('[data-test-cancel-button]', 'disabled');
   defaultInstanceStatus = new SelectInteractor('[data-test-default-instance-status] [class^="select---"]');
   defaultDiscoverySuppress = new SelectInteractor('[data-test-default-discovery-suppress] [class^="select---"]');
+  defaultInstanceStatusReadOnly = property('select[name="instanceStatusCode"] option:last-child', 'disabled');
+  defaultDiscoverySuppressReadOnly = property('select[name="defaultDiscoverySuppress"] option', 'disabled');
 }
 
 export default new FastAddSettingsInteractor();

--- a/test/bigtest/tests/settings/fast-add/fast-add-test.js
+++ b/test/bigtest/tests/settings/fast-add/fast-add-test.js
@@ -42,4 +42,46 @@ describe('Settings page for Fast add', () => {
       expect(FastAddSettings.cancelFormButtonDisabled).to.be.false;
     });
   });
+
+  describe('Patron has permissions', () => {
+    setupApplication({
+      hasAllPerms: false,
+      permissions: {
+        'settings.inventory.enabled': true,
+        'ui-inventory.settings.fast-add': true,
+      },
+    });
+
+    beforeEach(async function () {
+      this.server.createList('instance-status', 3);
+
+      await this.visit('/settings/inventory/fastAdd');
+    });
+
+    it('both selectors should be selectable', () => {
+      expect(FastAddSettings.defaultInstanceStatusReadOnly).to.be.false;
+      expect(FastAddSettings.defaultDiscoverySuppressReadOnly).to.be.false;
+    });
+  });
+
+  describe('Patron does not have permissions', () => {
+    setupApplication({
+      hasAllPerms: false,
+      permissions: {
+        'settings.inventory.enabled': true,
+        'ui-inventory.settings.list.view': true,
+      },
+    });
+
+    beforeEach(async function () {
+      this.server.createList('instance-status', 3);
+
+      await this.visit('/settings/inventory/fastAdd');
+    });
+
+    it('both selectors should be read-only', () => {
+      expect(FastAddSettings.defaultInstanceStatusReadOnly).to.be.true;
+      expect(FastAddSettings.defaultDiscoverySuppressReadOnly).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1257

## Purpose
Add the permission for editing the Fast add settings page. Otherwise, this page should display read-only.