### PR TITLE
UIIN-1276 Confusing error when saving duplicate Statistical code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.0.0 (IN PROGRESS)
 
+* Altering validation code to check for unique statistical code name.  Addresses UIIN-1276.
 * Modified permissions and built permission checking into fast add button.  Addresses UIIN-1210.
 * Changed value of 'shouldRefresh' in statistical code settings.  Addresses UIIN-1268
 * Reverting problematic code refactor in fix of UIIN-1259.

--- a/src/settings/StatisticalCodeSettings.js
+++ b/src/settings/StatisticalCodeSettings.js
@@ -44,12 +44,20 @@ class StatisticalCodeSettings extends React.Component {
   validate = (item, index, items) => {
     const errors = validateNameAndCode(item);
 
-    // if code has been entered, check to make sure the code value is unique
+    // if code/name has been entered, check to make sure the value is unique
     if (item.code) {
       const codes = items.map(({ code }) => code);
       const count = codes.filter(x => x === item.code).length;
       if (count > 1) {
         errors.code = <FormattedMessage id="ui-inventory.uniqueCode" />;
+      }
+    }
+
+    if (item.name) {
+      const names = items.map(({ name }) => name);
+      const count = names.filter(x => x === item.name).length;
+      if (count > 1) {
+        errors.name = <FormattedMessage id="ui-inventory.uniqueName" />;
       }
     }
 

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -18,6 +18,7 @@
   "item.availability.loanDate": "Loan date",
   "item.availability.dueDate": "Due date",
   "uniqueCode": "Code must be unique",
+  "uniqueName": "Name must be unique",
   "fillIn": "Please fill this in to continue",
   "selectToContinue": "Please select to continue",
   "add": "Add",


### PR DESCRIPTION
As part of the fix for this issue, it was requested that the validation
code also check that the statistical code name be unique as well as the
code.

refs: https://issues.folio.org/browse/UIIN-1276

