### PR TITLE
UIIN-894: Add permission to mark items with four new statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * Connect the `Remove leading zeroes from HRID` field to the `HRID handling` form. Refs UIIN-1413.
 * Rename `Settings (Inventory): Display list of settings pages` permission to `Settings (Inventory): View list of settings pages`. Refs UIIN-1399.
 * Add ability to duplicate MARC bib record. Refs UIIN-1407.
+* Add permission for marking item as In process (non-requestable), Long missing, Unavailable, Unknown. Refs UIIN-1308, UIIN-894, UIIN-1307, UIIN-1326.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/package.json
+++ b/package.json
@@ -680,6 +680,38 @@
         "visible": true
       },
       {
+        "permissionName": "ui-inventory.items.mark-unknown",
+        "displayName": "Inventory: Mark items unknown",
+        "subPermissions": [
+          "inventory.items.item.mark-unknown.post"
+        ],
+        "visible": true
+      },
+      {
+        "permissionName": "ui-inventory.items.mark-unavailable",
+        "displayName": "Inventory: Mark items unavailable",
+        "subPermissions": [
+          "inventory.items.item.mark-unavailable.post"
+        ],
+        "visible": true
+      },
+      {
+        "permissionName": "ui-inventory.items.mark-long-missing",
+        "displayName": "Inventory: Mark items long missing",
+        "subPermissions": [
+          "inventory.items.item.mark-long-missing.post"
+        ],
+        "visible": true
+      },
+      {
+        "permissionName": "ui-inventory.items.mark-in-process-non-requestable",
+        "displayName": "Inventory: Mark items in process (non-requestable)",
+        "subPermissions": [
+          "inventory.items.item.mark-in-process-non-requestable.post"
+        ],
+        "visible": true
+      },
+      {
         "permissionName": "ui-inventory.single-record-import",
         "displayName": "Inventory: Import single bibliographic records",
         "subPermissions": [

--- a/src/constants.js
+++ b/src/constants.js
@@ -136,6 +136,10 @@ export const actionMenuDisplayPerms = [
   'ui-inventory.items.mark-items-withdrawn',
   'ui-inventory.items.mark-intellectual-item',
   'ui-inventory.items.mark-restricted',
+  'ui-inventory.items.mark-unknown',
+  'ui-inventory.items.mark-unavailable',
+  'ui-inventory.items.mark-long-missing',
+  'ui-inventory.items.mark-in-process-non-requestable',
 ];
 
 export const DATE_FORMAT = 'YYYY-MM-DD';

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -345,17 +345,17 @@ class ItemView extends React.Component {
 
               /**
                 This is a temporary condition for displaying new item statuses, and as soon as
-                  https://issues.folio.org/browse/UIIN-894 (LONG_MISSING),
                   https://issues.folio.org/browse/UIIN-1166 (IN_PROCESS),
-                  https://issues.folio.org/browse/UIIN-1307 (UNAVAILABLE),
-                  https://issues.folio.org/browse/UIIN-1308 (IN_PROCESS_NON_REQUESTABLE),
-                  https://issues.folio.org/browse/UIIN-1326 (UNKNOWN)
-                are implemented, it will need to be removed.
+                is implemented, it will need to be removed.
                 Each "mark as" menu item will eventually be returned in the <IfPermission /> wrapper.
               */
               const isPermImplemented = [
                 'INTELLECTUAL_ITEM',
                 'RESTRICTED',
+                'UNKNOWN',
+                'UNAVAILABLE',
+                'LONG_MISSING',
+                'IN_PROCESS_NON_REQUESTABLE',
               ].includes(status);
 
               return isPermImplemented

--- a/test/bigtest/tests/item-view-page-test.js
+++ b/test/bigtest/tests/item-view-page-test.js
@@ -509,6 +509,22 @@ describe('ItemViewPage', () => {
         expect(ItemViewPage.headerDropdownMenu.hasMarkAsRestricted).to.be.false;
       });
 
+      it('should not show a mark as unknown item', () => {
+        expect(ItemViewPage.headerDropdownMenu.hasMarkAsUnknown).to.be.false;
+      });
+
+      it('should not show a mark as unavailable item', () => {
+        expect(ItemViewPage.headerDropdownMenu.hasMarkAsUnavailable).to.be.false;
+      });
+
+      it('should not show a mark as long missing item', () => {
+        expect(ItemViewPage.headerDropdownMenu.hasMarkAsLongMissing).to.be.false;
+      });
+
+      it('should not show a mark as in process (non-requestable) item', () => {
+        expect(ItemViewPage.headerDropdownMenu.hasMarkAsInProcessNonRequestable).to.be.false;
+      });
+
       it('should not show a delete menu item', () => {
         expect(ItemViewPage.headerDropdownMenu.hasDeleteItem).to.be.false;
       });

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -603,6 +603,11 @@
   "permission.items.mark-intellectual-item": "Inventory: Mark items intellectual item",
   "permission.items.mark-restricted": "Inventory: Mark items restricted",
   "permission.single-record-import": "Inventory: Import single bibliographic records",
+  "permission.items.mark-unknown": "Inventory: Mark items unknown",
+  "permission.items.mark-unavailable": "Inventory: Mark items unavailable",
+  "permission.items.mark-long-missing": "Inventory: Mark items long missing",
+  "permission.items.mark-in-process-non-requestable": "Inventory: Mark items in process (non-requestable)",
+
   "moveItems.moveButton": "Move to",
   "moveItems.selectAll": "Select/unselect all items for movement",
   "moveItems.selectItem": "Select/unselect item for movement",


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1308
https://issues.folio.org/browse/UIIN-894
https://issues.folio.org/browse/UIIN-1307
https://issues.folio.org/browse/UIIN-1326

## Purpose
Added 4 permissions at once for the ability to mark items with statuses ` In process (non-requestable)`, `Long missing`, `Unavailable`, `Unknown`.