### PR TITLE
UIIN-1310: Update title in Holdings detailed view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Replace most holdings-record `<TextField>` elements with `<TextArea>`s to support scrolling. Refs UIIN-1279.
 * Replace some item record `<TextField>` elements with `<TextArea>`s to support scrolling. Refs UIIN-1280.
 * Add selected instances count in the sub header. Refs UIIN-1364.
+* Update title in Holdings detailed view. Fixes UIIN-1310.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -498,7 +498,7 @@ class ViewHoldingsRecord extends React.Component {
                   paneTitle={
                     <span data-test-header-title>
                       <FormattedMessage
-                        id="ui-inventory.holdingRecord"
+                        id="ui-inventory.holdingsTitle"
                         values={{
                           location: get(holdingsPermanentLocation, 'name', ''),
                           callNumber: callNumberLabel(holdingsRecord)
@@ -516,7 +516,7 @@ class ViewHoldingsRecord extends React.Component {
                       {instance.title}
                       {(instance.publication && instance.publication.length > 0) &&
                         <span>
-                          <em>, </em>
+                          <em>. </em>
                           <em>
                             {instance.publication[0].publisher}
                             {instance.publication[0].dateOfPublication ? `, ${instance.publication[0].dateOfPublication}` : ''}


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1310

## Purpose
An easy-peasy bug fix is to reformat the title and replace the comma with a period.