### PR TITLE
UIIN-1367: Add quick instances UUIDs export limit reached warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Result list. Align text in the columns in the top. Refs UIIN-1356.
 * Update API endpoint for retrieving instances UUIDs. Refs UIIN-1368.
 * Make holdings sources with source value `folio` non-editable in Settings. Refs UIIN-1314.
+* Add quick instances UUIDs export limit reached warning. Refs UIIN-1367.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -279,7 +279,7 @@ class InstancesView extends React.Component {
     const { parentResources } = this.props;
     const selectedRowsCount = size(this.state.selectedRows);
     const isInstancesListEmpty = isEmpty(get(parentResources, ['records', 'records'], []));
-    const isSelectedRowsCountExceededLimit = selectedRowsCount > QUICK_EXPORT_LIMIT;
+    const isQuickExportLimitExceeded = selectedRowsCount > QUICK_EXPORT_LIMIT;
 
     const buildOnClickHandler = onClickHandler => {
       return () => {
@@ -338,10 +338,13 @@ class InstancesView extends React.Component {
           icon: 'download',
           messageId: 'ui-inventory.exportInstancesInMARC',
           onClickHandler: buildOnClickHandler(noop),
-          isDisabled: true,
+          isDisabled: !selectedRowsCount || isQuickExportLimitExceeded,
         })}
-        {isSelectedRowsCountExceededLimit && (
-          <span className={css.feedbackError}>
+        {isQuickExportLimitExceeded && (
+          <span
+            className={css.feedbackError}
+            data-test-quick-marc-export-limit-exceeded
+          >
             <FormattedMessage
               id="ui-inventory.exportInstancesInMARCLimitExceeded"
               values={{ count: QUICK_EXPORT_LIMIT }}

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -41,7 +41,10 @@ import {
   marshalInstance,
   omitFromArray,
 } from '../../utils';
-import { INSTANCES_ID_REPORT_TIMEOUT } from '../../constants';
+import {
+  INSTANCES_ID_REPORT_TIMEOUT,
+  QUICK_EXPORT_LIMIT,
+} from '../../constants';
 import {
   InTransitItemReport,
   InstancesIdReport,
@@ -274,7 +277,9 @@ class InstancesView extends React.Component {
 
   getActionMenu = ({ onToggle }) => {
     const { parentResources } = this.props;
+    const selectedRowsCount = size(this.state.selectedRows);
     const isInstancesListEmpty = isEmpty(get(parentResources, ['records', 'records'], []));
+    const isSelectedRowsCountExceededLimit = selectedRowsCount > QUICK_EXPORT_LIMIT;
 
     const buildOnClickHandler = onClickHandler => {
       return () => {
@@ -335,6 +340,14 @@ class InstancesView extends React.Component {
           onClickHandler: buildOnClickHandler(noop),
           isDisabled: true,
         })}
+        {isSelectedRowsCountExceededLimit && (
+          <span className={css.feedbackError}>
+            <FormattedMessage
+              id="ui-inventory.exportInstancesInMARCLimitExceeded"
+              values={{ count: QUICK_EXPORT_LIMIT }}
+            />
+          </span>
+        )}
         {this.getActionItem({
           id: 'dropdown-clickable-export-json',
           icon: 'download',

--- a/src/components/InstancesList/instances.css
+++ b/src/components/InstancesList/instances.css
@@ -1,6 +1,14 @@
+@import '@folio/stripes-components/lib/variables';
+
 .actionIcon {
   margin-right: 10px;
 }
 .cellAlign {
   align-items: flex-start;
+}
+
+.feedbackError {
+  margin-left: 26px;
+  font-weight: var(--text-weight-bold);
+  color: var(--error);
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -106,3 +106,5 @@ export const indentifierTypeNames = {
 export const DATE_FORMAT = 'YYYY-MM-DD';
 
 export const INSTANCES_ID_REPORT_TIMEOUT = 2000;
+
+export const QUICK_EXPORT_LIMIT = process.env.NODE_ENV !== 'test' ? 100 : 2;

--- a/test/bigtest/interactors/inventory.js
+++ b/test/bigtest/interactors/inventory.js
@@ -70,6 +70,7 @@ export default @interactor class InventoryInteractor {
 
   headerDropdown = scoped('[data-test-pane-header-actions-button]');
   headerDropdownMenu = new InventoryHeaderDropdownMenu();
+  headerDropdownMenuQuickMarcExportLimitExceeded = new Interactor('[data-test-quick-marc-export-limit-exceeded]');
 
   resourceTypeFilter = scoped('#resource', MultiSelectFilterInteractor);
   formatFilter = scoped('#format', MultiSelectFilterInteractor);

--- a/test/bigtest/tests/export-to-csv-test.js
+++ b/test/bigtest/tests/export-to-csv-test.js
@@ -149,10 +149,6 @@ describe('Instances', () => {
       expect(inventory.headerDropdownMenu.isExportInstancesMARCIconPresent).to.be.true;
     });
 
-    it('should disable action button for export instances (MARC) if there are not items in search result', () => {
-      expect(inventory.headerDropdownMenu.isExportInstancesMARCBtnDisabled).to.be.true;
-    });
-
     it('should display action button for export instances (JSON)', () => {
       expect(inventory.headerDropdownMenu.exportInstancesJSONBtnIsVisible).to.be.true;
     });

--- a/test/bigtest/tests/filters/instances/instances-list-test.js
+++ b/test/bigtest/tests/filters/instances/instances-list-test.js
@@ -8,37 +8,42 @@ import { expect } from 'chai';
 import setupApplication from '../../../helpers/setup-application';
 import InstancesRouteInteractor from '../../../interactors/routes/instances-route';
 import InventoryInteractor from '../../../interactors/inventory';
+import { QUICK_EXPORT_LIMIT } from '../../../../../src/constants';
 
 describe('Instances list', () => {
   setupApplication();
 
   const instancesRoute = new InstancesRouteInteractor();
   const inventory = new InventoryInteractor({
-    timeout: 3000,
+    timeout: 2000,
     scope: '[data-test-inventory-instances]',
   });
+  const instancesAmount = 3;
 
   beforeEach(function () {
-    this.server.create('instance', {
-      title: 'Homo Deus: A Brief History of Tomorrow',
-      contributors: [{ name: 'Yuval Noah Harari' }],
-      metadata: {
-        createdDate: '2020-03-04',
-        updatedDate: '2020-04-15',
-      },
-      source: 'MARC',
-    }, 'withHoldingAndItem');
-    this.server.create('instance', {
-      title: 'A Brief History of Tomorrow',
-      contributors: [{ name: 'Yuval Noah Harari' }],
-      metadata: {
-        createdDate: '2020-03-04',
-        updatedDate: '2020-04-15',
-      },
-      source: 'MARC',
-    }, 'withHoldingAndItem');
+    for (let i = 0; i < instancesAmount; i++) {
+      this.server.create('instance', {
+        title: `Homo Deus: A Brief History of Tomorrow ${i + 1}`,
+        contributors: [{ name: 'Yuval Noah Harari' }],
+        metadata: {
+          createdDate: '2020-03-04',
+          updatedDate: '2020-04-15',
+        },
+        source: 'MARC',
+      }, 'withHoldingAndItem');
+    }
 
     this.visit('/inventory');
+  });
+
+  describe('opening the action menu', () => {
+    beforeEach(async () => {
+      await inventory.headerDropdown.click();
+    });
+
+    it('should not display warning about exceeded limit', () => {
+      expect(inventory.headerDropdownMenuQuickMarcExportLimitExceeded.isPresent).to.be.false;
+    });
   });
 
   describe('filtering by source', () => {
@@ -48,7 +53,7 @@ describe('Instances list', () => {
     });
 
     it('should have proper list results size', () => {
-      expect(instancesRoute.rows().length).to.equal(2);
+      expect(instancesRoute.rows().length).to.equal(instancesAmount);
     });
 
     it('should render nothing for select row column header', () => {
@@ -63,13 +68,40 @@ describe('Instances list', () => {
       expect(instancesRoute.customPaneSub.isPresent).to.be.false;
     });
 
+    describe('opening the action menu', () => {
+      beforeEach(async () => {
+        await inventory.headerDropdown.click();
+      });
+
+      it('should disable action button for export instances (MARC) if there are no selected rows', () => {
+        expect(inventory.headerDropdownMenu.isExportInstancesMARCBtnDisabled).to.be.true;
+      });
+    });
+
+    describe('selecting rows to exceed the quick export limit', () => {
+      beforeEach(async () => {
+        await instancesRoute.selectRowCheckboxes(0).clickInput();
+        await instancesRoute.selectRowCheckboxes(1).clickInput();
+        await instancesRoute.selectRowCheckboxes(2).clickInput();
+        await inventory.headerDropdown.click();
+      });
+
+      it('should display warning about exceeded limit', () => {
+        expect(inventory.headerDropdownMenuQuickMarcExportLimitExceeded.text).to.equal(`Selected record limit of ${QUICK_EXPORT_LIMIT} exceeded`);
+      });
+
+      it('should disable action button for export instances (MARC)', () => {
+        expect(inventory.headerDropdownMenu.isExportInstancesMARCBtnDisabled).to.be.true;
+      });
+    });
+
     describe('selecting row', () => {
       beforeEach(async () => {
         await instancesRoute.selectRowCheckboxes(0).clickInput();
       });
 
       it('should have proper list results size', () => {
-        expect(instancesRoute.rows().length).to.equal(2);
+        expect(instancesRoute.rows().length).to.equal(instancesAmount);
       });
 
       it('should display checked select row checkbox', () => {
@@ -78,6 +110,16 @@ describe('Instances list', () => {
 
       it('should display selected rows count message in the sub header', () => {
         expect(instancesRoute.customPaneSub.text).to.equal('1 record selected');
+      });
+
+      describe('opening the action menu', () => {
+        beforeEach(async () => {
+          await inventory.headerDropdown.click();
+        });
+
+        it('should enable action button for export instances (MARC) when there are selected rows', () => {
+          expect(inventory.headerDropdownMenu.isExportInstancesMARCBtnDisabled).to.be.false;
+        });
       });
 
       describe('selecting more than one row', () => {

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -483,6 +483,7 @@
   "saveInstancesUIIDS.error": "Error occurred while saving instances UUIDs. Please try again.",
   "saveInstancesCQLQuery": "Save instances CQL query",
   "exportInstancesInMARC": "Export instances (MARC)",
+  "exportInstancesInMARCLimitExceeded": "Selected record limit of {count, number} exceeded",
   "exportInstancesInJSON": "Export instances (JSON)",
   "reports.inTransitItem.barcode": "Item barcode",
   "reports.inTransitItem.title": "Title",


### PR DESCRIPTION
## Purpose

UIIN-1367: Add quick instances UUIDs export limit reached warning in the scope of the [UIIN-1367](https://issues.folio.org/browse/UIIN-1367).

## Screenshot

Limit is not exceeded
<img width="1680" alt="Screen Shot 2020-12-11 at 4 55 32 PM" src="https://user-images.githubusercontent.com/40821852/101918200-c0931380-3bd1-11eb-8c54-d1a285994fda.png">

Limit is
<img width="1680" alt="Screen Shot 2020-12-11 at 4 55 21 PM" src="https://user-images.githubusercontent.com/40821852/101918226-c7218b00-3bd1-11eb-9f72-084c08e9f5a5.png">
 exceeded