### PR TITLE
UIIN-1259: Correct data validation in statistical code settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.0.0 (IN PROGRESS)
 
+* Fived validator fucntion ofr statitical codes settings.  Addresses UIIN-1259.
 * changed order of items on holdings record action menu.  Addresses UIIN-1093.
 * removed link around awaiting pickup status in item detail view.  Addresses UIIN-1185.
 * removed "recieved" status from search and sort menu.  Addresses UIIN-1199.

--- a/src/settings/StatisticalCodeSettings.js
+++ b/src/settings/StatisticalCodeSettings.js
@@ -46,9 +46,8 @@ class StatisticalCodeSettings extends React.Component {
 
     // if code has been entered, check to make sure the code value is unique
     if (item.code) {
-      const codes = items.map(({ code }) => code);
-      const count = codes.filter(x => x === item.code).length;
-      if (count > 1) {
+      const isDuplicated = items.some(({code}) => code === item.code);
+      if (isDuplicated) {
         errors.code = <FormattedMessage id="ui-inventory.uniqueCode" />;
       }
     }

--- a/src/settings/StatisticalCodeSettings.js
+++ b/src/settings/StatisticalCodeSettings.js
@@ -46,7 +46,7 @@ class StatisticalCodeSettings extends React.Component {
 
     // if code has been entered, check to make sure the code value is unique
     if (item.code) {
-      const isDuplicated = items.some(({code}) => code === item.code);
+      const isDuplicated = items.some(({ code }) => code === item.code);
       if (isDuplicated) {
         errors.code = <FormattedMessage id="ui-inventory.uniqueCode" />;
       }

--- a/src/settings/StatisticalCodeSettings.js
+++ b/src/settings/StatisticalCodeSettings.js
@@ -41,11 +41,20 @@ class StatisticalCodeSettings extends React.Component {
     this.connectedControlledVocab = props.stripes.connect(ControlledVocab);
   }
 
-  validate = (item) => {
+  validate = (item, index, items) => {
     const errors = validateNameAndCode(item);
 
+    // if code has been entered, check to make sure the code value is unique
+    if (item.code) {
+      const codes = items.map(({ code }) => code);
+      const count = codes.filter(x => x === item.code).length;
+      if (count > 1) {
+        errors.code = <FormattedMessage id="ui-inventory.uniqueCode" />;
+      }
+    }
+
     if (!item.statisticalCodeTypeId) {
-      errors.name = <FormattedMessage id="ui-inventory.selectToContinue" />;
+      errors.statisticalCodeTypeId = <FormattedMessage id="ui-inventory.selectToContinue" />;
     }
     return errors;
   };
@@ -82,7 +91,6 @@ class StatisticalCodeSettings extends React.Component {
         const record = _.isArray(statisticalCodeTypes)
           ? statisticalCodeTypes.find(element => element.id === item.statisticalCodeTypeId)
           : null;
-
         return record
           ? <p>{record.name}</p>
           : null;
@@ -116,6 +124,7 @@ class StatisticalCodeSettings extends React.Component {
             nameKey="name"
             id="statistical-codes"
             sortby="code"
+            validate={this.validate}
             editable={hasPerm}
           />
         )}

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -17,6 +17,7 @@
   "item.availability.borrower": "Borrower",
   "item.availability.loanDate": "Loan date",
   "item.availability.dueDate": "Due date",
+  "uniqueCode": "Code must be unique",
   "fillIn": "Please fill this in to continue",
   "selectToContinue": "Please select to continue",
   "add": "Add",


### PR DESCRIPTION
UI-inventory was not passing a validator function to the 
controlledVocabulary component, which was causing submission errors.
Those errors were confusing because they have very generic text, leading
to confusion about what was going wrong.  I re-wrote the validation function
to check that the statistical code was unique and hooked it up to the
component. Data is now being validated properly before being passed to the back end. 

Note that there are still some bugs in this particular settings pane that have
to do with CRUD operations-I have filed separate bug reports for those issues.


refs: https://issues.folio.org/browse/UIIN-1259