### PR TITLE
UIIN-1314: Make holdings sources with value folio non-editable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Modify display of statistical codes in instance detail view. Refs UIIN-1150.
 * Result list. Align text in the columns in the top. Refs UIIN-1356.
 * Update API endpoint for retrieving instances UUIDs. Refs UIIN-1368.
+* Make holdings sources with source value `folio` non-editable in Settings. Refs UIIN-1314.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/src/settings/HoldingsSourcesSettings.js
+++ b/src/settings/HoldingsSourcesSettings.js
@@ -5,6 +5,8 @@ import { FormattedMessage } from 'react-intl';
 import { ControlledVocab } from '@folio/stripes/smart-components';
 import { IntlConsumer } from '@folio/stripes/core';
 
+import { sourceSuppressor } from '../utils';
+
 class HoldingsSourcesSettings extends React.Component {
   static propTypes = {
     stripes: PropTypes.shape({
@@ -21,6 +23,7 @@ class HoldingsSourcesSettings extends React.Component {
 
   render() {
     const hasPerm = this.props.stripes.hasPerm('ui-inventory.settings.holdings-sources');
+    const suppress = sourceSuppressor('folio');
 
     return (
       <IntlConsumer>
@@ -41,6 +44,7 @@ class HoldingsSourcesSettings extends React.Component {
             itemTemplate={{ source: 'local' }}
             hiddenFields={['numberOfObjects']}
             nameKey="name"
+            actionSuppressor={{ edit: suppress, delete: suppress }}
             id="holdingsSources"
             sortby="name"
             editable={hasPerm}

--- a/src/utils.js
+++ b/src/utils.js
@@ -560,3 +560,5 @@ export const unmarshalInstance = (instance, identifierTypesById) => {
  *
  */
 export const omitFromArray = (array, path) => array.map(title => omit(title, path));
+
+export const sourceSuppressor = sourceValue => term => term.source === sourceValue;

--- a/test/bigtest/network/factories/holdings-source.js
+++ b/test/bigtest/network/factories/holdings-source.js
@@ -1,3 +1,13 @@
+import faker from 'faker';
 import ApplicationFactory from './application';
 
-export default ApplicationFactory.extend();
+const {
+  lorem,
+  random,
+} = faker;
+
+export default ApplicationFactory.extend({
+  id: () => random.uuid(),
+  name: () => lorem.word(),
+  source: () => lorem.word(),
+});

--- a/test/bigtest/tests/settings/holdings-sources/holdings-sources-test.js
+++ b/test/bigtest/tests/settings/holdings-sources/holdings-sources-test.js
@@ -5,19 +5,6 @@ import setupApplication from '../../../helpers/setup-application';
 import HoldingsSources from '../../../interactors/settings/holdings-sources/holdings-sources';
 
 describe('Holdings Sources', () => {
-  function mockData() {
-    this.server.create('holdingsSource', {
-      'id' : 'd6510242-5ec3-42ed-b593-3585d2e48fd6',
-      'name' : 'FOLIO',
-      'source' : 'folio'
-    });
-    this.server.create('holdingsSource', {
-      'id' : 'e19eabab-a85c-4aef-a7b2-33bd9acef24e',
-      'name' : 'MARC',
-      'source' : 'folio'
-    });
-  }
-
   describe('User has permissions', () => {
     setupApplication({
       hasAllPerms: false,
@@ -28,11 +15,11 @@ describe('Holdings Sources', () => {
       }
     });
 
-    beforeEach(mockData);
-
     describe('viewing holdings sources list', () => {
-      beforeEach(function () {
-        this.visit('/settings/inventory/holdingsSources');
+      beforeEach(async function () {
+        this.server.createList('holdingsSource', 2);
+
+        await this.visit('/settings/inventory/holdingsSources');
       });
 
       it('has a holdings sources list', () => {
@@ -49,6 +36,31 @@ describe('Holdings Sources', () => {
         expect(HoldingsSources.hasDeleteButton).to.be.true;
       });
     });
+
+    describe('viewing holdings sources list with source value "folio"', () => {
+      beforeEach(async function () {
+        this.server.createList('holdingsSource', 2, { source: 'folio' });
+
+        await this.visit('/settings/inventory/holdingsSources');
+      });
+
+      it('has a holdings sources list', () => {
+        expect(HoldingsSources.hasList).to.be.true;
+      });
+
+      it('list has 2 items', () => {
+        expect(HoldingsSources.rowCount).to.equal(2);
+      });
+
+      it('list has new buttons', () => {
+        expect(HoldingsSources.hasCreateButton).to.be.true;
+      });
+
+      it('list does not have edit, delete buttons', () => {
+        expect(HoldingsSources.hasEditButton).to.be.false;
+        expect(HoldingsSources.hasDeleteButton).to.be.false;
+      });
+    });
   });
 
   describe('User does not have permissions to see the list', () => {
@@ -59,10 +71,10 @@ describe('Holdings Sources', () => {
       }
     });
 
-    beforeEach(mockData);
-
     describe('viewing holdings sources list', () => {
       beforeEach(async function () {
+        this.server.createList('holdingsSource', 2);
+
         await this.visit('/settings/inventory/holdingsSources');
       });
 
@@ -80,11 +92,12 @@ describe('Holdings Sources', () => {
         'ui-inventory.settings.list.view': true
       }
     });
-    beforeEach(mockData);
 
     describe('viewing holdings holdings sources list', () => {
-      beforeEach(function () {
-        this.visit('/settings/inventory/holdingsSources');
+      beforeEach(async function () {
+        this.server.createList('holdingsSource', 2);
+
+        await this.visit('/settings/inventory/holdingsSources');
       });
 
       it('has a holdings sources list', () => {


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1314

## Purpose
In `Settings` -> `Holdings sources` entries with source value `folio` should not be editable.

### Screenshot
![Screen Shot 2020-12-10 at 16 51 46](https://user-images.githubusercontent.com/49517355/101788275-93c6f980-3b08-11eb-9079-b9f776ab1d46.png)