### PR TITLE
UIIN-1399: Rename permission to `Settings (Inventory): View list of settings pages`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * Update to `stripes-cli v2.0.0`. Refs UIIN-1410.
 * Show new request option for item with status restricted. Refs UIIN-1306.
 * Connect the `Remove leading zeroes from HRID` field to the `HRID handling` form. Refs UIIN-1413.
+* Rename `Settings (Inventory): Display list of settings pages` permission to `Settings (Inventory): View list of settings pages`. Refs UIIN-1399.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/package.json
+++ b/package.json
@@ -603,7 +603,7 @@
       },
       {
         "permissionName": "ui-inventory.settings.list.view",
-        "displayName": "Settings (Inventory): Display list of settings pages",
+        "displayName": "Settings (Inventory): View list of settings pages",
         "subPermissions": [
           "settings.inventory.enabled",
           "users.collection.get",

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -597,7 +597,7 @@
   "permission.holdings.move": "Inventory: Move holdings",
   "permission.holdings.delete": "Inventory: View, create, edit, delete holdings",
   "permission.instance.view-staff-suppressed-records": "Inventory: View instance records being suppressed for staff",
-  "permission.settings.list.view": "Settings (Inventory): Display list of settings pages",
+  "permission.settings.list.view": "Settings (Inventory): View list of settings pages",
   "permission.items.mark-items-withdrawn": "Inventory: Mark items withdrawn",
   "permission.items.mark-intellectual-item": "Inventory: Mark items intellectual item",
   "permission.items.mark-restricted": "Inventory: Mark items restricted",


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1399

## Purpose
Rename `Settings (Inventory): Display list of settings pages` permission to `Settings (Inventory): View list of settings pages`.