### PR TITLE
UIIN-1305: Add ability to switch between new item statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,8 @@
 * Add permission for marking an item restricted. Refs UIIN-1335.
 * Add confirmation and warning when storage locations is changed to non-remote storage location. Refs UIIN-1321.
 * Add ability to mark an item with new statuses (In process, In process (non-requestable), Long missing, Unavailable, Unknown). Refs UIIN-756.
-* Add option to remove leading zeroes from Inventory HRIDs. Refs UIIN-1398
+* Add option to remove leading zeroes from Inventory HRIDs. Refs UIIN-1398.
+* Add ability to switch between new item statuses. Refs UIIN-1305.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,40 +43,58 @@ export function craftLayerUrl(mode, location) { // eslint-disable-line import/pr
 export function canMarkItemAsMissing(item) {
   return includes([
     itemStatusesMap.AVAILABLE,
-    itemStatusesMap.IN_TRANSIT,
-    itemStatusesMap.AWAITING_PICKUP,
-    itemStatusesMap.PAGED,
-    itemStatusesMap.IN_PROCESS,
     itemStatusesMap.AWAITING_DELIVERY,
-    itemStatusesMap.WITHDRAWN,
+    itemStatusesMap.AWAITING_PICKUP,
+    itemStatusesMap.INTELLECTUAL_ITEM,
+    itemStatusesMap.IN_PROCESS,
+    itemStatusesMap.IN_PROCESS_NON_REQUESTABLE,
+    itemStatusesMap.IN_TRANSIT,
+    itemStatusesMap.LONG_MISSING,
     itemStatusesMap.LOST_AND_PAID,
+    itemStatusesMap.PAGED,
+    itemStatusesMap.RESTRICTED,
+    itemStatusesMap.UNAVAILABLE,
+    itemStatusesMap.UNKNOWN,
+    itemStatusesMap.WITHDRAWN,
   ], item?.status?.name);
 }
 
 export function canMarkItemAsWithdrawn(item) {
   return includes([
-    itemStatusesMap.IN_PROCESS,
     itemStatusesMap.AVAILABLE,
-    itemStatusesMap.IN_TRANSIT,
-    itemStatusesMap.AWAITING_PICKUP,
-    itemStatusesMap.MISSING,
     itemStatusesMap.AWAITING_DELIVERY,
-    itemStatusesMap.PAGED,
+    itemStatusesMap.AWAITING_PICKUP,
+    itemStatusesMap.INTELLECTUAL_ITEM,
+    itemStatusesMap.IN_PROCESS,
+    itemStatusesMap.IN_PROCESS_NON_REQUESTABLE,
+    itemStatusesMap.IN_TRANSIT,
+    itemStatusesMap.LONG_MISSING,
     itemStatusesMap.LOST_AND_PAID,
+    itemStatusesMap.MISSING,
+    itemStatusesMap.PAGED,
+    itemStatusesMap.RESTRICTED,
+    itemStatusesMap.UNAVAILABLE,
+    itemStatusesMap.UNKNOWN,
   ], item?.status?.name);
 }
 
 export function canMarkItemWithStatus(item) {
   return includes([
-    itemStatusesMap.ORDER_CLOSED,
     itemStatusesMap.AVAILABLE,
-    itemStatusesMap.IN_TRANSIT,
-    itemStatusesMap.AWAITING_PICKUP,
-    itemStatusesMap.MISSING,
-    itemStatusesMap.WITHDRAWN,
     itemStatusesMap.AWAITING_DELIVERY,
-    itemStatusesMap.PAGED,
+    itemStatusesMap.AWAITING_PICKUP,
+    itemStatusesMap.INTELLECTUAL_ITEM,
+    itemStatusesMap.IN_PROCESS_NON_REQUESTABLE,
+    itemStatusesMap.IN_TRANSIT,
+    itemStatusesMap.LONG_MISSING,
     itemStatusesMap.LOST_AND_PAID,
+    itemStatusesMap.MISSING,
+    itemStatusesMap.ORDER_CLOSED,
+    itemStatusesMap.PAGED,
+    itemStatusesMap.RESTRICTED,
+    itemStatusesMap.UNAVAILABLE,
+    itemStatusesMap.UNKNOWN,
+    itemStatusesMap.WITHDRAWN,
   ], item?.status?.name);
 }
 

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -318,8 +318,9 @@ class ItemView extends React.Component {
           )}
         </IfPermission>
         { canMarkItemWithStatus(firstItem) && (
-          Object.keys(itemStatusMutators).map(
-            status => {
+          Object.keys(itemStatusMutators)
+            .filter(status => itemStatusesMap[status] !== firstItem?.status?.name)
+            .map(status => {
               const itemStatus = itemStatusesMap[status].toLowerCase();
               const parameterizedStatus = parameterize(itemStatus);
 
@@ -364,8 +365,7 @@ class ItemView extends React.Component {
                   </IfPermission>
                 )
                 : actionMenuItem;
-            }
-          )
+            })
         )}
         { canCreateNewRequest(firstItem, stripes) && (
         <Button

--- a/test/bigtest/tests/item-view-page-test.js
+++ b/test/bigtest/tests/item-view-page-test.js
@@ -400,8 +400,39 @@ describe('ItemViewPage', () => {
         });
       });
     });
-  });
 
+    Object.keys(itemStatusesMap).forEach(status => {
+      const statusName = itemStatusesMap[status];
+
+      describe(`visiting the item with status ${statusName} view page`, () => {
+        beforeEach(async function () {
+          const instance = this.server.create(
+            'instance',
+            'withHoldingAndItemStatus',
+            {
+              title: 'ADVANCING RESEARCH',
+              itemStatus: statusName,
+            }
+          );
+          const holding = this.server.schema.instances.first().holdings.models[0];
+          const item = holding.items.models[0].attrs;
+
+          this.visit(`/inventory/view/${instance.id}/${holding.id}/${item.id}`);
+          await ItemViewPage.whenLoaded();
+        });
+
+        describe('clicking pane header dropdown menu', () => {
+          beforeEach(async () => {
+            await ItemViewPage.headerDropdown.click();
+          });
+
+          it(`should not display the "mark as ${statusName}" menu item`, () => {
+            expect(ItemViewPage.headerDropdownMenu[`hasMarkAs${status}`]).to.be.false;
+          });
+        });
+      });
+    });
+  });
 
   describe('User does not have permissions', () => {
     setupApplication({


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1305

### Purpose
This allows switching between new item statuses according to this [spreadsheet](https://docs.google.com/spreadsheets/d/1el9_XTlpZKNzYqWSoN_XcCQxdgZDxwB_blbSWrcsAL8/edit#gid=0).

### Screenshot
![Screen Shot 2021-02-03 at 16 43 39](https://user-images.githubusercontent.com/49517355/106763118-2f737280-663f-11eb-889d-9d71aac9b674.png)