### PR TITLE
Remove unused prop

### DIFF
--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -505,7 +505,6 @@ class ViewInstance extends React.Component {
   render() {
     const {
       match: { params: { id, holdingsrecordid, itemid } },
-      referenceTables,
       stripes,
       onClose,
       paneWidth,
@@ -636,7 +635,6 @@ ViewInstance.propTypes = {
   onClose: PropTypes.func,
   onCopy: PropTypes.func,
   paneWidth: PropTypes.string.isRequired,
-  referenceTables: PropTypes.object.isRequired,
   resources: PropTypes.shape({
     allInstanceItems: PropTypes.object.isRequired,
     allInstanceHoldings: PropTypes.object.isRequired,


### PR DESCRIPTION
Fixes an ESLint error, making the whole repository once more lint-clean aside from the ravening horde of `react-hooks/exhaustive-deps` errors.
