### PR TITLE
UIIN-1312: Fix search by identifierTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Remove `onChangeIndex` prop passed to `SearchAndSort`. Fixes UIIN-1299.
 * Remove extraneous trailing slash. Refs UIIN-1316.
 * Show the number of open requests when the item status changes. Refs UIIN-1294.
+* Fix search by `identifierTypes`. Fixes UIIN-1312.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -20,7 +20,8 @@ export function buildQuery(queryParams, pathComponents, resourceData, logger, pr
   let queryTemplate = getQueryTemplate(queryIndex, indexes);
 
   if (queryIndex.match(/isbn|issn/)) {
-    queryTemplate = getIsbnIssnTemplate(queryTemplate, props, queryIndex);
+    const identifierTypes = resourceData?.identifier_types?.records ?? [];
+    queryTemplate = getIsbnIssnTemplate(queryTemplate, identifierTypes, queryIndex);
   }
 
   if (queryIndex === 'querySearch' && queryValue.match('sortby')) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -209,9 +209,8 @@ export function getQueryTemplate(queryIndex, indexes) {
   return get(searchableIndex, 'queryTemplate');
 }
 
-export function getIsbnIssnTemplate(queryTemplate, props, queryIndex) {
-  const { resources: { identifierTypes } } = props;
-  const identifierType = get(identifierTypes, 'records', [])
+export function getIsbnIssnTemplate(queryTemplate, identifierTypes, queryIndex) {
+  const identifierType = identifierTypes
     .find(({ name }) => name.toLowerCase() === queryIndex);
   const identifierTypeId = get(identifierType, 'id', 'identifier-type-not-found');
 


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1312

After refactoring done in https://github.com/folio-org/ui-inventory/pull/1177 we lost access to `identifierTypes` via props. Thankfully we can still access them via `resourceData` when building a query. 