### PR TITLE
UIIN-1368: Update API endpoint for retrieving instances UUIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Update title in Holdings detailed view. Fixes UIIN-1310.
 * Modify display of statistical codes in instance detail view. Refs UIIN-1150.
 * Result list. Align text in the columns in the top. Refs UIIN-1356.
+* Update API endpoint for retrieving instances UUIDs. Refs UIIN-1368.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
       "location-units": "2.0",
       "circulation": "9.0",
       "configuration": "2.0",
-      "tags": "1.0"
+      "tags": "1.0",
+      "inventory-record-bulk": "8.0"
     },
     "permissionSets": [
       {
@@ -463,7 +464,7 @@
           "inventory-storage.service-points.item.get",
           "inventory-storage.service-points.collection.get",
           "inventory-storage.hrid-settings.item.get",
-          "inventory-storage.instance-bulk.ids.get"
+          "inventory-storage.record-bulk.ids.get"
         ],
         "visible": true
       },

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -76,7 +76,7 @@ export function buildManifestObject() {
       records: 'ids',
       accumulate: true,
       fetch: false,
-      path: 'instance-bulk/ids',
+      path: 'record-bulk/ids',
       throwErrors: false,
       GET: {
         params: {

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -62,7 +62,7 @@ export default function configure() {
   });
   this.get('/item-damaged-statuses/:id');
 
-  this.get('/instance-bulk/ids', {});
+  this.get('/record-bulk/ids', {});
 
   this.get('/modes-of-issuance', ({ issuanceModes }) => issuanceModes.all());
   this.get('/modes-of-issuance/:id', ({ issuanceModes }, { params }) => {

--- a/test/bigtest/tests/export-to-csv-test.js
+++ b/test/bigtest/tests/export-to-csv-test.js
@@ -25,7 +25,7 @@ describe('Instances', () => {
   let requests = [];
 
   async function setupInstancedIdReportInfoCallout(server, timeout) {
-    server.get('/instance-bulk/ids', () => {
+    server.get('/record-bulk/ids', () => {
       return new Promise((resolve) => {
         setTimeout(() => resolve([]), timeout);
       });
@@ -73,7 +73,7 @@ describe('Instances', () => {
 
     describe('clicking save instances UIIDs button with API request set up to fail', () => {
       beforeEach(async function () {
-        this.server.put('/instance-bulk/ids', {}, 500);
+        this.server.put('/record-bulk/ids', {}, 500);
 
         // Timeout to skip enabling animation
         await wait();


### PR DESCRIPTION
## Purpose
Update API endpoint for retrieving instances UUIDs in the scope of the [UIIN-1368](https://issues.folio.org/browse/UIIN-1368).