### PR TITLE
UIIN-906: Highlight search results when searching for item barcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * Implement easy way to copy HRID in the Instance record. Refs UIIN-1000.
 * Add Holdings sources to settings. Refs UIIN-1229.
 * Add Holdings source to holdings view and edit screens. Refs UIIN-1123.
+* Highlight results when searching for item barcode. Refs UIIN-906.
 
 ## [4.0.1](https://github.com/folio-org/ui-inventory/tree/v4.0.1) (2020-07-01)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v4.0.0...v4.0.1)

--- a/src/Instance/ItemsList/ItemBarcode.js
+++ b/src/Instance/ItemsList/ItemBarcode.js
@@ -38,7 +38,7 @@ const ItemBarcode = ({ location, item, holdingId, instanceId }) => {
     });
   }, [item.barcode, callout]);
 
-  const highlightableBarcode = <Highlighter searchWords={[queryBarcode]} text={item.barcode} />;
+  const highlightableBarcode = <Highlighter searchWords={[queryBarcode]} text={String(item.barcode)} />;
   return (
     <>
       <Link

--- a/src/Instance/ItemsList/ItemBarcode.js
+++ b/src/Instance/ItemsList/ItemBarcode.js
@@ -38,7 +38,7 @@ const ItemBarcode = ({ location, item, holdingId, instanceId }) => {
     });
   }, [item.barcode, callout]);
 
-  const highlightableBarcode = <Highlighter searchWords={[queryBarcode]} text={item.barcode}/>
+  const highlightableBarcode = <Highlighter searchWords={[queryBarcode]} text={item.barcode} />;
   return (
     <>
       <Link

--- a/src/Instance/ItemsList/ItemBarcode.js
+++ b/src/Instance/ItemsList/ItemBarcode.js
@@ -11,17 +11,20 @@ import {
   FormattedMessage,
 } from 'react-intl';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
+import queryString from 'query-string';
 
 import {
   CalloutContext,
   AppIcon,
 } from '@folio/stripes/core';
 import {
+  Highlighter,
   IconButton,
 } from '@folio/stripes/components';
 
 const ItemBarcode = ({ location, item, holdingId, instanceId }) => {
   const { search } = location;
+  const queryBarcode = queryString.parse(search)?.query;
 
   const callout = useContext(CalloutContext);
   const onCopyToClipbaord = useCallback(() => {
@@ -35,6 +38,7 @@ const ItemBarcode = ({ location, item, holdingId, instanceId }) => {
     });
   }, [item.barcode, callout]);
 
+  const highlightableBarcode = <Highlighter searchWords={[queryBarcode]} text={item.barcode}/>
   return (
     <>
       <Link
@@ -43,7 +47,7 @@ const ItemBarcode = ({ location, item, holdingId, instanceId }) => {
       >
         <span data-test-items-app-icon>
           <AppIcon app="inventory" iconKey="item" size="small">
-            {item.barcode || <FormattedMessage id="ui-inventory.noBarcode" />}
+            {highlightableBarcode || <FormattedMessage id="ui-inventory.noBarcode" />}
           </AppIcon>
         </span>
       </Link>

--- a/test/bigtest/network/scenarios/item-filters.js
+++ b/test/bigtest/network/scenarios/item-filters.js
@@ -19,6 +19,7 @@ export default function (server) {
   item.materialType = materialType.attrs;
   item.status.name = 'Missing';
   item.hrid = 'it00000000005';
+  item.barcode = '0100110101000011';
 
   item.save();
 }

--- a/test/bigtest/tests/instances-index-test.js
+++ b/test/bigtest/tests/instances-index-test.js
@@ -2,6 +2,7 @@ import { beforeEach, describe, it } from '@bigtest/mocha';
 
 import { expect } from 'chai';
 
+import HighlighterInteractor from '@folio/stripes-components/lib/Highlighter/tests/interactor';
 import setupApplication from '../helpers/setup-application';
 import InventoryInteractor from '../interactors/inventory';
 import ItemPageInteractor from '../interactors/item-page';
@@ -16,6 +17,7 @@ describe('Instances', () => {
   });
 
   const itemInteractor = new ItemPageInteractor();
+  const highlighter = new HighlighterInteractor();
 
   describe('instance segment', () => {
     beforeEach(async function () {
@@ -63,6 +65,10 @@ describe('Instances', () => {
 
         it('loads the instance details', function () {
           expect(inventory.instance.isVisible).to.equal(true);
+        });
+
+        it('highlights the search term', function () {
+          expect(highlighter.highlightedWordCount).to.equal(1);
         });
       });
     });


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-906

This uses `<Highlighter>` to identify the searched-for barcode when an instance is opened.

<img width="1150" alt="Screen Shot 2020-09-30 at 4 22 23 PM" src="https://user-images.githubusercontent.com/1322242/94735731-30b32c80-0339-11eb-8b23-dd04a6787391.png">
