### PR TITLE
Reverting code refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 5.0.0 (IN PROGRESS)
 
-* Fived validator fucntion ofr statitical codes settings.  Addresses UIIN-1259.
+* Reverting problematic code refactor in fix of UIIN-1259.
+* Fixed validator fucntion for statitical codes settings.  Addresses UIIN-1259.
 * changed order of items on holdings record action menu.  Addresses UIIN-1093.
 * removed link around awaiting pickup status in item detail view.  Addresses UIIN-1185.
 * removed "recieved" status from search and sort menu.  Addresses UIIN-1199.

--- a/src/settings/StatisticalCodeSettings.js
+++ b/src/settings/StatisticalCodeSettings.js
@@ -46,8 +46,9 @@ class StatisticalCodeSettings extends React.Component {
 
     // if code has been entered, check to make sure the code value is unique
     if (item.code) {
-      const isDuplicated = items.some(({ code }) => code === item.code);
-      if (isDuplicated) {
+      const codes = items.map(({ code }) => code);
+      const count = codes.filter(x => x === item.code).length;
+      if (count > 1) {
         errors.code = <FormattedMessage id="ui-inventory.uniqueCode" />;
       }
     }


### PR DESCRIPTION
One of the reviewers on the PR request for UIIN-1259 suggested a slight refactor to some of the code I wrote, which I accepted and merged in.  I should have tested it first-it's produced a bug where now, the statistical code field is flagging all entered values as duplicates.  I've reverted the refactor here to my old code, which I know works.

Refs: https://issues.folio.org/browse/UIIN-1259