### PR TITLE
Fixes UIIN-128: Show "No barcode" for items without barcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 * Instance record (detailed view). Add holdings copy number to holdings accordion. Refs UIIN-1254.
 * Use `<MultiSelectionFilter>` for item status filter. Refs UIIN-1224.
 * Correctly filter languages pursuant to STCOM-492. Refs UIIN-1287.
+* Show `No barcode` for items without barcode. Fixes UIIN-1288.
 
 ## [4.0.1](https://github.com/folio-org/ui-inventory/tree/v4.0.1) (2020-07-01)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v4.0.0...v4.0.1)

--- a/src/Instance/ItemsList/ItemBarcode.js
+++ b/src/Instance/ItemsList/ItemBarcode.js
@@ -39,6 +39,7 @@ const ItemBarcode = ({ location, item, holdingId, instanceId }) => {
   }, [item.barcode, callout]);
 
   const highlightableBarcode = <Highlighter searchWords={[queryBarcode]} text={String(item.barcode)} />;
+
   return (
     <>
       <Link
@@ -47,7 +48,7 @@ const ItemBarcode = ({ location, item, holdingId, instanceId }) => {
       >
         <span data-test-items-app-icon>
           <AppIcon app="inventory" iconKey="item" size="small">
-            {highlightableBarcode || <FormattedMessage id="ui-inventory.noBarcode" />}
+            {item.barcode ? highlightableBarcode : <FormattedMessage id="ui-inventory.noBarcode" />}
           </AppIcon>
         </span>
       </Link>


### PR DESCRIPTION
Show `No barcode` for items without barcode

https://issues.folio.org/browse/UIIN-1288

![no-barcode](https://user-images.githubusercontent.com/63545/95615607-7ad19780-0a36-11eb-8cb8-17d7ae5531ff.png)
