### PR TITLE
UIIN-1339: Return promise when submitting instance, holdings record or item form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add info callout when saving file with the instance UUIDs takes longer. Refs UIIN-1329.
 * Do not escape quotes when submitting query-search queries. Refs UIIN-1319, UIIN-1320.
 * Use `TextArea` for some data fields on instance form. Refs UIIN-1278.
+* Return promise when submitting instance, holdings record or item form. Fixes UIIN-1339 and UIIN-1340.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/src/Holding/CreateHolding/CreateHolding.js
+++ b/src/Holding/CreateHolding/CreateHolding.js
@@ -38,7 +38,7 @@ const CreateHolding = ({
   }, [location.search, instanceId]);
 
   const onSubmit = useCallback((newHolding) => {
-    mutator.holding.POST(newHolding)
+    return mutator.holding.POST(newHolding)
       .then(() => {
         onCancel();
       });

--- a/src/Instance/InstanceEdit/InstanceEdit.js
+++ b/src/Instance/InstanceEdit/InstanceEdit.js
@@ -43,7 +43,7 @@ const InstanceEdit = ({
   const goBack = useGoBack(`/inventory/view/${instanceId}`);
 
   const onSubmit = useCallback((updatedInstance) => {
-    mutator.instanceEdit.PUT(marshalInstance(updatedInstance, identifierTypesByName))
+    return mutator.instanceEdit.PUT(marshalInstance(updatedInstance, identifierTypesByName))
       .then(() => {
         goBack();
       });

--- a/src/Item/CreateItem/CreateItem.js
+++ b/src/Item/CreateItem/CreateItem.js
@@ -60,7 +60,7 @@ const CreateItem = ({
   }, [location.search, instanceId]);
 
   const onSubmit = useCallback((item) => {
-    mutator.item.POST(item)
+    return mutator.item.POST(item)
       .then(() => {
         onCancel();
       });

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -132,9 +132,11 @@ class ViewHoldingsRecord extends React.Component {
 
   updateHoldingsRecord = (holdingsRecord) => {
     const holdings = holdingsRecord;
+
     if (holdings.permanentLocationId === '') delete holdings.permanentLocationId;
     if (holdings.temporaryLocationId === '') delete holdings.temporaryLocationId;
-    this.props.mutator.holdingsRecords.PUT(holdings).then(() => {
+
+    return this.props.mutator.holdingsRecords.PUT(holdings).then(() => {
       this.onClickCloseEditHoldingsRecord();
     });
   }

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -124,7 +124,7 @@ class InstancesView extends React.Component {
   };
 
   onCreate = (instance) => {
-    this.createInstance(instance).then(() => this.closeNewInstance());
+    return this.createInstance(instance).then(() => this.closeNewInstance());
   }
 
   openCreateInstance = () => {

--- a/src/edit/InstanceForm.js
+++ b/src/edit/InstanceForm.js
@@ -215,6 +215,7 @@ class InstanceForm extends React.Component {
       submitting,
       copy,
     } = this.props;
+
     const cancelButton = (
       <Button
         buttonStyle="default mega"

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -219,6 +219,7 @@ class ItemForm extends React.Component {
       submitting,
       copy,
     } = this.props;
+
     const cancelButton = (
       <Button
         data-test-inventory-cancel-item-edit-action

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -98,7 +98,7 @@ class ItemView extends React.Component {
       delete item.barcode;
     }
 
-    this.props.mutator.items.PUT(item).then(() => this.onClickCloseEditItem());
+    return this.props.mutator.items.PUT(item).then(() => this.onClickCloseEditItem());
   };
 
   copyItem = item => {
@@ -1219,7 +1219,7 @@ class ItemView extends React.Component {
             >
               <ItemForm
                 form={`itemform_${item.id}`}
-                onSubmit={(record) => { this.saveItem(record); }}
+                onSubmit={record => this.saveItem(record)}
                 initialValues={item}
                 onCancel={this.onClickCloseEditItem}
                 okapi={okapi}


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1339
https://issues.folio.org/browse/UIIN-1340

While submitting a form asynchronously FinalForm expects to receive a promise during submission in order to correctly set the `submitting` flag to `true`. 

https://final-form.org/docs/final-form/types/FormState#submitting

This PR is trying to address it.

The `submitting` flag was correctly used in ui-inventory in order to disable submit buttons during submission but the problem was that the flag was never set to `true` causing a "double submission" problem.

