### PR TITLE
Duplicate ui-inventory.instance.view-staff-suppressed-records

### DIFF
--- a/package.json
+++ b/package.json
@@ -650,14 +650,6 @@
         "visible": true
       },
       {
-        "permissionName": "ui-inventory.instance.view-staff-suppressed-records",
-        "displayName": "Inventory: View instance records being suppressed for staff",
-        "subPermissions": [
-          "ui-inventory.instance.view"
-        ],
-        "visible": true
-      },
-      {
         "permissionName": "ui-inventory.items.mark-items-withdrawn",
         "displayName": "Inventory: Mark items withdrawn",
         "subPermissions": [


### PR DESCRIPTION
Permission defined twice .. Remove one of them. Fortunately they had same definition. See FOLIO-2989