### PR TITLE
UIIN-1329: Add info callout when saving file with the instance UUIDs takes longer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Show the number of open requests when the item status changes. Refs UIIN-1294.
 * Fix search by `identifierTypes`. Fixes UIIN-1312.
 * Omit `id` from preceding/succeeding titles when duplicating instance. Fixes UIIN-1324.
+* Add info callout when saving file with the instance UUIDs takes longer. Refs UIIN-1329.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {
   omit,
@@ -39,11 +39,13 @@ import {
   marshalInstance,
   omitFromArray,
 } from '../../utils';
+import { INSTANCES_ID_REPORT_TIMEOUT } from '../../constants';
 import {
   InTransitItemReport,
   InstancesIdReport,
 } from '../../reports';
 import ErrorModal from '../ErrorModal';
+
 import { buildQuery } from '../../routes/buildManifestObject';
 
 import css from './instances.css';
@@ -197,17 +199,30 @@ class InstancesView extends React.Component {
         reset,
         GET,
       } = this.props.parentMutator.recordsToExportIDs;
+      let infoCalloutTimer;
 
       try {
         reset();
 
+        infoCalloutTimer = setTimeout(() => {
+          sendCallout({
+            type: 'info',
+            message: <FormattedMessage id="ui-inventory.saveInstancesUIIDS.info" />,
+          });
+        }, INSTANCES_ID_REPORT_TIMEOUT);
+
         const items = await GET();
+
+        clearTimeout(infoCalloutTimer);
+
         const report = new InstancesIdReport();
 
         if (!isEmpty(items)) {
           report.toCSV(items);
         }
       } catch (error) {
+        clearTimeout(infoCalloutTimer);
+
         sendCallout({
           type: 'error',
           message: <FormattedMessage id="ui-inventory.saveInstancesUIIDS.error" />,

--- a/src/constants.js
+++ b/src/constants.js
@@ -104,3 +104,5 @@ export const indentifierTypeNames = {
 };
 
 export const DATE_FORMAT = 'YYYY-MM-DD';
+
+export const INSTANCES_ID_REPORT_TIMEOUT = 2000;

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -477,6 +477,7 @@
   "item.status.statusUpdatedLabel": "status updated {statusDate}",
   "inTransitReport": "In transit items report (CSV)",
   "saveInstancesUIIDS": "Save instances UUIDs",
+  "saveInstancesUIIDS.info": "Request to save instances UUIDs has been received. File download may take a few minutes.",
   "saveInstancesUIIDS.error": "Error occurred while saving instances UUIDs. Please try again.",
   "saveInstancesCQLQuery": "Save instances CQL query",
   "exportInstancesInMARC": "Export instances (MARC)",


### PR DESCRIPTION
## Purpose

Add info callout when saving a file with the instance UUIDs takes longer in the scope of the [UIIN-1329](https://issues.folio.org/browse/UIIN-1329).

## Screenshot

<img width="1375" alt="Screen Shot 2020-11-12 at 6 18 54 PM" src="https://user-images.githubusercontent.com/40821852/98966526-0e095b80-2514-11eb-8ee5-0d30ea980a54.png">
