### PR TITLE
UIIN-1287 correctly implement language filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * Instance record (detailed view). Add copy number to item list. Refs UIIN-1251.
 * Instance record (detailed view). Add holdings copy number to holdings accordion. Refs UIIN-1254.
 * Use `<MultiSelectionFilter>` for item status filter. Refs UIIN-1224.
+* Correctly filter languages pursuant to STCOM-492. Refs UIIN-1287.
 
 ## [4.0.1](https://github.com/folio-org/ui-inventory/tree/v4.0.1) (2020-07-01)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v4.0.0...v4.0.1)

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -19,6 +19,7 @@ export const instanceFilterConfig = [
     name: 'language',
     cql: 'languages',
     values: [],
+    operator: '=',
   },
   {
     name: 'format',


### PR DESCRIPTION
STCOM-492 changed the default query filter action from `=` to `==`.
This is much more efficient at the DB level for most relationship
types, but does not function when only the related value, rather
than the related object, is available on the record, which is the case
here with languages, exposed on an instance record like
```
"languages" : [ "ger", "eng", "spa", "fre", "ita", "dut", "por" ],
```

Refs [UIIN-1287](https://issues.folio.org/browse/UIIN-1287), [STCOM-492](https://issues.folio.org/browse/STCOM-492)

