### PR TITLE
UIIN-1391: Add checkboxes on the show selected instances modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Add jest setup. Refs UIIN-1375.
 * Cover select instances functionality with jest/rtl tests. Refs UIIN-1390.
 * Fix type ahead for location filters. Fixes UIIN-1393 and UIIN-1395.
+* Add checkboxes on the show selected instances records modal. Refs UIIN-1391.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -409,10 +409,9 @@ class InstancesList extends React.Component {
     this.setState({ showErrorModal: false });
   };
 
-  toggleRowSelection = ({
-    id: rowId,
-    ...rowData
-  }) => {
+  toggleRowSelection = rowData => {
+    const { id: rowId } = rowData;
+
     this.setState(({ selectedRows }) => {
       const isRowSelected = Boolean(selectedRows[rowId]);
       const newSelectedRows = { ...selectedRows };
@@ -429,6 +428,13 @@ class InstancesList extends React.Component {
 
   handleResetAll = () => {
     this.setState({ selectedRows: {} });
+  }
+
+  handleSelectedRecordsModalSave = selectedRecords => {
+    this.setState({
+      isSelectedRecordsModalOpened: false,
+      selectedRows: selectedRecords,
+    });
   }
 
   handleSelectedRecordsModalCancel = () => {
@@ -584,9 +590,10 @@ class InstancesList extends React.Component {
         />
         <SelectedRecordsModal
           isOpen={isSelectedRecordsModalOpened}
-          selectedRecords={selectedRows}
+          records={selectedRows}
           columnMapping={columnMapping}
           formatter={resultsFormatter}
+          onSave={this.handleSelectedRecordsModalSave}
           onCancel={this.handleSelectedRecordsModalCancel}
         />
       </>

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -37,6 +37,7 @@ import formatters from '../../referenceFormatters';
 import withLocation from '../../withLocation';
 import {
   getCurrentFilters,
+  getNextSelectedRowsState,
   parseFiltersToStr,
   marshalInstance,
   omitFromArray,
@@ -409,21 +410,8 @@ class InstancesList extends React.Component {
     this.setState({ showErrorModal: false });
   };
 
-  toggleRowSelection = rowData => {
-    const { id: rowId } = rowData;
-
-    this.setState(({ selectedRows }) => {
-      const isRowSelected = Boolean(selectedRows[rowId]);
-      const newSelectedRows = { ...selectedRows };
-
-      if (isRowSelected) {
-        delete newSelectedRows[rowId];
-      } else {
-        newSelectedRows[rowId] = rowData;
-      }
-
-      return { selectedRows: newSelectedRows };
-    });
+  toggleRowSelection = row => {
+    this.setState(({ selectedRows }) => ({ selectedRows: getNextSelectedRowsState(selectedRows, row) }));
   };
 
   handleResetAll = () => {

--- a/src/components/SelectedRecordsModal/SelectedRecordsModal.js
+++ b/src/components/SelectedRecordsModal/SelectedRecordsModal.js
@@ -15,6 +15,8 @@ import {
   Checkbox,
   MultiColumnList
 } from '@folio/stripes/components';
+
+import { getNextSelectedRowsState } from '../../utils';
 import CheckboxColumn from '../InstancesList/CheckboxColumn';
 
 const SelectedRecordsModal = ({
@@ -34,19 +36,8 @@ const SelectedRecordsModal = ({
     }
   }, [records, isOpen]);
 
-  const toggleRowSelection = rowData => {
-    setSelectedRecords(state => {
-      const isRowSelected = Boolean(selectedRecords[rowData.id]);
-      const newSelectedRows = { ...state };
-
-      if (isRowSelected) {
-        delete newSelectedRows[rowData.id];
-      } else {
-        newSelectedRows[rowData.id] = rowData;
-      }
-
-      return newSelectedRows;
-    });
+  const toggleRowSelection = row => {
+    setSelectedRecords(state => getNextSelectedRowsState(state, row));
   };
 
   const resultsFormatter = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -572,4 +572,18 @@ export const omitFromArray = (array, path) => array.map(title => omit(title, pat
 
 export const sourceSuppressor = sourceValue => term => term.source === sourceValue;
 
+export const getNextSelectedRowsState = (selectedRows, row) => {
+  const { id } = row;
+  const isRowSelected = Boolean(selectedRows[id]);
+  const newSelectedRows = { ...selectedRows };
+
+  if (isRowSelected) {
+    delete newSelectedRows[id];
+  } else {
+    newSelectedRows[id] = row;
+  }
+
+  return newSelectedRows;
+};
+
 export const isTestEnv = () => process.env.NODE_ENV === 'test';


### PR DESCRIPTION
## Purpose

Add checkboxes on the show selected instances modal in the scope of the [UIIN-1391](https://issues.folio.org/browse/UIIN-1391).

Note, that `eslint` warnings and errors are not related to my PR so I am not fixing them. Usually fixing them as a part of feature PR is not appreciated. Usually, it should be done as part of dedicated PR so that is why I did not do it here.

## Jest coverage

### Coverage of related code in the `InstancesList.js`
<img width="1107" alt="Screen Shot 2021-01-11 at 4 25 40 PM" src="https://user-images.githubusercontent.com/40821852/104195612-85cc0780-542b-11eb-8cb6-d9d31e3337be.png">


### Coverage of `SelectedRecordsModal.js`
<img width="1107" alt="Screen Shot 2021-01-11 at 4 25 40 PM" src="https://user-images.githubusercontent.com/40821852/104195612-85cc0780-542b-11eb-8cb6-d9d31e3337be.png">
