### PR TITLE
UIIN-1441: Fix nature of content filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 * Fix instance format filter. Refs UIIN-1423.
 * Change label Duplicate MARC bib record to Derive new MARC bib record. Refs UIIN-1436.
 * Add a warning icon for instance/holdings/item marked as Suppressed from discovery. Refs UIIN-1380.
+* Fix nature of content filter. Fixes UIIN-1441.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -41,6 +41,7 @@ export const instanceFilterConfig = [
     name: 'natureOfContent',
     cql: 'natureOfContentTermIds',
     values: [],
+    operator: '=',
   },
   {
     name: 'location',


### PR DESCRIPTION
Fix nature of content filter by changing the default `==` operator to single `=`.
https://issues.folio.org/browse/UIIN-1441