### PR TITLE
UIIN-756: Add ability to mark item with new statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * Add ability to mark item as Intellectual item and Restricted. Refs UIIN-1374.
 * Add permission for marking an item intellectual. Refs UIIN-1336.
 * Add permission for marking an item restricted. Refs UIIN-1335.
+* Add ability to mark an item with new statuses (In process, In process (non-requestable), Long missing, Unavailable, Unknown). Refs UIIN-756.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,28 +5,38 @@ const AWAITING_PICKUP = 'Awaiting pickup';
 const IN_TRANSIT = 'In transit';
 
 export const itemStatusesMap = {
-  CHECKED_OUT: 'Checked out',
-  ON_ORDER: 'On order',
-  AVAILABLE: 'Available',
-  IN_TRANSIT,
-  IN_PROCESS: 'In process',
-  AWAITING_PICKUP,
-  PAGED: 'Paged',
-  AWAITING_DELIVERY,
-  MISSING: 'Missing',
-  WITHDRAWN: 'Withdrawn',
-  CLAIMED_RETURNED: 'Claimed returned',
-  LOST_AND_PAID: 'Lost and paid',
   AGED_TO_LOST: 'Aged to lost',
-  ORDER_CLOSED: 'Order closed',
+  AVAILABLE: 'Available',
+  AWAITING_PICKUP,
+  AWAITING_DELIVERY,
+  CHECKED_OUT: 'Checked out',
+  CLAIMED_RETURNED: 'Claimed returned',
+  DECLARED_LOST: 'Declared lost',
+  IN_PROCESS: 'In process',
+  IN_PROCESS_NON_REQUESTABLE: 'In process (non-requestable)',
+  IN_TRANSIT,
   INTELLECTUAL_ITEM: 'Intellectual item',
+  LONG_MISSING: 'Long missing',
+  LOST_AND_PAID: 'Lost and paid',
+  MISSING: 'Missing',
+  ON_ORDER: 'On order',
+  ORDER_CLOSED: 'Order closed',
+  PAGED: 'Paged',
   RESTRICTED: 'Restricted',
+  UNAVAILABLE: 'Unavailable',
+  UNKNOWN: 'Unknown',
+  WITHDRAWN: 'Withdrawn',
 };
 
 // Matching mutator names to the corresponding item statuses
 export const itemStatusMutators = {
+  IN_PROCESS: 'markAsInProcess',
+  IN_PROCESS_NON_REQUESTABLE: 'markAsInProcessNonRequestable',
   INTELLECTUAL_ITEM: 'markAsIntellectualItem',
+  LONG_MISSING: 'markAsLongMissing',
   RESTRICTED: 'markAsRestricted',
+  UNAVAILABLE: 'markAsUnavailable',
+  UNKNOWN: 'markAsUnknown',
 };
 
 export const requestStatuses = {
@@ -52,9 +62,9 @@ export const itemStatuses = [
   { label: 'ui-inventory.item.status.lostAndPaid', value: 'Lost and paid' },
   { label: 'ui-inventory.item.status.missing', value: 'Missing' },
   { label: 'ui-inventory.item.status.onOrder', value: 'On order' },
+  { label: 'ui-inventory.item.status.orderClosed', value: 'Order closed' },
   { label: 'ui-inventory.item.status.paged', value: 'Paged' },
   { label: 'ui-inventory.item.status.restricted', value: 'Restricted' },
-  { label: 'ui-inventory.item.status.orderClosed', value: 'Order closed' },
   { label: 'ui-inventory.item.status.unavailable', value: 'Unavailable' },
   { label: 'ui-inventory.item.status.unknown', value: 'Unknown' },
   { label: 'ui-inventory.item.status.withdrawn', value: 'Withdrawn' },

--- a/src/routes/ItemRoute.js
+++ b/src/routes/ItemRoute.js
@@ -44,6 +44,22 @@ class ItemRoute extends React.Component {
       clientGeneratePk: false,
       fetch: false,
     },
+    markAsInProcess: {
+      type: 'okapi',
+      POST: {
+        path: 'inventory/items/:{itemid}/mark-in-process',
+      },
+      clientGeneratePk: false,
+      fetch: false,
+    },
+    markAsInProcessNonRequestable: {
+      type: 'okapi',
+      POST: {
+        path: 'inventory/items/:{itemid}/mark-in-process-non-requestable',
+      },
+      clientGeneratePk: false,
+      fetch: false,
+    },
     markAsIntellectualItem: {
       type: 'okapi',
       POST: {
@@ -52,10 +68,34 @@ class ItemRoute extends React.Component {
       clientGeneratePk: false,
       fetch: false,
     },
+    markAsLongMissing: {
+      type: 'okapi',
+      POST: {
+        path: 'inventory/items/:{itemid}/mark-long-missing',
+      },
+      clientGeneratePk: false,
+      fetch: false,
+    },
     markAsRestricted: {
       type: 'okapi',
       POST: {
         path: 'inventory/items/:{itemid}/mark-restricted',
+      },
+      clientGeneratePk: false,
+      fetch: false,
+    },
+    markAsUnavailable: {
+      type: 'okapi',
+      POST: {
+        path: 'inventory/items/:{itemid}/mark-unavailable',
+      },
+      clientGeneratePk: false,
+      fetch: false,
+    },
+    markAsUnknown: {
+      type: 'okapi',
+      POST: {
+        path: 'inventory/items/:{itemid}/mark-unknown',
       },
       clientGeneratePk: false,
       fetch: false,

--- a/test/bigtest/interactors/item-view-page.js
+++ b/test/bigtest/interactors/item-view-page.js
@@ -28,10 +28,22 @@ import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumn
   clickMarkAsMissing = clickable('[data-test-mark-as-missing-item]');
   hasMarkAsWithdrawn = isPresent('[data-test-mark-as-withdrawn-item]');
   clickMarkAsWithdrawn = clickable('[data-test-mark-as-withdrawn-item]')
+
+  hasMarkAsInProcess = isPresent('#clickable-in-process');
+  clickMarkAsInProcess = clickable('#clickable-in-process')
+  hasMarkAsInProcessNonRequestable = isPresent('#clickable-in-process-non-requestable');
+  clickMarkAsInProcessNonRequestable = clickable('#clickable-in-process-non-requestable')
   hasMarkAsIntellectual = isPresent('#clickable-intellectual-item');
   clickMarkAsIntellectual = clickable('#clickable-intellectual-item')
+  hasMarkAsLongMissing = isPresent('#clickable-long-missing');
+  clickMarkAsLongMissing = clickable('#clickable-long-missing')
   hasMarkAsRestricted = isPresent('#clickable-restricted');
   clickMarkAsRestricted = clickable('#clickable-restricted')
+  hasMarkAsUnavailable = isPresent('#clickable-unavailable');
+  clickMarkAsUnavailable = clickable('#clickable-unavailable')
+  hasMarkAsUnknown = isPresent('#clickable-unknown');
+  clickMarkAsUnknown = clickable('#clickable-unknown')
+
   hasDeleteItem = isPresent('[data-test-inventory-delete-item-action]');
   clickDelete = clickable('[data-test-inventory-delete-item-action]');
 }

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -441,6 +441,22 @@ export default function configure() {
     return item.attrs;
   });
 
+  this.post('/inventory/items/:id/mark-in-process', ({ items }, request) => {
+    const item = items.find(request.params.id);
+
+    item.update({ status: { name: 'In process' } });
+
+    return item.attrs;
+  });
+
+  this.post('/inventory/items/:id/mark-in-process-non-requestable', ({ items }, request) => {
+    const item = items.find(request.params.id);
+
+    item.update({ status: { name: 'In process (non-requestable)' } });
+
+    return item.attrs;
+  });
+
   this.post('/inventory/items/:id/mark-intellectual-item', ({ items }, request) => {
     const item = items.find(request.params.id);
 
@@ -449,10 +465,34 @@ export default function configure() {
     return item.attrs;
   });
 
+  this.post('/inventory/items/:id/mark-long-missing', ({ items }, request) => {
+    const item = items.find(request.params.id);
+
+    item.update({ status: { name: 'Long missing' } });
+
+    return item.attrs;
+  });
+
   this.post('/inventory/items/:id/mark-restricted', ({ items }, request) => {
     const item = items.find(request.params.id);
 
     item.update({ status: { name: 'Restricted' } });
+
+    return item.attrs;
+  });
+
+  this.post('/inventory/items/:id/mark-unavailable', ({ items }, request) => {
+    const item = items.find(request.params.id);
+
+    item.update({ status: { name: 'Unavailable' } });
+
+    return item.attrs;
+  });
+
+  this.post('/inventory/items/:id/mark-unknown', ({ items }, request) => {
+    const item = items.find(request.params.id);
+
+    item.update({ status: { name: 'Unknown' } });
 
     return item.attrs;
   });

--- a/test/bigtest/tests/item-view-page-test.js
+++ b/test/bigtest/tests/item-view-page-test.js
@@ -9,8 +9,13 @@ import ItemEditPage from '../interactors/item-edit-page';
 import ItemCreatePage from '../interactors/item-create-page';
 
 const itemStatusesMap = {
+  InProcess: 'In process',
+  InProcessNonRequestable: 'In process (non-requestable)',
   Intellectual: 'Intellectual item',
+  LongMissing: 'Long missing',
   Restricted: 'Restricted',
+  Unavailable: 'Unavailable',
+  Unknown: 'Unknown',
 };
 
 describe('ItemViewPage', () => {
@@ -116,12 +121,32 @@ describe('ItemViewPage', () => {
           expect(ItemViewPage.headerDropdownMenu.hasMarkAsWithdrawn).to.be.true;
         });
 
+        it('should show a mark as in process', () => {
+          expect(ItemViewPage.headerDropdownMenu.hasMarkAsInProcess).to.be.true;
+        });
+
+        it('should show a mark as in process (non-requestable)', () => {
+          expect(ItemViewPage.headerDropdownMenu.hasMarkAsInProcessNonRequestable).to.be.true;
+        });
+
         it('should show a mark as intellectual item', () => {
           expect(ItemViewPage.headerDropdownMenu.hasMarkAsIntellectual).to.be.true;
         });
 
+        it('should show a mark as long missing', () => {
+          expect(ItemViewPage.headerDropdownMenu.hasMarkAsLongMissing).to.be.true;
+        });
+
         it('should show a mark as restricted', () => {
           expect(ItemViewPage.headerDropdownMenu.hasMarkAsRestricted).to.be.true;
+        });
+
+        it('should show a mark as unavailable', () => {
+          expect(ItemViewPage.headerDropdownMenu.hasMarkAsUnavailable).to.be.true;
+        });
+
+        it('should show a mark as unknown', () => {
+          expect(ItemViewPage.headerDropdownMenu.hasMarkAsUnknown).to.be.true;
         });
 
         it('should show a delete menu item', () => {
@@ -231,7 +256,9 @@ describe('ItemViewPage', () => {
         });
 
         Object.keys(itemStatusesMap).forEach(status => {
-          describe(`clicking on mark as ${status}`, () => {
+          const statusName = itemStatusesMap[status];
+
+          describe(`clicking on mark as ${statusName}`, () => {
             beforeEach(async () => {
               await ItemViewPage.headerDropdownMenu[`clickMarkAs${status}`]();
             });
@@ -264,8 +291,8 @@ describe('ItemViewPage', () => {
                 expect(ItemViewPage.hasItemStatusModal).to.be.false;
               });
 
-              it(`should change item status to ${status}`, () => {
-                expect(ItemViewPage.loanAccordion.keyValues(2).text).to.be.equal(itemStatusesMap[status]);
+              it(`should change item status to ${statusName}`, () => {
+                expect(ItemViewPage.loanAccordion.keyValues(2).text).to.be.equal(statusName);
               });
             });
           });


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-756

## Purpose
The ability to mark items with five new statuses has been added: `In process`, `In process (non-requestable)`, `Long missing`, `Unavailable`, and `Unknown`.

Also, the `constants.js` has been cleaned up a bit so that all statuses are in alphabetical order.

### Screenshot
![Screen Shot 2021-01-25 at 17 42 21](https://user-images.githubusercontent.com/49517355/105728554-f77c7900-5f34-11eb-8708-4f5b7ba16ff8.png)