### PR TITLE
UIIN-1299: Remove onChangeIndex prop passed to SearchAndSort.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.0.0 (IN PROGRESS)
 
 * Move 'Material type' to far end of item table. Refs UIIN-1003.
+* Remove `onChangeIndex` prop passed to `SearchAndSort`. Fixes UIIN-1299.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -87,11 +87,6 @@ class InstancesView extends React.Component {
     showErrorModal: false,
   };
 
-  onChangeIndex = (e) => {
-    const qindex = e.target.value;
-    this.props.updateLocation({ qindex });
-  };
-
   onFilterChangeHandler = ({ name, values }) => {
     const {
       data: { query },
@@ -375,7 +370,6 @@ class InstancesView extends React.Component {
             searchableIndexes={formattedSearchableIndexes}
             selectedIndex={get(data.query, 'qindex')}
             searchableIndexesPlaceholder={null}
-            onChangeIndex={this.onChangeIndex}
             initialResultCount={INITIAL_RESULT_COUNT}
             resultCountIncrement={RESULT_COUNT_INCREMENT}
             viewRecordComponent={ViewInstance}


### PR DESCRIPTION
Based on the changes in https://issues.folio.org/browse/STSMACOM-350 and https://github.com/folio-org/stripes-smart-components/pull/944 the `onChangeIndex` is not required anymore because changing query index will be handled by `SearchAndSort` internally.

https://issues.folio.org/browse/UIIN-1299