### PR TITLE
UIIN-1423: Fix instance format filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 * Add `tags.collection.get` as subpermission to `Inventory: View instances, holdings, and items` permission. Fixes UIIN-1422.
 * Display shelving order on the item record. Refs UIIN-816.
 * Add item counter to each holding record. Refs UIIN-803.
+* Fix instance format filter. Refs UIIN-1423.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -25,6 +25,7 @@ export const instanceFilterConfig = [
     name: 'format',
     cql: 'instanceFormatIds',
     values: [],
+    operator: '=',
   },
   {
     name: 'resource',


### PR DESCRIPTION
Fix instance format filter by changing the default `==` operator to single `=`.
https://issues.folio.org/browse/UIIN-1423