### PR TITLE
UIIN-1300 update plugins for stripes v5 compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## 5.0.1 IN PROGRESS
+
+* Update plugins to `stripes v5`-compatible versions. Refs UIIN-1301.
+
 ## [5.0.0](https://github.com/folio-org/ui-inventory/tree/v5.0.0) (2020-10-14)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v4.0.1...v5.0.0)
 

--- a/package.json
+++ b/package.json
@@ -705,8 +705,8 @@
   },
   "optionalDependencies": {
     "@folio/plugin-create-inventory-records": "^1.0.0",
-    "@folio/plugin-find-instance": "^3.0.0",
-    "@folio/quick-marc": "^1.0.0"
+    "@folio/plugin-find-instance": "^4.0.0",
+    "@folio/quick-marc": "^2.0.0"
 
   },
   "resolutions": {


### PR DESCRIPTION
Apps and plugins must depend on the same versions of peer dependencies.

Refs [UIIN-1300](https://issues.folio.org/browse/UIIN-1300)