### PR TITLE
UIIN-1434: Add ability to search by allTitles index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
 * Add permission for marking item as In process (non-requestable), Long missing, Unavailable, Unknown. Refs UIIN-1308, UIIN-894, UIIN-1307, UIIN-1326.
 * Parse `item.enumeration` numerically for sorting if possible. Refs UIIN-1412.
 * Allow the selection of remote storage locations. Refs UIIN-1290.
-
+* Add ability to search by `allTitles` index. Refs UIIN-1434.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -87,7 +87,7 @@ export const instanceFilterConfig = [
 export const instanceIndexes = [
   { label: 'ui-inventory.search.all', value: 'all', queryTemplate: 'keyword all "%{query.query}"' },
   { label: 'ui-inventory.contributor', value: 'contributor', queryTemplate: 'contributors =/@name "%{query.query}"' },
-  { label: 'ui-inventory.title', value: 'title', queryTemplate: 'title all "%{query.query}"' },
+  { label: 'ui-inventory.title', value: 'title', queryTemplate: 'allTitles all "%{query.query}"' },
   { label: 'ui-inventory.identifierAll', value: 'identifier', queryTemplate: 'identifiers =/@value "%{query.query}"' },
   { label: 'ui-inventory.isbn', prefix: '- ', value: 'isbn', queryTemplate: 'identifiers =/@value/@identifierTypeId="<%= identifierTypeId %>" "%{query.query}"' },
   { label: 'ui-inventory.isbnNormalized', prefix: '- ', value: 'isbnNormalized', queryTemplate: 'isbn="%{query.query}" OR invalidIsbn="%{query.query}"' },

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -150,6 +150,10 @@ export default function configure() {
           inst.contributors[0].name.match(right.term));
       }
 
+      if (field === 'allTitles') {
+        return instances.all().filter(inst => inst.alternativeTitles.some(el => el.alternativeTitle === term));
+      }
+
       // With the addition of a third condition to search for records by 'Holdings. Call number readable by eye" in the CQL query,
       // cqlParser.tree object gets a deeper structure in the 'left' and 'right' properties.
       if (left?.left?.field === 'holdingsRecords.fullCallNumber') {

--- a/test/bigtest/network/factories/alternative-title-type.js
+++ b/test/bigtest/network/factories/alternative-title-type.js
@@ -1,0 +1,3 @@
+import ApplicationFactory from './application';
+
+export default ApplicationFactory.extend();

--- a/test/bigtest/tests/filters/instances/search-field-filter-test.js
+++ b/test/bigtest/tests/filters/instances/search-field-filter-test.js
@@ -110,4 +110,27 @@ describe('SearchFieldFilter', () => {
       });
     });
   });
+
+  describe('selecting the "Title (all)" search option', function () {
+    beforeEach(async function () {
+      const alternativeTitleType = this.server.create('alternative-title-type');
+      const alternativeTitle = 'Петро Прокопович - український пасічник, викладач і науковець';
+
+      this.server.create('instance', {
+        title: 'Petro Prokopovich – Ukrainian beekeeper, teacher and scientist',
+        contributors: [{ name: 'Mykola Haydak' }],
+        alternativeTitles: [
+          { alternativeTitleTypeId: alternativeTitleType.id, alternativeTitle },
+        ],
+      }, 'withHoldingAndItem');
+
+      await instancesRoute.searchFieldFilter.searchField.selectIndex('Title (all)');
+      await instancesRoute.searchFieldFilter.searchField.fillInput(alternativeTitle);
+      await instancesRoute.searchFieldFilter.clickSearch();
+    });
+
+    it('should find instances by alternative title', () => {
+      expect(instancesRoute.rows().length).to.equal(1);
+    });
+  });
 });


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1434

BE part: https://github.com/folio-org/mod-inventory-storage/pull/573

### Purpose
Adding `allTitles` index allows to search not only by `title` field but by all title-related fields: `Alternative title`, `Index title`, and `Series statement`.

### Screenshot
![Screen Shot 2021-02-25 at 21 51 25](https://user-images.githubusercontent.com/49517355/109209135-db7a2a80-77b3-11eb-8e20-064a75333068.png)