### PR TITLE
UIIN-1349: Add select row checkboxes to inventory instance search result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Do not escape quotes when submitting query-search queries. Refs UIIN-1319, UIIN-1320.
 * Use `TextArea` for some data fields on instance form. Refs UIIN-1278.
 * Return promise when submitting instance, holdings record or item form. Fixes UIIN-1339 and UIIN-1340.
+* Add select row checkboxes to inventory instance search result. Refs UIIN-1349.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/src/components/InstancesList/CheckboxColumn/CheckboxColumn.js
+++ b/src/components/InstancesList/CheckboxColumn/CheckboxColumn.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const CheckboxColumn = ({ children }) => (
+  <div // eslint-disable-line jsx-a11y/click-events-have-key-events
+    tabIndex="0"
+    role="button"
+    data-test-select-row
+    onClick={e => e.stopPropagation()}
+  >
+    {children}
+  </div>
+);
+
+CheckboxColumn.propTypes = { children: PropTypes.node.isRequired };
+
+export default CheckboxColumn;

--- a/src/components/InstancesList/CheckboxColumn/index.js
+++ b/src/components/InstancesList/CheckboxColumn/index.js
@@ -1,0 +1,1 @@
+export { default } from './CheckboxColumn';

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -24,7 +24,8 @@ import {
 import { SearchAndSort } from '@folio/stripes/smart-components';
 import {
   Button,
-  Icon
+  Icon,
+  Checkbox,
 } from '@folio/stripes/components';
 
 import FilterNavigation from '../FilterNavigation';
@@ -45,6 +46,7 @@ import {
   InstancesIdReport,
 } from '../../reports';
 import ErrorModal from '../ErrorModal';
+import CheckboxColumn from './CheckboxColumn';
 
 import { buildQuery } from '../../routes/buildManifestObject';
 
@@ -365,6 +367,11 @@ class InstancesView extends React.Component {
     } = this.props;
 
     const resultsFormatter = {
+      'select': () => (
+        <CheckboxColumn>
+          <Checkbox aria-label={intl.formatMessage({ id: 'ui-inventory.instances.rows.select' })} />
+        </CheckboxColumn>
+      ),
       'title': ({ title }) => (
         <AppIcon
           size="small"
@@ -410,14 +417,18 @@ class InstancesView extends React.Component {
               previouslyHeld: false,
               source: 'FOLIO',
             }}
-            visibleColumns={visibleColumns || ['title', 'contributors', 'publishers', 'relation']}
+            visibleColumns={visibleColumns || ['select', 'title', 'contributors', 'publishers', 'relation']}
             columnMapping={{
+              select: '',
               title: intl.formatMessage({ id: 'ui-inventory.instances.columns.title' }),
               contributors: intl.formatMessage({ id: 'ui-inventory.instances.columns.contributors' }),
               publishers: intl.formatMessage({ id: 'ui-inventory.instances.columns.publishers' }),
               relation: intl.formatMessage({ id: 'ui-inventory.instances.columns.relation' }),
             }}
-            columnWidths={{ title: '40%' }}
+            columnWidths={{
+              select: '30px',
+              title: '40%',
+            }}
             resultsFormatter={resultsFormatter}
             onCreate={this.onCreate}
             viewRecordPerms="ui-inventory.instance.view"

--- a/test/bigtest/interactors/routes/instances-route.js
+++ b/test/bigtest/interactors/routes/instances-route.js
@@ -4,6 +4,8 @@ import {
   scoped,
 } from '@bigtest/interactor';
 
+import CheckboxInteractor from '@folio/stripes-components/lib/Checkbox/tests/interactor';
+
 import {
   SearchFieldFilterInteractor,
 } from '../filters';
@@ -14,4 +16,5 @@ export default @interactor class InstancesRouteInteractor {
   searchFieldFilter = scoped('#pane-filter', SearchFieldFilterInteractor);
   rows = collection('#list-inventory [data-row-index]');
   headers = collection('#list-inventory [data-test-clickable-header]');
+  selectRowCheckboxes = collection('[data-test-inventory-instances] [data-test-select-row]', CheckboxInteractor);
 }

--- a/test/bigtest/tests/filters/instances/instance-filters-test.js
+++ b/test/bigtest/tests/filters/instances/instance-filters-test.js
@@ -139,7 +139,7 @@ describe('Instance filters', () => {
     beforeEach(async function () {
       await inventory.clickSelectStaffSuppressFilter();
       await inventory.clickSelectDiscoverySuppressFilter();
-      await instancesRoute.headers(1).click();
+      await instancesRoute.headers(2).click();
     });
 
     it('adds filters to the URL', function () {

--- a/test/bigtest/tests/filters/instances/instances-list-test.js
+++ b/test/bigtest/tests/filters/instances/instances-list-test.js
@@ -1,0 +1,53 @@
+import {
+  beforeEach,
+  describe,
+  it,
+} from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import setupApplication from '../../../helpers/setup-application';
+import InstancesRouteInteractor from '../../../interactors/routes/instances-route';
+import InventoryInteractor from '../../../interactors/inventory';
+
+describe('Instances list', () => {
+  setupApplication();
+
+  const instancesRoute = new InstancesRouteInteractor();
+  const inventory = new InventoryInteractor({
+    timeout: 3000,
+    scope: '[data-test-inventory-instances]',
+  });
+
+  beforeEach(function () {
+    this.server.create('instance', {
+      title: 'Homo Deus: A Brief History of Tomorrow',
+      contributors: [{ name: 'Yuval Noah Harari' }],
+      metadata: {
+        createdDate: '2020-03-04',
+        updatedDate: '2020-04-15',
+      },
+      source: 'MARC',
+    }, 'withHoldingAndItem');
+
+    this.visit('/inventory');
+  });
+
+  describe('filtering by source', () => {
+    beforeEach(async () => {
+      await inventory.source.open();
+      await inventory.source.checkboxes.dataOptions(5).click();
+    });
+
+    it('should have proper list results size', () => {
+      expect(instancesRoute.rows().length).to.equal(1);
+    });
+
+    it('should render nothing for select row column header', () => {
+      expect(instancesRoute.headers(0).text).to.equal('');
+    });
+
+    it('should display unchecked select row checkbox', () => {
+      expect(instancesRoute.selectRowCheckboxes(0).isChecked).to.be.false;
+    });
+  });
+});

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -5,6 +5,7 @@
   "instances.columns.contributors": "Contributors",
   "instances.columns.publishers": "Publishers",
   "instances.columns.relation": "Relation",
+  "instances.rows.select": "Select instance",
   "instances.resourceType": "Resource Type",
   "instances.language": "Language",
   "holdingsRecord.awaitingResources": "Awaiting resources",


### PR DESCRIPTION
## Purpose

Add select row checkboxes to inventory instance search result in the scope of the [UIIN-1349](https://issues.folio.org/browse/UIIN-1349).

## Screenshots
<img width="1245" alt="Screen Shot 2020-11-17 at 1 56 17 PM" src="https://user-images.githubusercontent.com/40821852/99387451-afa9f780-28dc-11eb-9eee-b698e6bb4e30.png">

