### PR TITLE
UIIN-1283: Mark connected preceding and succeeding titles as connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * Move dictionary data fetching above router. Fixes UIIN-1265.
 * Show service point an item was sent to. Refs UIIN-934.
 * Fix permission for mark as missing action. Fixes UIIN-1272.
+* Mark connected preceding and succeeding titles as connected. Fixes UIIN-1283.
 
 ## [4.0.1](https://github.com/folio-org/ui-inventory/tree/v4.0.1) (2020-07-01)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v4.0.0...v4.0.1)

--- a/src/components/TitleField/TitleField.js
+++ b/src/components/TitleField/TitleField.js
@@ -17,9 +17,6 @@ const TitleField = ({ field, index, fields, titleIdKey, isDisabled }) => {
     succeedingInstanceId,
     connected,
   } = instance;
-
-  console.log('instance', instance);
-
   const isConnected = connected || precedingInstanceId || succeedingInstanceId;
 
   const handleSelect = (inst) => {

--- a/src/components/TitleField/TitleField.js
+++ b/src/components/TitleField/TitleField.js
@@ -18,7 +18,9 @@ const TitleField = ({ field, index, fields, titleIdKey, isDisabled }) => {
     connected,
   } = instance;
 
-  const isConnected = connected || (precedingInstanceId && succeedingInstanceId);
+  console.log('instance', instance);
+
+  const isConnected = connected || precedingInstanceId || succeedingInstanceId;
 
   const handleSelect = (inst) => {
     update(index, {


### PR DESCRIPTION
Mark connected preceding and succeeding titles as actually "connected":

https://issues.folio.org/browse/UIIN-1283

