### PR TITLE
UIIN-803: Add item counter to each holding record accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * Add ability to search by `allTitles` index. Refs UIIN-1434.
 * Add `tags.collection.get` as subpermission to `Inventory: View instances, holdings, and items` permission. Fixes UIIN-1422.
 * Display shelving order on the item record. Refs UIIN-816.
+* Add item counter to each holding record. Refs UIIN-803.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,14 +1,15 @@
 /** @param {import('karma').Config} config */
 module.exports = config => config.set({
+
   client: {
     captureConsole: false,
     mocha: {
-      timeout: 100000
+      timeout: 10000000
     },
   },
-  browserDisconnectTimeout: 100000,
-  browserDisconnectTolerance: 10,
-  browserNoActivityTimeout: 100000,
+  browserDisconnectTimeout: 10000000,
+  browserDisconnectTolerance: 1000,
+  browserNoActivityTimeout: 10000000,
   flags: [
     '--disable-gpu',
     '--no-sandbox'

--- a/src/Instance/HoldingsList/Holding/Holding.js
+++ b/src/Instance/HoldingsList/Holding/Holding.js
@@ -1,103 +1,24 @@
-import React, {
-  useMemo,
-  useCallback,
-  useContext,
-  useState,
-} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
-import {
-  IfPermission,
-} from '@folio/stripes/core';
-import {
-  Accordion,
-  Row,
-  Col,
-  Button,
-  Checkbox,
-} from '@folio/stripes/components';
+import { Checkbox } from '@folio/stripes/components';
 
-import {
-  callNumberLabel
-} from '../../../utils';
 import { ItemsListContainer } from '../../ItemsList';
-import { MoveToDropdown } from './MoveToDropdown';
-import DnDContext from '../../DnDContext';
-import { DataContext } from '../../../contexts';
+
+import HoldingAccordion from './HoldingAccordion';
 
 const Holding = ({
   holding,
   onViewHolding,
   onAddItem,
   holdings,
-
   draggable,
   droppable,
   selectHoldingsForDrag,
   isHoldingDragSelected,
   isDraggable,
 }) => {
-  const {
-    selectItemsForDrag,
-    isItemsDragSelected,
-    getDraggingItems,
-    activeDropZone,
-    isItemsDroppable,
-    selectedItemsMap,
-    selectedHoldingsMap,
-  } = useContext(DnDContext);
-
-  const { locationsById } = useContext(DataContext);
-  const labelLocation = holding.permanentLocationId ? locationsById[holding.permanentLocationId].name : '';
-  const withMoveDropdown = draggable || isDraggable;
-
-  const [open, setOpen] = useState(false);
-
-  const handleAccordionToggle = () => setOpen(!open);
-
-  const viewHoldings = useCallback(() => {
-    onViewHolding();
-  }, [onViewHolding]);
-
-  const addItem = useCallback(() => {
-    onAddItem();
-  }, [onAddItem]);
-
-  const holdingButtonsGroup = useMemo(() => {
-    return (
-      <>
-        {
-          withMoveDropdown && (
-            <MoveToDropdown
-              holding={holding}
-              holdings={holdings}
-            />
-          )
-        }
-
-        <Button
-          id={`clickable-view-holdings-${holding.id}`}
-          data-test-view-holdings
-          onClick={viewHoldings}
-        >
-          <FormattedMessage id="ui-inventory.viewHoldings" />
-        </Button>
-
-        <IfPermission perm="ui-inventory.item.create">
-          <Button
-            id={`clickable-new-item-${holding.id}`}
-            data-test-add-item
-            onClick={addItem}
-            buttonStyle="primary paneHeaderNewButton"
-          >
-            <FormattedMessage id="ui-inventory.addItem" />
-          </Button>
-        </IfPermission>
-      </>
-    );
-  }, [holding.id, viewHoldings, addItem, withMoveDropdown, selectedItemsMap, selectedHoldingsMap, labelLocation]);
-
   return (
     <div>
       {isDraggable &&
@@ -116,41 +37,25 @@ const Holding = ({
           }
         </FormattedMessage>
       }
-      <Accordion
-        id={holding.id}
-        open={open}
-        onToggle={handleAccordionToggle}
-        label={(
-          <FormattedMessage
-            id="ui-inventory.holdingsHeader"
-            values={{
-              location: labelLocation,
-              callNumber: callNumberLabel(holding),
-              copyNumber: holding.copyNumber,
-            }}
-          />
-        )}
-        displayWhenOpen={holdingButtonsGroup}
-        displayWhenClosed={holdingButtonsGroup}
+      <HoldingAccordion
+        key={`items_${holding.id}`}
+        holding={holding}
+        withMoveDropdown={draggable || isDraggable}
+        holdings={holdings}
+        onViewHolding={onViewHolding}
+        onAddItem={onAddItem}
       >
-        <Row>
-          <Col sm={12}>
+        {
+          ({ items }) => (
             <ItemsListContainer
-              key={`items_${holding.id}`}
               holding={holding}
-              setOpen={setOpen}
-
               draggable={draggable}
               droppable={droppable}
-              isItemsDragSelected={isItemsDragSelected}
-              selectItemsForDrag={selectItemsForDrag}
-              getDraggingItems={getDraggingItems}
-              activeDropZone={activeDropZone}
-              isItemsDroppable={isItemsDroppable}
+              items={items}
             />
-          </Col>
-        </Row>
-      </Accordion>
+          )
+        }
+      </HoldingAccordion>
     </div>
   );
 };
@@ -160,7 +65,6 @@ Holding.propTypes = {
   onViewHolding: PropTypes.func.isRequired,
   onAddItem: PropTypes.func.isRequired,
   holdings: PropTypes.arrayOf(PropTypes.object),
-
   draggable: PropTypes.bool,
   droppable: PropTypes.bool,
   isDraggable: PropTypes.bool,

--- a/src/Instance/HoldingsList/Holding/HoldingAccordion.js
+++ b/src/Instance/HoldingsList/Holding/HoldingAccordion.js
@@ -1,0 +1,115 @@
+import React, {
+  useEffect,
+  useState,
+  useContext,
+} from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import { stripesConnect } from '@folio/stripes/core';
+import {
+  Accordion,
+  Row,
+  Col,
+} from '@folio/stripes/components';
+
+import { DataContext } from '../../../contexts';
+import { callNumberLabel } from '../../../utils';
+import HoldingButtonsGroup from './HoldingButtonsGroup';
+
+const HoldingAccordion = ({
+  children,
+  holding,
+  holdings,
+  onViewHolding,
+  onAddItem,
+  withMoveDropdown,
+  mutator: {
+    instanceHoldingItems: {
+      reset,
+      GET,
+    },
+  },
+}) => {
+  const [items, setItems] = useState();
+  const [isLoading, setIsLoading] = useState(true);
+  const { locationsById } = useContext(DataContext);
+  const labelLocation = holding.permanentLocationId ? locationsById[holding.permanentLocationId].name : '';
+  const [open, setOpen] = useState(false);
+  const handleAccordionToggle = () => setOpen(!open);
+  const itemCount = items?.length ?? 0;
+
+  const holdingButtonsGroup = <HoldingButtonsGroup
+    holding={holding}
+    holdings={holdings}
+    itemCount={itemCount}
+    locationsById={locationsById}
+    onViewHolding={onViewHolding}
+    onAddItem={onAddItem}
+    withMoveDropdown={withMoveDropdown}
+    isOpen={open}
+  />;
+
+  useEffect(() => {
+    setIsLoading(true);
+    reset();
+    GET()
+      .then(setItems)
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  if (isLoading) return null;
+
+  return (
+    <Accordion
+      id={holding.id}
+      open={open}
+      onToggle={handleAccordionToggle}
+      label={(
+        <FormattedMessage
+          id="ui-inventory.holdingsHeader"
+          values={{
+            location: labelLocation,
+            callNumber: callNumberLabel(holding),
+            copyNumber: holding.copyNumber,
+          }}
+        />
+      )}
+      displayWhenOpen={holdingButtonsGroup}
+      displayWhenClosed={holdingButtonsGroup}
+    >
+      <Row>
+        <Col sm={12}>
+          {children({ items })}
+        </Col>
+      </Row>
+    </Accordion>
+  );
+};
+
+HoldingAccordion.manifest = Object.freeze({
+  instanceHoldingItems: {
+    type: 'okapi',
+    records: 'items',
+    path: 'inventory/items',
+    params: {
+      query: 'holdingsRecordId==!{holding.id}',
+      limit: '5000',
+    },
+    accumulate: true,
+    resourceShouldRefresh: true,
+    abortOnUnmount: true,
+  },
+});
+
+HoldingAccordion.propTypes = {
+  mutator: PropTypes.object.isRequired,
+  holding: PropTypes.object.isRequired,
+  onViewHolding: PropTypes.func.isRequired,
+  onAddItem: PropTypes.func.isRequired,
+  holdings: PropTypes.arrayOf(PropTypes.object),
+  withMoveDropdown: PropTypes.bool,
+  children: PropTypes.func,
+};
+
+export default stripesConnect(HoldingAccordion);

--- a/src/Instance/HoldingsList/Holding/HoldingAccordion.test.js
+++ b/src/Instance/HoldingsList/Holding/HoldingAccordion.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { noop } from 'lodash';
+import userEvent from '@testing-library/user-event';
+import { act } from 'react-dom/test-utils';
+import { screen } from '@testing-library/react';
+
+import '../../../../test/jest/__mock__';
+
+import { StripesContext } from '@folio/stripes-core/src/StripesContext';
+import DataContext from '../../../contexts/DataContext';
+
+import renderWithIntl from '../../../../test/jest/helpers/renderWithIntl';
+import translations from '../../../../test/jest/helpers/translationsProperties';
+import { items as itemsFixture } from '../../../../test/fixtures/items';
+import HoldingAccordion from './HoldingAccordion';
+
+const stripesStub = {
+  connect: Component => <Component />,
+  hasPerm: () => true,
+  hasInterface: () => true,
+  logger: { log: noop },
+  locale: 'en-US',
+  plugins: {},
+};
+
+const HoldingAccordionSetup = ({
+  items = itemsFixture,
+} = {}) => (
+  <Router>
+    <DataContext.Provider value={{ locationsById: {} }}>
+      <StripesContext.Provider value={stripesStub}>
+        <HoldingAccordion
+          holding={{ id: '123' }}
+          holdings={[]}
+          onViewHolding={noop}
+          onAddItem={noop}
+          withMoveDropdown={false}
+          mutator={{
+            instanceHoldingItems: {
+              GET: () => new Promise(resolve => resolve(items)),
+              reset: noop,
+            },
+          }}
+        >
+          {() => null}
+        </HoldingAccordion>
+      </StripesContext.Provider>
+    </DataContext.Provider>
+  </Router>
+);
+
+describe('HoldingAccordion', () => {
+  beforeEach(async () => {
+    await act(async () => {
+      await renderWithIntl(<HoldingAccordionSetup />, translations);
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render items counter', () => {
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  describe('opening accordion', () => {
+    beforeEach(() => {
+      userEvent.click(screen.getByText(/Holdings:/));
+    });
+
+    it('should hide item counter', async () => {
+      expect(screen.queryByText('3')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/Instance/HoldingsList/Holding/HoldingButtonsGroup.js
+++ b/src/Instance/HoldingsList/Holding/HoldingButtonsGroup.js
@@ -1,0 +1,67 @@
+import React, { memo } from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import { IfPermission } from '@folio/stripes/core';
+import {
+  Button,
+  Badge,
+} from '@folio/stripes/components';
+
+import { MoveToDropdown } from './MoveToDropdown';
+
+const HoldingButtonsGroup = ({
+  withMoveDropdown,
+  holding,
+  holdings,
+  locationsById,
+  onViewHolding,
+  onAddItem,
+  itemCount,
+  isOpen,
+}) => (
+  <>
+    {
+      withMoveDropdown && (
+        <MoveToDropdown
+          holding={holding}
+          holdings={holdings}
+          locationsById={locationsById}
+        />
+      )
+    }
+    <Button
+      id={`clickable-view-holdings-${holding.id}`}
+      data-test-view-holdings
+      onClick={onViewHolding}
+    >
+      <FormattedMessage id="ui-inventory.viewHoldings" />
+    </Button>
+
+    <IfPermission perm="ui-inventory.item.create">
+      <Button
+        id={`clickable-new-item-${holding.id}`}
+        data-test-add-item
+        onClick={onAddItem}
+        buttonStyle="primary paneHeaderNewButton"
+      >
+        <FormattedMessage id="ui-inventory.addItem" />
+      </Button>
+    </IfPermission>
+    {!isOpen && <Badge>{itemCount}</Badge>}
+  </>
+);
+
+HoldingButtonsGroup.propTypes = {
+  holding: PropTypes.object.isRequired,
+  holdings: PropTypes.arrayOf(PropTypes.object).isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  itemCount: PropTypes.number.isRequired,
+  locationsById: PropTypes.object.isRequired,
+  onAddItem: PropTypes.func.isRequired,
+  onViewHolding: PropTypes.func.isRequired,
+  withMoveDropdown: PropTypes.bool,
+};
+
+
+export default memo(HoldingButtonsGroup);

--- a/src/Instance/ItemsList/ItemsListContainer.js
+++ b/src/Instance/ItemsList/ItemsListContainer.js
@@ -1,60 +1,43 @@
-import React, {
-  useEffect,
-  useState,
-} from 'react';
+import React, { useContext, memo } from 'react';
 import PropTypes from 'prop-types';
-import { isEmpty } from 'lodash';
 
-import { stripesConnect } from '@folio/stripes/core';
-
+import DnDContext from '../DnDContext';
 import ItemsList from './ItemsList';
 
-const ItemsListContainer = ({ holding, mutator, setOpen, ...rest }) => {
-  const [items, setItems] = useState();
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    setIsLoading(true);
-
-    mutator.instanceHoldingItems.GET()
-      .then(data => {
-        setItems(data);
-        if (!isEmpty(data)) setOpen(true);
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
-  }, []);
-
-  if (isLoading) return null;
+const ItemsListContainer = ({
+  holding,
+  items,
+  draggable,
+  droppable,
+}) => {
+  const {
+    selectItemsForDrag,
+    isItemsDragSelected,
+    getDraggingItems,
+    activeDropZone,
+    isItemsDroppable,
+  } = useContext(DnDContext);
 
   return (
     <ItemsList
-      {...rest}
+      isItemsDragSelected={isItemsDragSelected}
+      selectItemsForDrag={selectItemsForDrag}
+      getDraggingItems={getDraggingItems}
+      activeDropZone={activeDropZone}
+      isItemsDroppable={isItemsDroppable}
       holding={holding}
       items={items}
+      draggable={draggable}
+      droppable={droppable}
     />
   );
 };
 
-ItemsListContainer.manifest = Object.freeze({
-  instanceHoldingItems: {
-    type: 'okapi',
-    records: 'items',
-    path: 'inventory/items',
-    params: {
-      query: 'holdingsRecordId==!{holding.id}',
-      limit: '5000',
-    },
-    accumulate: true,
-    resourceShouldRefresh: true,
-  },
-});
-
 ItemsListContainer.propTypes = {
-  mutator: PropTypes.object.isRequired,
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
   holding: PropTypes.object.isRequired,
-  setOpen: PropTypes.func.isRequired,
+  draggable: PropTypes.bool,
+  droppable: PropTypes.bool
 };
 
-export default stripesConnect(ItemsListContainer);
+export default memo(ItemsListContainer);

--- a/test/bigtest/interactors/instance-view-page.js
+++ b/test/bigtest/interactors/instance-view-page.js
@@ -54,7 +54,7 @@ import KeyValue from './KeyValue';
   isLoaded = isPresent('[data-test-instance-header-title]');
 
   whenLoaded() {
-    return this.when(() => this.isLoaded);
+    return this.when(() => this.isLoaded).timeout(5000);
   }
 
   title = text('[data-test-instance-header-title]');
@@ -94,5 +94,5 @@ import KeyValue from './KeyValue';
 
 export default new InstanceViewPage({
   scope: '[data-test-instance-details]',
-  timeout: 20000,
+  timeout: 30000,
 });

--- a/test/bigtest/interactors/item-view-page.js
+++ b/test/bigtest/interactors/item-view-page.js
@@ -83,5 +83,5 @@ import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumn
 }
 
 export default new ItemViewPage({
-  timeout: 10000,
+  timeout: 50000,
 });

--- a/test/bigtest/tests/instance-view-page-test.js
+++ b/test/bigtest/tests/instance-view-page-test.js
@@ -109,22 +109,22 @@ describe('InstanceViewPage', () => {
       });
     });
 
-    describe('collapse all clicked', () => {
+    describe('expand all clicked', () => {
       beforeEach(async () => {
         await InstanceViewPage.expandAll.click();
       });
 
-      it('accordion should not be displayed', () => {
-        expect(InstanceViewPage.accordion.isOpen).to.be.false;
+      it('accordion should be displayed', () => {
+        expect(InstanceViewPage.accordion.isOpen).to.be.true;
       });
 
-      describe('expand all', () => {
+      describe('collapse all', () => {
         beforeEach(async () => {
           await InstanceViewPage.expandAll.click();
         });
 
-        it('accordion should be displayed', () => {
-          expect(InstanceViewPage.accordion.isOpen).to.be.true;
+        it('accordion should not be displayed', () => {
+          expect(InstanceViewPage.accordion.isOpen).to.be.false;
         });
       });
     });

--- a/test/fixtures/items.js
+++ b/test/fixtures/items.js
@@ -1,0 +1,157 @@
+export const items = [
+  {
+    id: '7abd8dfe-0234-4256-b2e6-539499999cac',
+    status: {
+      name: 'Checked out',
+    },
+    title: '14 cows for America',
+    hrid: 'it00000168',
+    contributorNames: [
+      {
+        name: 'Deedy, Carmen Agra.',
+      },
+      {
+        name: 'Naiyomah, Wilson Kimeli.',
+      },
+      {
+        name: 'Gonzalez, Thomas',
+      },
+    ],
+    formerIds: [],
+    discoverySuppress: null,
+    holdingsRecordId: '44a21d17-a666-4f34-b24d-644f8ed1537b',
+    barcode: '5860825104574',
+    enumeration : 'v.72:no.1-6',
+    chronology : '1986:Jan.-June',
+    copyNumber: '',
+    notes: [],
+    circulationNotes: [],
+    numberOfPieces: '3',
+    volume: 'V.1 2345',
+    yearCaption: [2018, 2019, 2020],
+    electronicAccess: [],
+    statisticalCodeIds: [],
+    purchaseOrderLineIdentifier: null,
+    materialType: {
+      id: '1a54b431-2e4f-452d-9cae-9cee66c9a892',
+      name: 'book',
+    },
+    permanentLoanType: {
+      id: '2b94c631-fca9-4892-a730-03ee529ffe27',
+      name: 'Can circulate',
+    },
+    metadata: {
+      createdDate: '2019-04-11T03:34:21.745+0000',
+      createdByUserId: '834408d0-5f11-5278-8945-4508aadf94b6',
+      updatedDate: '2019-04-11T12:01:48.451+0000',
+      updatedByUserId: '834408d0-5f11-5278-8945-4508aadf94b6',
+    },
+    effectiveLocation: {
+      id: 'fcd64ce1-6995-48f0-840e-89ffa2288371',
+      name: 'Main Library',
+    },
+  },
+  {
+    id: '8abd8dfe-0234-4256-b2e6-539499999cac',
+    status: {
+      name: 'Available',
+    },
+    title: '14 cows for America',
+    hrid: 'it00000169',
+    contributorNames: [
+      {
+        name: 'Deedy, Carmen Agra.',
+      },
+      {
+        name: 'Naiyomah, Wilson Kimeli.',
+      },
+      {
+        name: 'Gonzalez, Thomas',
+      },
+    ],
+    formerIds: [],
+    discoverySuppress: null,
+    holdingsRecordId: '44a21d17-a666-4f34-b24d-644f8ed1537b',
+    barcode: '60825104574',
+    enumeration : 'v.70:no.7-12',
+    chronology : '1984:July-Dec.',
+    copyNumber: '',
+    notes: [],
+    circulationNotes: [],
+    numberOfPieces: '3',
+    volume: 'V.1 101',
+    yearCaption: [2020],
+    electronicAccess: [],
+    statisticalCodeIds: [],
+    purchaseOrderLineIdentifier: null,
+    materialType: {
+      id: '1a54b431-2e4f-452d-9cae-9cee66c9a892',
+      name: 'text',
+    },
+    permanentLoanType: {
+      id: '2b94c631-fca9-4892-a730-03ee529ffe27',
+      name: 'Can circulate',
+    },
+    metadata: {
+      createdDate: '2019-04-11T03:34:21.745+0000',
+      createdByUserId: '834408d0-5f11-5278-8945-4508aadf94b6',
+      updatedDate: '2019-04-11T12:01:48.451+0000',
+      updatedByUserId: '834408d0-5f11-5278-8945-4508aadf94b6',
+    },
+    effectiveLocation: {
+      id: 'fcd64ce1-6995-48f0-840e-89ffa2288371',
+      name: 'Main Library',
+    },
+  }, {
+    id: '6abd8dfe-0234-4256-b2e6-539499999cac',
+    status: {
+      name: 'Paged',
+    },
+    title: '14 cows for America',
+    hrid: 'it00000170',
+    contributorNames: [
+      {
+        name: 'Deedy, Carmen Agra.',
+      },
+      {
+        name: 'Naiyomah, Wilson Kimeli.',
+      },
+      {
+        name: 'Gonzalez, Thomas',
+      },
+    ],
+    formerIds: [],
+    discoverySuppress: null,
+    holdingsRecordId: '44a21d17-a666-4f34-b24d-644f8ed1537b',
+    barcode: '40875104574',
+    enumeration : 'v.73:no.1-6',
+    chronology : '1987:Jan.-June',
+    copyNumber: '',
+    notes: [],
+    circulationNotes: [],
+    numberOfPieces: '3',
+    volume: 'V.2 211',
+    yearCaption: [2015, 2019],
+    electronicAccess: [],
+    statisticalCodeIds: [],
+    purchaseOrderLineIdentifier: null,
+    materialType: {
+      id: '1a54b431-2e4f-452d-9cae-9cee66c9a892',
+      name: 'book',
+    },
+    permanentLoanType: {
+      id: '2b94c631-fca9-4892-a730-03ee529ffe27',
+      name: 'Can circulate',
+    },
+    metadata: {
+      createdDate: '2019-04-11T03:34:21.745+0000',
+      createdByUserId: '834408d0-5f11-5278-8945-4508aadf94b6',
+      updatedDate: '2019-04-11T12:01:48.451+0000',
+      updatedByUserId: '834408d0-5f11-5278-8945-4508aadf94b6',
+    },
+    effectiveLocation: {
+      id: 'fcd64ce1-6995-48f0-840e-89ffa2288372',
+      name: 'Annex',
+    },
+  }
+];


### PR DESCRIPTION
Add item counter to each holdings record accordion. 

https://issues.folio.org/browse/UIIN-803

This took a bit longer because I had to move things around in order to get access to item records on the accordion level.

We could potentially improve this a bit more by fetching items for all holding records in one request.


![holdings](https://user-images.githubusercontent.com/63545/109020834-53e3cd00-7688-11eb-87c0-5b54adec40ac.gif)
