### PR TITLE
UIIN-1436: Instance Record |  Change Actions menu option Duplicate MARC bibliographic record to Derive new MARC bibliographic record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 * Display shelving order on the item record. Refs UIIN-816.
 * Add item counter to each holding record. Refs UIIN-803.
 * Fix instance format filter. Refs UIIN-1423.
+* Change label Duplicate MARC bib record to Derive new MARC bib record. Refs UIIN-1436.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -559,7 +559,7 @@
   "confirmDirtyNavigate": "Form has unsaved changes. Are you sure you want to leave?",
 
   "editInstanceMarc": "Edit in quickMARC",
-  "duplicateInstanceMarc": "Duplicate MARC bibliographic record",
+  "duplicateInstanceMarc": "Derive new MARC bibliographic record",
   "quickMarcNotAvailable": "No plugin available!",
 
   "permission.all-permissions.TEMPORARY": "Inventory: All permissions",


### PR DESCRIPTION
## Description
Change label for duplicate MARC record button from `Duplicate MARC bib record` to `Derive new MARC bib record`

## Issues
[UIIN-1436](https://issues.folio.org/browse/UIIN-1436)