### PR TITLE
Improved settings page for single-record-import profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * Inventory app now degrades gracefully in the absence of mod-copycat. Fixes UIIN-1428.
 * Modify language of Settings/Inventory/Single record import. Fixes UIIN-1429.
 * Disable the single-record-import modal's Import button until something has been entered. Fixes UIIN-1431.
+* Better settings UI for maintaining copycat targets. Fixes UIIN-1437.
 * Update to `stripes-cli v2.0.0`. Refs UIIN-1410.
 * Show new request option for item with status restricted. Refs UIIN-1306.
 * Connect the `Remove leading zeroes from HRID` field to the `HRID handling` form. Refs UIIN-1413.

--- a/src/components/ImportRecordModal/ImportRecordModal.js
+++ b/src/components/ImportRecordModal/ImportRecordModal.js
@@ -34,7 +34,11 @@ const ImportRecordModal = ({
           onSubmit={onSubmit}
           render={({ handleSubmit, values }) => (
             <form onSubmit={handleSubmit}>
-              {profiles.length === 1 ? (
+              {!profiles || profiles.length === 0 ? (
+                <p>
+                  <FormattedMessage id="ui-inventory.copycat.noProfiles" />
+                </p>
+              ) : profiles.length === 1 ? (
                 <Field name="externalIdentifierType" initialValue={currentProfile.id}>
                   {props2 => <input type="hidden" {...props2.input} />}
                 </Field>
@@ -43,16 +47,18 @@ const ImportRecordModal = ({
                   {props2 => <Select {...props2.input} dataOptions={options} />}
                 </Field>
               )}
-              <Field
-                name="externalIdentifier"
-                component={TextField}
-                label={
-                  <FormattedMessage
-                    id={`ui-inventory.copycat.enterIdentifier${id ? 'ForUpdate' : ''}`}
-                    values={{ identifierName: profileById[values.externalIdentifierType] }}
-                  />}
-                autoFocus
-              />
+              {currentProfile && (
+                <Field
+                  name="externalIdentifier"
+                  component={TextField}
+                  label={
+                    <FormattedMessage
+                      id={`ui-inventory.copycat.enterIdentifier${id ? 'ForUpdate' : ''}`}
+                      values={{ identifierName: profileById[values.externalIdentifierType] }}
+                    />}
+                  autoFocus
+                />
+              )}
               <ModalFooter>
                 <Button buttonStyle="primary" disabled={!values.externalIdentifier} onClick={() => handleSubmit()}>
                   <FormattedMessage id="ui-inventory.copycat.import" />

--- a/src/settings/SingleRecordImport.js
+++ b/src/settings/SingleRecordImport.js
@@ -34,7 +34,7 @@ class SingleRecordImport extends React.Component {
             label={<FormattedMessage id="ui-inventory.targetProfiles" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.targetProfile' })}
             objectLabel={<FormattedMessage id="ui-inventory.targetProfiles" />}
-            visibleFields={['name', 'url', 'authentication', 'externalIdQueryMap', 'internalIdEmbedPath', 'jobProfileId', 'externalIdentifierType', 'enabled']}
+            visibleFields={['name', 'url', 'authentication', 'externalIdQueryMap', 'internalIdEmbedPath', 'jobProfileId', 'targetOptions', 'externalIdentifierType', 'enabled']}
             columnMapping={{
               name: intl.formatMessage({ id: 'ui-inventory.name' }),
               url: intl.formatMessage({ id: 'ui-inventory.url' }),
@@ -42,6 +42,7 @@ class SingleRecordImport extends React.Component {
               externalIdQueryMap: intl.formatMessage({ id: 'ui-inventory.externalIdQueryMap' }),
               internalIdEmbedPath: intl.formatMessage({ id: 'ui-inventory.internalIdEmbedPath' }),
               jobProfileId: intl.formatMessage({ id: 'ui-inventory.jobProfileId' }),
+              targetOptions: intl.formatMessage({ id: 'ui-inventory.targetOptions' }),
               externalIdentifierType: intl.formatMessage({ id: 'ui-inventory.externalIdentifierType' }),
               enabled: intl.formatMessage({ id: 'ui-inventory.enabled' }),
             }}

--- a/src/settings/TargetProfileDetail.js
+++ b/src/settings/TargetProfileDetail.js
@@ -1,22 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { stripesConnect } from '@folio/stripes/core';
 import { Col, Row, KeyValue } from '@folio/stripes/components';
-import { ViewMetaData } from '@folio/stripes/smart-components';
 
 
 class TargetProfileDetail extends React.Component {
   static propTypes = {
-    stripes: PropTypes.shape({
-      connect: PropTypes.func.isRequired,
+    initialValues: PropTypes.object.isRequired,
+    resources: PropTypes.shape({
+      identifierType: PropTypes.shape({
+        records: PropTypes.arrayOf(
+          PropTypes.shape({
+            name: PropTypes.string,
+          }).isRequired,
+        ),
+      }).isRequired,
     }).isRequired,
-    initialValues: PropTypes.object,
   };
 
-  constructor(props) {
-    super(props);
-    this.ConnectedViewMetaData = props.stripes.connect(ViewMetaData);
-  }
+  static manifest = Object.freeze({
+    identifierType: {
+      type: 'okapi',
+      path: 'identifier-types?query=id=!{initialValues.externalIdentifierType}',
+      records: 'identifierTypes',
+    },
+  });
 
   render() {
     const { initialValues } = this.props;
@@ -71,9 +80,33 @@ class TargetProfileDetail extends React.Component {
             />
           </Col>
         </Row>
+        <Row>
+          <Col xs={12}>
+            <KeyValue
+              label={<FormattedMessage id="ui-inventory.targetOptions" />}
+              value={initialValues.targetOptions}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col xs={12}>
+            <KeyValue
+              label={<FormattedMessage id="ui-inventory.externalIdentifierType" />}
+              value={this.props.resources.identifierType.records?.[0]?.name}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col xs={12}>
+            <KeyValue
+              label={<FormattedMessage id="ui-inventory.enabled" />}
+              value={initialValues.enabled ? '✓' : '✕'}
+            />
+          </Col>
+        </Row>
       </div>
     );
   }
 }
 
-export default TargetProfileDetail;
+export default stripesConnect(TargetProfileDetail);

--- a/src/settings/TargetProfileForm.js
+++ b/src/settings/TargetProfileForm.js
@@ -126,7 +126,7 @@ const TargetProfileForm = ({ initialValues, onSubmit, onCancel, intl, resources 
                   name="enabled"
                   id="input-targetprofile-enabled"
                   component={Checkbox}
-                  defaultChecked={initialValues?.enabled}
+                  type="checkbox"
                 />
               </Col>
             </Row>

--- a/src/settings/TargetProfileForm.js
+++ b/src/settings/TargetProfileForm.js
@@ -1,52 +1,106 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
-import { Row, Col, TextField, Button } from '@folio/stripes/components';
-import stripesFinalForm from '@folio/stripes/final-form';
+import { Form, Field } from 'react-final-form';
+import { FormattedMessage, injectIntl } from 'react-intl';
+import { Prompt } from 'react-router-dom';
 
-class TargetProfileForm extends React.Component {
-  static propTypes = {
-    pristine: PropTypes.bool.isRequired,
-    submitting: PropTypes.bool.isRequired,
-    initialValues: PropTypes.object,
-    handleSubmit: PropTypes.func.isRequired,
-  };
+import {
+  Button,
+  Checkbox,
+  Col,
+  IconButton,
+  Pane,
+  PaneFooter,
+  PaneMenu,
+  Paneset,
+  Row,
+  TextField,
+} from '@folio/stripes/components';
 
-  render() {
-    const { pristine, submitting, initialValues, handleSubmit } = this.props;
-
-    return (
-      <form
-        id="form-loan-rules"
-        data-test-circulation-rules-form
-        onSubmit={handleSubmit}
-      >
-        <Row end="xs">
-          <Col xs={3}>
-            <FormattedMessage id="ui-inventory.name">
-              {placeholder => (
-                <TextField
-                  aria-label={placeholder}
-                  placeholder={placeholder}
-                  value={initialValues.name}
+const TargetProfileForm = ({ initialValues, onSubmit, onCancel, intl }) => (
+  <Form onSubmit={onSubmit} initialValues={initialValues}>
+    {({ handleSubmit, pristine, submitting, submitSucceeded }) => (
+      <form id="form-patron-notice" noValidate data-test-notice-form onSubmit={handleSubmit}>
+        <Paneset isRoot>
+          <Pane
+            defaultWidth="100%"
+            paneTitle={initialValues?.id
+              ? initialValues?.name
+              : <FormattedMessage id="stripes-components.addNew" />
+            }
+            firstMenu={
+              <PaneMenu>
+                <FormattedMessage id="stripes-components.cancel">
+                  {ariaLabel => (
+                    <IconButton
+                      icon="times"
+                      id="close-targetprofile-form-button"
+                      onClick={onCancel}
+                      aria-label={ariaLabel}
+                    />
+                  )}
+                </FormattedMessage>
+              </PaneMenu>
+            }
+            footer={
+              <PaneFooter
+                renderEnd={
+                  <Button
+                    buttonStyle="primary mega"
+                    disabled={pristine || submitting}
+                    marginBottom0
+                    onClick={handleSubmit}
+                    type="submit"
+                  >
+                    <FormattedMessage id="stripes-components.saveAndClose" />
+                  </Button>
+                }
+                renderStart={
+                  <Button buttonStyle="default mega" marginBottom0 onClick={onCancel}>
+                    <FormattedMessage id="stripes-components.cancel" />
+                  </Button>
+                }
+              />
+            }
+          >
+            <Row>
+              <Col xs={8} data-test-notice-template-name>
+                <Field
+                  label={<FormattedMessage id="ui-inventory.name" />}
+                  name="name"
+                  required
+                  id="input-targetprofile-name"
+                  component={TextField}
                 />
-              )}
-            </FormattedMessage>
-          </Col>
-          <Col xs={3}>
-            <Button
-              fullWidth
-              id="clickable-save-loan-rules"
-              type="submit"
-              disabled={pristine || submitting}
-            >
-              <FormattedMessage id="ui-inventory.save" />
-            </Button>
-          </Col>
-        </Row>
+              </Col>
+              <Col xs={4}>
+                <Field
+                  label={<FormattedMessage id="ui-inventory.enabled" />}
+                  name="enabled"
+                  id="input-targetprofile-enabled"
+                  component={Checkbox}
+                  defaultChecked={initialValues?.enabled}
+                />
+              </Col>
+            </Row>
+          </Pane>
+        </Paneset>
+        <Prompt
+          when={!pristine && !(submitting || submitSucceeded)}
+          message={intl.formatMessage({ id: 'ui-inventory.confirmDirtyNavigate' })}
+        />
       </form>
-    );
-  }
-}
+    )}
+  </Form>
+);
 
-export default stripesFinalForm({ navigationCheck: true })(TargetProfileForm);
+TargetProfileForm.propTypes = {
+  initialValues: PropTypes.object,
+  onSubmit: PropTypes.func,
+  onCancel: PropTypes.func,
+  intl: PropTypes.shape({
+    formatMessage: PropTypes.func.isRequired,
+  }).isRequired,
+};
+
+export default injectIntl(TargetProfileForm);

--- a/src/settings/TargetProfileForm.js
+++ b/src/settings/TargetProfileForm.js
@@ -24,7 +24,7 @@ function makeOptions(resource) {
 }
 
 const TargetProfileForm = ({ initialValues, onSubmit, onCancel, intl, resources }) => (
-  <Form onSubmit={onSubmit} initialValues={initialValues}>
+  <Form onSubmit={onSubmit} initialValues={{ ...initialValues, displayName: undefined }}>
     {({ handleSubmit, pristine, submitting, submitSucceeded }) => (
       <form id="form-patron-notice" noValidate data-test-notice-form onSubmit={handleSubmit}>
         <Paneset isRoot>

--- a/src/settings/TargetProfileForm.js
+++ b/src/settings/TargetProfileForm.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Form, Field } from 'react-final-form';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { Prompt } from 'react-router-dom';
+import { stripesConnect } from '@folio/stripes-core';
 
 import {
   Button,
@@ -14,10 +15,15 @@ import {
   PaneMenu,
   Paneset,
   Row,
+  Select,
   TextField,
 } from '@folio/stripes/components';
 
-const TargetProfileForm = ({ initialValues, onSubmit, onCancel, intl }) => (
+function makeOptions(resource) {
+  return (resource.records || []).map(p => ({ value: p.id, label: p.name }));
+}
+
+const TargetProfileForm = ({ initialValues, onSubmit, onCancel, intl, resources }) => (
   <Form onSubmit={onSubmit} initialValues={initialValues}>
     {({ handleSubmit, pristine, submitting, submitSucceeded }) => (
       <form id="form-patron-notice" noValidate data-test-notice-form onSubmit={handleSubmit}>
@@ -112,7 +118,8 @@ const TargetProfileForm = ({ initialValues, onSubmit, onCancel, intl }) => (
                   label={<FormattedMessage id="ui-inventory.externalIdentifierType" />}
                   name="externalIdentifierType"
                   id="input-targetprofile-externalIdentifierType"
-                  component={TextField}
+                  component={Select}
+                  dataOptions={makeOptions(resources.identifierTypes)}
                 />
                 <Field
                   label={<FormattedMessage id="ui-inventory.enabled" />}
@@ -141,6 +148,19 @@ TargetProfileForm.propTypes = {
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
+  resources: PropTypes.shape({
+    identifierTypes: PropTypes.shape({
+      records: PropTypes.arrayOf(PropTypes.object),
+    }).isRequired
+  }),
 };
 
-export default injectIntl(TargetProfileForm);
+TargetProfileForm.manifest = Object.freeze({
+  identifierTypes: {
+    type: 'okapi',
+    records: 'identifierTypes',
+    path: 'identifier-types?limit=1000&query=cql.allRecords=1 sortby name',
+  },
+});
+
+export default stripesConnect(injectIntl(TargetProfileForm));

--- a/src/settings/TargetProfileForm.js
+++ b/src/settings/TargetProfileForm.js
@@ -64,7 +64,7 @@ const TargetProfileForm = ({ initialValues, onSubmit, onCancel, intl }) => (
             }
           >
             <Row>
-              <Col xs={8} data-test-notice-template-name>
+              <Col xs={12}>
                 <Field
                   label={<FormattedMessage id="ui-inventory.name" />}
                   name="name"
@@ -72,8 +72,48 @@ const TargetProfileForm = ({ initialValues, onSubmit, onCancel, intl }) => (
                   id="input-targetprofile-name"
                   component={TextField}
                 />
-              </Col>
-              <Col xs={4}>
+                <Field
+                  label={<FormattedMessage id="ui-inventory.url" />}
+                  name="url"
+                  id="input-targetprofile-url"
+                  component={TextField}
+                />
+                <Field
+                  label={<FormattedMessage id="ui-inventory.authentication" />}
+                  name="authentication"
+                  id="input-targetprofile-authentication"
+                  component={TextField}
+                />
+                <Field
+                  label={<FormattedMessage id="ui-inventory.externalIdQueryMap" />}
+                  name="externalIdQueryMap"
+                  id="input-targetprofile-externalIdQueryMap"
+                  component={TextField}
+                />
+                <Field
+                  label={<FormattedMessage id="ui-inventory.internalIdEmbedPath" />}
+                  name="internalIdEmbedPath"
+                  id="input-targetprofile-internalIdEmbedPath"
+                  component={TextField}
+                />
+                <Field
+                  label={<FormattedMessage id="ui-inventory.jobProfileId" />}
+                  name="jobProfileId"
+                  id="input-targetprofile-jobProfileId"
+                  component={TextField}
+                />
+                <Field
+                  label={<FormattedMessage id="ui-inventory.targetOptions" />}
+                  name="targetOptions"
+                  id="input-targetprofile-targetOptions"
+                  component={TextField}
+                />
+                <Field
+                  label={<FormattedMessage id="ui-inventory.externalIdentifierType" />}
+                  name="externalIdentifierType"
+                  id="input-targetprofile-externalIdentifierType"
+                  component={TextField}
+                />
                 <Field
                   label={<FormattedMessage id="ui-inventory.enabled" />}
                   name="enabled"

--- a/src/settings/TargetProfiles.js
+++ b/src/settings/TargetProfiles.js
@@ -36,7 +36,8 @@ class TargetProfiles extends React.Component {
   };
 
   render() {
-    const entryList = sortBy((this.props.resources.entries || {}).records || [], ['name']);
+    const entryList = sortBy((this.props.resources.entries || {}).records || [], ['name'])
+      .map(entry => ({ ...entry, displayName: `${entry.enabled ? '✓' : '✕'} ${entry.name}` }));
 
     return (
       <EntryManager
@@ -48,7 +49,7 @@ class TargetProfiles extends React.Component {
         paneTitle={this.props.label}
         entryLabel={this.props.label}
         entryFormComponent={TargetProfileForm}
-        nameKey="name"
+        nameKey="displayName"
         permissions={{
           put: 'ui-inventory.single-record-import',
           post: 'ui-inventory.single-record-import',

--- a/src/settings/TargetProfiles.js
+++ b/src/settings/TargetProfiles.js
@@ -36,8 +36,8 @@ class TargetProfiles extends React.Component {
   };
 
   render() {
-    const entryList = sortBy((this.props.resources.entries || {}).records || [], ['name'])
-      .map(entry => ({ ...entry, displayName: `${entry.enabled ? '✓' : '✕'} ${entry.name}` }));
+    const entryList = sortBy((this.props.resources.entries || {}).records || [], ['name']);
+    // .map(entry => ({ ...entry, displayName: `${entry.enabled ? '✓' : '✕'} ${entry.name}` }))
 
     return (
       <EntryManager
@@ -49,7 +49,7 @@ class TargetProfiles extends React.Component {
         paneTitle={this.props.label}
         entryLabel={this.props.label}
         entryFormComponent={TargetProfileForm}
-        nameKey="displayName"
+        nameKey="name"
         permissions={{
           put: 'ui-inventory.single-record-import',
           post: 'ui-inventory.single-record-import',

--- a/src/settings/TargetProfiles.js
+++ b/src/settings/TargetProfiles.js
@@ -36,8 +36,8 @@ class TargetProfiles extends React.Component {
   };
 
   render() {
-    const entryList = sortBy((this.props.resources.entries || {}).records || [], ['name']);
-    // .map(entry => ({ ...entry, displayName: `${entry.enabled ? '✓' : '✕'} ${entry.name}` }))
+    const entryList = sortBy((this.props.resources.entries || {}).records || [], ['name'])
+      .map(entry => ({ ...entry, displayName: `${entry.enabled ? '✓' : '✕'} ${entry.name}` }));
 
     return (
       <EntryManager
@@ -49,7 +49,7 @@ class TargetProfiles extends React.Component {
         paneTitle={this.props.label}
         entryLabel={this.props.label}
         entryFormComponent={TargetProfileForm}
-        nameKey="name"
+        nameKey="displayName"
         permissions={{
           put: 'ui-inventory.single-record-import',
           post: 'ui-inventory.single-record-import',

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -198,7 +198,10 @@ class InventorySettings extends React.Component {
           },
         ]
       },
-      {
+    ];
+
+    if (this.props.stripes.hasInterface('copycat-imports')) {
+      this.sections.push({
         label: <FormattedMessage id="ui-inventory.integrations" />,
         pages: [
           {
@@ -215,8 +218,8 @@ class InventorySettings extends React.Component {
             perm: 'ui-inventory.settings.single-record-import',
           },
         ]
-      },
-    ];
+      });
+    }
   }
 
   addPerm = permission => {

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -19,7 +19,7 @@ import HoldingsNoteTypesSettings from './HoldingsNoteTypesSettings';
 import HoldingsSourcesSettings from './HoldingsSourcesSettings';
 import CallNumberTypes from './CallNumberTypes';
 import SingleRecordImport from './SingleRecordImport';
-// import TargetProfiles from './TargetProfiles';
+import TargetProfiles from './TargetProfiles';
 import HRIDHandlingSettings from './HRIDHandling/HRIDHandlingSettings';
 import StatisticalCodeTypes from './StatisticalCodeTypes';
 import AlternativeTitleTypesSettings from './AlternativeTitleTypesSettings';
@@ -208,14 +208,12 @@ class InventorySettings extends React.Component {
             component: SingleRecordImport,
             perm: 'ui-inventory.settings.single-record-import',
           },
-          /*
           {
             route: 'targetProfiles',
             label: <FormattedMessage id="ui-inventory.targetProfiles" />,
             component: TargetProfiles,
             perm: 'ui-inventory.settings.single-record-import',
           },
-          */
         ]
       },
     ];

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -290,6 +290,7 @@
   "externalIdQueryMap": "External ID query map",
   "internalIdEmbedPath": "Internal ID embed path",
   "jobProfileId": "Job profile ID",
+  "targetOptions": "Target options",
   "externalIdentifierType": "External identifier type",
   "enabled": "Enabled",
   "urls": "URLs",

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -560,6 +560,7 @@
   "precedingField.title": "Title",
   "precedingField.notConnected": "Not connected",
   "precedingField.connected": "Connected",
+  "confirmDirtyNavigate": "Form has unsaved changes. Are you sure you want to leave?",
 
   "editInstanceMarc": "Edit in quickMARC",
   "duplicateInstanceMarc": "Duplicate MARC bibliographic record",

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -638,7 +638,7 @@
   "showColumns": "Show columns",
   "copycat.import": "Import",
   "copycat.reimport": "Overlay",
-  "copycat.idToImport": "ID to import",
+  "copycat.noProfiles": "No profiles enabled",
   "copycat.enterIdentifier": "Enter {identifierName} identifier",
   "copycat.enterIdentifierForUpdate": "Enter the {identifierName} identifier to be used to overlay the current data",
   "copycat.callout.updated": "Updated record {xid}",


### PR DESCRIPTION
The old version simply used `<ControlledVocab>`, which is a real squeeze when you have nine editable fields. The new uses `<EntryManager>` and gives you 

I've retained the old version for now, as well as the new page, since we _know_ it does what we need, albeit in a really horrible way, and it's not impossible that there are surprises lurking in the brand new code. I'll rip out the old version once we have some experience with the new.

Fixes UIUN-1437, or at least constitutes _a_ fix. No doubt we will want to come back to this with some UX insight, and change the arrangement of the fields. But for now, we need something functional.