### PR TITLE
UIIN-1316 remove extraneous trailing slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Move 'Material type' to far end of item table. Refs UIIN-1003.
 * Remove `onChangeIndex` prop passed to `SearchAndSort`. Fixes UIIN-1299.
+* Remove extraneous trailing slash. Refs UIIN-1316.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/src/Instance/InstanceDetails/InstanceRelationshipView/utils.js
+++ b/src/Instance/InstanceDetails/InstanceRelationshipView/utils.js
@@ -37,7 +37,7 @@ export const formatChildInstances = (instance, search) => {
 
   return instance.childInstances.map(childInstance => (
     <div key={childInstance.subInstanceId}>
-      <Link to={`/inventory/view/${childInstance.subInstanceId}/${search}`}>
+      <Link to={`/inventory/view/${childInstance.subInstanceId}${search}`}>
         {childInstance.subInstanceId}
       </Link>
     </div>
@@ -53,7 +53,7 @@ export const formatParentInstance = (instance, search) => {
 
   return (
     <div>
-      <Link to={`/inventory/view/${parentInstance.superInstanceId}/${search}`}>
+      <Link to={`/inventory/view/${parentInstance.superInstanceId}${search}`}>
         {`${parentInstance.superInstanceId} (M)`}
       </Link>
     </div>


### PR DESCRIPTION
Bound-with links included an extraneous trailing slash before appending
`location.search`, causing double slashes when other URLs were
assembled, causing navigation glitches.

Refs [UIIN-1316](https://issues.folio.org/browse/UIIN-1316)
