### PR TITLE
Fix trivial ESLint errors

### DIFF
--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -573,7 +573,7 @@ class InstancesList extends React.Component {
             pagingType="click"
             hasNewButton={false}
             onResetAll={this.handleResetAll}
-            sortableColumns={["title","contributors","publishers"]}
+            sortableColumns={['title', 'contributors', 'publishers']}
           />
         </div>
         <ErrorModal


### PR DESCRIPTION
We need to pick up our game on lint-policing: when "ignorable" errors begin to proliferate, significant errors get ignored. I fixed some quoting-and-spacing problems.

There still remains an error that mystifies me:
```
/Users/mike/ui-inventory/src/routes/InstancesRoute.test.js
  10:23  error  Unable to resolve path to module '@testing-library/user-event'  import/no-unresolved
```
Yet the package file specifies in the `devDependencies`:
```
    "@testing-library/user-event": "^12.1.10",
```
If anyone can see what's going wrong here, I'd like to know!