### PR TITLE
UIIN-1335: Add permission for marking item restricted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * Update to stripes v6. Refs UIIN-1402.
 * Add ability to mark item as Intellectual item and Restricted. Refs UIIN-1374.
 * Add permission for marking an item intellectual. Refs UIIN-1336.
+* Add permission for marking an item restricted. Refs UIIN-1335.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/package.json
+++ b/package.json
@@ -674,6 +674,14 @@
         "visible": true
       },
       {
+        "permissionName": "ui-inventory.items.mark-restricted",
+        "displayName": "Inventory: Mark items restricted",
+        "subPermissions": [
+          "inventory.items.item.mark-restricted.post"
+        ],
+        "visible": true
+      },
+      {
         "permissionName": "ui-inventory.single-record-import",
         "displayName": "Inventory: Import single record",
         "subPermissions": [

--- a/src/constants.js
+++ b/src/constants.js
@@ -125,6 +125,7 @@ export const actionMenuDisplayPerms = [
   'ui-requests.create',
   'ui-inventory.items.mark-items-withdrawn',
   'ui-inventory.items.mark-intellectual-item',
+  'ui-inventory.items.mark-restricted',
 ];
 
 export const DATE_FORMAT = 'YYYY-MM-DD';

--- a/test/bigtest/tests/item-view-page-test.js
+++ b/test/bigtest/tests/item-view-page-test.js
@@ -419,6 +419,10 @@ describe('ItemViewPage', () => {
         expect(ItemViewPage.headerDropdownMenu.hasMarkAsIntellectual).to.be.false;
       });
 
+      it('should not show a mark as restricted item', () => {
+        expect(ItemViewPage.headerDropdownMenu.hasMarkAsRestricted).to.be.false;
+      });
+
       it('should not show a delete menu item', () => {
         expect(ItemViewPage.headerDropdownMenu.hasDeleteItem).to.be.false;
       });

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -590,6 +590,7 @@
   "permission.settings.list.view": "Settings (Inventory): Display list of settings pages",
   "permission.items.mark-items-withdrawn": "Inventory: Mark items withdrawn",
   "permission.items.mark-intellectual-item": "Inventory: Mark items intellectual item",
+  "permission.items.mark-restricted": "Inventory: Mark items restricted",
   
   "moveItems.moveButton": "Move to",
   "moveItems.selectAll": "Select/unselect all items for movement",


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1335

## Purpose
This PR is almost a copy of the previous #1277 and adds a new permission that allows users to change the item's status to `Restricted`.
