### PR TITLE
UIIN-1279 use TextAreas on holdings-record form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Return promise when submitting instance, holdings record or item form. Fixes UIIN-1339 and UIIN-1340.
 * Add select row checkboxes to inventory instance search result. Refs UIIN-1349.
 * Implement records selection on the inventory search screen. Refs UIIN-1350.
+* Replace most holdings-record `<TextField>` elements with `<TextArea>`s to support scrolling. Refs UIIN-1279.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/src/edit/holdings/HoldingsForm.js
+++ b/src/edit/holdings/HoldingsForm.js
@@ -12,6 +12,7 @@ import {
   Row,
   Col,
   Button,
+  TextArea,
   TextField,
   Select,
   Checkbox,
@@ -580,7 +581,8 @@ class HoldingsForm extends React.Component {
                     label={<FormattedMessage id="ui-inventory.callNumberPrefix" />}
                     name="callNumberPrefix"
                     id="additem_callnumberprefix"
-                    component={TextField}
+                    component={TextArea}
+                    rows={1}
                     fullWidth
                   />
                 </Col>
@@ -589,7 +591,8 @@ class HoldingsForm extends React.Component {
                     label={<FormattedMessage id="ui-inventory.callNumber" />}
                     name="callNumber"
                     id="additem_callnumber"
-                    component={TextField}
+                    component={TextArea}
+                    rows={1}
                     fullWidth
                   />
                 </Col>
@@ -598,7 +601,8 @@ class HoldingsForm extends React.Component {
                     label={<FormattedMessage id="ui-inventory.callNumberSuffix" />}
                     name="callNumberSuffix"
                     id="additem_callnumbersuffix"
-                    component={TextField}
+                    component={TextArea}
+                    rows={1}
                     fullWidth
                   />
                 </Col>
@@ -653,7 +657,8 @@ class HoldingsForm extends React.Component {
                     label={<FormattedMessage id="ui-inventory.digitizationPolicy" />}
                     name="digitizationPolicy"
                     id="edit_digitizationpolicy"
-                    component={TextField}
+                    component={TextArea}
+                    rows={1}
                   />
                 </Col>
                 <Col sm={3}>
@@ -661,7 +666,8 @@ class HoldingsForm extends React.Component {
                     label={<FormattedMessage id="ui-inventory.retentionPolicy" />}
                     name="retentionPolicy"
                     id="edit_retentionpolicy"
-                    component={TextField}
+                    component={TextArea}
+                    rows={1}
                   />
                 </Col>
               </Row>
@@ -741,12 +747,14 @@ class HoldingsForm extends React.Component {
                       {
                         name: 'enumeration',
                         label: <FormattedMessage id="ui-inventory.enumeration" />,
-                        component: TextField,
+                        component: TextArea,
+                        rows: 1,
                       },
                       {
                         name: 'chronology',
                         label: <FormattedMessage id="ui-inventory.chronology" />,
-                        component: TextField,
+                        component: TextArea,
+                        rows: 1,
                       },
                     ]}
                   />

--- a/src/edit/holdings/holdingsStatementFields.js
+++ b/src/edit/holdings/holdingsStatementFields.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import { TextField } from '@folio/stripes/components';
+import { TextArea } from '@folio/stripes/components';
 
 import RepeatableField from '../../components/RepeatableField';
 
@@ -15,17 +15,20 @@ const HoldingsStatementFields = () => (
       {
         name: 'statement',
         label: <FormattedMessage id="ui-inventory.holdingsStatement" />,
-        component: TextField,
+        component: TextArea,
+        rows: 1,
       },
       {
         name: 'note',
         label: <FormattedMessage id="ui-inventory.holdingsStatementPublicNote" />,
-        component: TextField,
+        component: TextArea,
+        rows: 1,
       },
       {
         name: 'staffNote',
         label: <FormattedMessage id="ui-inventory.holdingsStatementStaffNote" />,
-        component: TextField,
+        component: TextArea,
+        rows: 1,
       },
     ]}
   />

--- a/src/edit/holdings/holdingsStatementForIndexesFields.js
+++ b/src/edit/holdings/holdingsStatementForIndexesFields.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import { TextField } from '@folio/stripes/components';
+import { TextArea } from '@folio/stripes/components';
 
 import RepeatableField from '../../components/RepeatableField';
 
@@ -14,17 +14,20 @@ const HoldingsStatementForIndexesFields = () => (
       {
         name: 'statement',
         label: <FormattedMessage id="ui-inventory.holdingsStatementForIndexes" />,
-        component: TextField,
+        component: TextArea,
+        rows: 1,
       },
       {
         name: 'note',
         label: <FormattedMessage id="ui-inventory.holdingsStatementForIndexesPublicNote" />,
-        component: TextField,
+        component: TextArea,
+        rows: 1,
       },
       {
         name: 'staffNote',
         label: <FormattedMessage id="ui-inventory.holdingsStatementForIndexesStaffNote" />,
-        component: TextField,
+        component: TextArea,
+        rows: 1,
       },
     ]}
   />

--- a/src/edit/holdings/holdingsStatementForSupplementsFields.js
+++ b/src/edit/holdings/holdingsStatementForSupplementsFields.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import { TextField } from '@folio/stripes/components';
+import { TextArea } from '@folio/stripes/components';
 
 import RepeatableField from '../../components/RepeatableField';
 
@@ -14,17 +14,20 @@ const HoldingsStatementForSupplementsFields = () => (
       {
         name: 'statement',
         label: <FormattedMessage id="ui-inventory.holdingsStatementForSupplements" />,
-        component: TextField,
+        component: TextArea,
+        rows: 1,
       },
       {
         name: 'note',
         label: <FormattedMessage id="ui-inventory.holdingsStatementForSupplementsPublicNote" />,
-        component: TextField,
+        component: TextArea,
+        rows: 1,
       },
       {
         name: 'staffNote',
         label: <FormattedMessage id="ui-inventory.holdingsStatementForSupplementsStaffNote" />,
-        component: TextField,
+        component: TextArea,
+        rows: 1,
       },
     ]}
   />

--- a/src/edit/holdings/note.js
+++ b/src/edit/holdings/note.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 
 import {
   Select,
-  TextField,
+  TextArea,
   Checkbox,
 } from '@folio/stripes/components';
 
@@ -28,7 +28,8 @@ const Note = ({ noteTypeOptions }) => (
           {
             name: 'note',
             label: <FormattedMessage id="ui-inventory.note" />,
-            component: TextField,
+            component: TextArea,
+            rows: 1,
           },
           {
             name: 'staffOnly',


### PR DESCRIPTION
Replace most holding-record `<TextField>` elements with `<TextArea>`s
to allow for long values that can be scrolled.

Refs [UIIN-1279](https://issues.folio.org/browse/UIIN-1279)