### PR TITLE
UIIN-1268 error message on deleting a statistical code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.0.0 (IN PROGRESS)
 
+* Changed value of 'shouldRefresh' in statistical code settings.  Addresses UIIN-1268
 * Reverting problematic code refactor in fix of UIIN-1259.
 * Fixed validator fucntion for statitical codes settings.  Addresses UIIN-1259.
 * changed order of items on holdings record action menu.  Addresses UIIN-1093.

--- a/src/settings/StatisticalCodeSettings.js
+++ b/src/settings/StatisticalCodeSettings.js
@@ -16,7 +16,7 @@ class StatisticalCodeSettings extends React.Component {
       type: 'okapi',
       path: 'statistical-code-types',
       records: 'statisticalCodeTypes',
-      shouldRefresh: true,
+      shouldRefresh: () => true,
       throwErrors: false,
       GET: {
         path: 'statistical-code-types?query=cql.allRecords=1 &limit=500'


### PR DESCRIPTION
This was caused by an incorrect value for the 'shouldRefresh'
option in the data manifest. That value is supposed to be a function,
not a simple boolean. because of this, basically anytime the ControlledVocab
tried to do any write operation, it caused an error. Changing the value to a simple
function that returns a boolean cleared up the problem.

refs:
https://issues.folio.org/browse/UIIN-1269
https://issues.folio.org/browse/UIIN-1268

