### PR TITLE
UIIN-1422: Add tags.collection.get subpermission to `Inventory: View …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 * Parse `item.enumeration` numerically for sorting if possible. Refs UIIN-1412.
 * Allow the selection of remote storage locations. Refs UIIN-1290.
 * Add ability to search by `allTitles` index. Refs UIIN-1434.
+* Add `tags.collection.get` as subpermission to `Inventory: View instances, holdings, and items` permission. Fixes UIIN-1422.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/package.json
+++ b/package.json
@@ -434,6 +434,7 @@
         "subPermissions": [
           "module.inventory.enabled",
           "users.collection.get",
+          "tags.collection.get",
           "source-storage.records.get",
           "circulation.loans.collection.get",
           "circulation.loans.collection.get",


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1422

### Purpose
The tag filter in the UI requires the `tags.collection.get` permission. This PR should solve this issue.