### PR TITLE
UIIN-1324: Omit id from preceding/succeeding titles when duplicating instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Remove extraneous trailing slash. Refs UIIN-1316.
 * Show the number of open requests when the item status changes. Refs UIIN-1294.
 * Fix search by `identifierTypes`. Fixes UIIN-1312.
+* Omit `id` from preceding/succeeding titles when duplicating instance. Fixes UIIN-1324.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -37,6 +37,7 @@ import {
   getCurrentFilters,
   parseFiltersToStr,
   marshalInstance,
+  omitFromArray,
 } from '../../utils';
 import {
   InTransitItemReport,
@@ -129,9 +130,23 @@ class InstancesView extends React.Component {
   }
 
   copyInstance = (instance) => {
+    const {
+      precedingTitles,
+      succeedingTitles,
+    } = instance;
     let copiedInstance = omit(instance, ['id', 'hrid']);
+
+    if (precedingTitles?.length) {
+      copiedInstance.precedingTitles = omitFromArray(precedingTitles, 'id');
+    }
+
+    if (succeedingTitles?.length) {
+      copiedInstance.succeedingTitles = omitFromArray(succeedingTitles, 'id');
+    }
+
     copiedInstance = set(copiedInstance, 'source', 'FOLIO');
-    this.setState({ copiedInstance });
+
+    if (instance?.precedingTitles) { this.setState({ copiedInstance }); }
     this.openCreateInstance();
   }
 

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -146,7 +146,7 @@ class InstancesView extends React.Component {
 
     copiedInstance = set(copiedInstance, 'source', 'FOLIO');
 
-    if (instance?.precedingTitles) { this.setState({ copiedInstance }); }
+    this.setState({ copiedInstance });
     this.openCreateInstance();
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,6 +16,7 @@ import {
   groupBy,
   map,
   isObject,
+  omit,
 } from 'lodash';
 import moment from 'moment';
 
@@ -545,3 +546,17 @@ export const unmarshalInstance = (instance, identifierTypesById) => {
 
   return unmarshaledInstance;
 };
+
+/**
+ * Omit from array
+ *
+ * For example:
+ *
+ * omitFromArray([{id: 1, title: 'A'}, {id: 2, title: 'B'}], 'id')
+ *
+ * will produce:
+ *
+ * [{title: 'A'}, {title: 'B'}]
+ *
+ */
+export const omitFromArray = (array, path) => array.map(title => omit(title, path));

--- a/test/bigtest/tests/instance-view-page-test.js
+++ b/test/bigtest/tests/instance-view-page-test.js
@@ -571,7 +571,7 @@ describe('InstanceViewPage', () => {
     });
   });
 
-  describe('Preceding and succeding titles', () => {
+  describe.only('Preceding and succeding titles', () => {
     setupApplication();
     beforeEach(async function () {
       const instance = this.server.create('instance', {
@@ -599,6 +599,20 @@ describe('InstanceViewPage', () => {
     });
     it('should show succeding title', () => {
       expect(InstanceViewPage.succeedingTitles.rowCount).to.be.equal(1);
+    });
+
+    describe('clicking on duplicate', () => {
+      beforeEach(async () => {
+        await InstanceViewPage.headerDropdownMenu.clickDuplicate();
+      });
+
+      it('should redirect to instance create page', () => {
+        expect(InstanceCreatePage.$root).to.exist;
+      });
+
+      it('should have a source value of "FOLIO"', () => {
+        expect(InstanceCreatePage.sourceValue).to.equal('FOLIO');
+      });
     });
   });
 

--- a/test/bigtest/tests/instance-view-page-test.js
+++ b/test/bigtest/tests/instance-view-page-test.js
@@ -571,7 +571,7 @@ describe('InstanceViewPage', () => {
     });
   });
 
-  describe.only('Preceding and succeding titles', () => {
+  describe('Preceding and succeding titles', () => {
     setupApplication();
     beforeEach(async function () {
       const instance = this.server.create('instance', {


### PR DESCRIPTION
Omit `id` from preceding/succeeding titles when duplicating instance

https://issues.folio.org/browse/UIIN-1324
