### PR TITLE
UIIN-1377: Add visual display when instance is suppressed from discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 * Add a warning icon for instance/holdings/item marked as Suppressed from discovery. Refs UIIN-1380.
 * Fix nature of content filter. Fixes UIIN-1441.
 * Add a warning icon for instance marked as Staff suppressed. Refs UIIN-1381.
+* Add visual display when instance is suppressed from discovery. Refs UIIN-1377 and UIIN-1386.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/src/Instance/InstanceDetails/InstanceAdministrativeView/InstanceAdministrativeView.js
+++ b/src/Instance/InstanceDetails/InstanceAdministrativeView/InstanceAdministrativeView.js
@@ -14,6 +14,8 @@ import {
   ClipCopy,
 } from '@folio/stripes/smart-components';
 
+import { WarningMessage } from '../../../components';
+
 import {
   getDateWithTime,
   checkIfElementIsEmpty,
@@ -62,15 +64,25 @@ const InstanceAdministrativeView = ({
       label={<FormattedMessage id="ui-inventory.instanceData" />}
     >
       {instance.metadata && <ViewMetaData metadata={instance.metadata} />}
-
       <Row>
-        <Col xs={12}>
-          {instance.discoverySuppress && <FormattedMessage id="ui-inventory.discoverySuppress" />}
-          {instance.discoverySuppress && instance.staffSuppress && '|'}
-          {instance.staffSuppress && <FormattedMessage id="ui-inventory.staffSuppress" />}
-          {(instance.discoverySuppress || instance.staffSuppress) && instance.previouslyHeld && '|'}
-          {instance.previouslyHeld && <FormattedMessage id="ui-inventory.previouslyHeld" />}
-        </Col>
+        {
+          instance.discoverySuppress &&
+          <Col xs={5}>
+            <WarningMessage id="ui-inventory.discoverySuppressed" />
+          </Col>
+        }
+        {
+          instance.staffSuppress &&
+          <Col xs={4}>
+            <WarningMessage id="ui-inventory.staffSuppressed" />
+          </Col>
+        }
+        {
+          instance.previouslyHeld &&
+          <Col xs={3}>
+            <WarningMessage id="ui-inventory.previouslyHeld" />
+          </Col>
+        }
       </Row>
 
       {(instance.discoverySuppress || instance.staffSuppress || instance.previouslyHeld) && <br />}

--- a/src/Instance/InstanceDetails/InstanceAdministrativeView/InstanceAdministrativeView.test.js
+++ b/src/Instance/InstanceDetails/InstanceAdministrativeView/InstanceAdministrativeView.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+
+import '../../../../test/jest/__mock__';
+
+import renderWithIntl from '../../../../test/jest/helpers/renderWithIntl';
+import translationsProperties from '../../../../test/jest/helpers/translationsProperties';
+import { instances as instancesFixture } from '../../../../test/fixtures/instances';
+import InstanceAdministrativeView from './InstanceAdministrativeView';
+
+const InstanceAdministrativeViewSetup = ({
+  instance = instancesFixture[0],
+} = {}) => (
+  <InstanceAdministrativeView
+    id={instance.id}
+    instance={{ ...instance, metadata: null, discoverySuppress: true }}
+  />
+);
+
+describe('InstanceAdministrativeView', () => {
+  describe('rendering warnings', () => {
+    beforeEach(() => {
+      renderWithIntl(
+        <InstanceAdministrativeViewSetup />,
+        translationsProperties
+      );
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should show supress from discovery warning', () => {
+      expect(screen.getByText(/suppressed from discovery/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/Instance/InstanceDetails/InstanceDetails.js
+++ b/src/Instance/InstanceDetails/InstanceDetails.js
@@ -15,6 +15,7 @@ import {
   Pane,
   PaneMenu,
   Row,
+  TextField,
 } from '@folio/stripes/components';
 
 import { InstanceTitle } from './InstanceTitle';
@@ -30,6 +31,7 @@ import { InstanceClassificationView } from './InstanceClassificationView';
 import { InstanceRelationshipView } from './InstanceRelationshipView';
 import { InstanceNewHolding } from './InstanceNewHolding';
 import HelperApp from '../../components/HelperApp';
+import { WarningMessage } from '../../components';
 
 import {
   getAccordionState,
@@ -119,11 +121,13 @@ const InstanceDetails = ({
         <TitleManager record={instance.title} />
 
         <AccordionStatus>
-          <Row end="xs">
-            <Col
-              data-test-expand-all
-              xs
-            >
+          <Row>
+            <Col xs={10}>
+              {
+                instance.discoverySuppress && <WarningMessage fill id="ui-inventory.instance.suppressedFromDiscovery" />
+              }
+            </Col>
+            <Col data-test-expand-all xs={2}>
               <ExpandAllButton />
             </Col>
           </Row>

--- a/src/components/WarningMessage/WarningMessage.css
+++ b/src/components/WarningMessage/WarningMessage.css
@@ -1,0 +1,17 @@
+@import "@folio/stripes-components/lib/variables.css";
+
+.fill {
+  padding: 3px;
+  border: 1px solid var(--error);
+  background-color: color(var(--error) alpha(-95%));
+}
+
+.iconStart {
+  margin-right: 0.2em;
+  background: none;
+}
+
+.iconEnd {
+  margin-left: 0.2em;
+  background: none;
+}

--- a/src/components/WarningMessage/WarningMessage.js
+++ b/src/components/WarningMessage/WarningMessage.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Icon,
+} from '@folio/stripes/components';
+import {
+  FormattedMessage,
+} from 'react-intl';
+
+import css from './WarningMessage.css';
+
+const renderIcon = (icon, iconClassName) => (
+  <Icon
+    status="warn"
+    iconClassName={iconClassName}
+    icon={icon}
+    iconSize="medium"
+  />
+);
+
+const WarningMessage = ({ id, icon, fill, iconPosition }) => (
+  <div className={fill ? css.fill : ''}>
+    {iconPosition === 'start' && renderIcon(icon, css.iconStart)}
+    <FormattedMessage id={id} />
+    {iconPosition === 'end' && renderIcon(icon, css.iconEnd)}
+  </div>
+);
+
+WarningMessage.propTypes = {
+  id: PropTypes.string.isRequired,
+  icon: PropTypes.string,
+  iconPosition: PropTypes.oneOf(['start', 'end']),
+  fill: PropTypes.bool,
+};
+
+WarningMessage.defaultProps = {
+  icon: 'exclamation-circle',
+  iconPosition: 'start',
+  fill: false,
+};
+
+
+
+export default WarningMessage;
+

--- a/src/components/WarningMessage/WarningMessage.test.js
+++ b/src/components/WarningMessage/WarningMessage.test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import renderWithIntl from '../../../test/jest/helpers/renderWithIntl';
+import translationsProperties from '../../../test/jest/helpers/translationsProperties';
+import WarningMessage from './WarningMessage';
+
+describe('WarningMessage', () => {
+  describe('render', () => {
+    it('should show warning', () => {
+      renderWithIntl(
+        <WarningMessage id="ui-inventory.instance.suppressedFromDiscovery" />,
+        translationsProperties
+      );
+      expect(screen.getByText(/suppressed/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/WarningMessage/index.js
+++ b/src/components/WarningMessage/index.js
@@ -1,0 +1,1 @@
+export { default } from './WarningMessage';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -12,3 +12,4 @@ export { default as TitleField } from './TitleField';
 export { default as TitlesView } from './TitlesView';
 export { default as ModalContent } from './ModalContent';
 export { PaneLoading, ViewLoading } from './Loading';
+export { default as WarningMessage } from './WarningMessage';

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -649,5 +649,10 @@
   "remote.warning.common": "To remove {something} from remote storage, run an exception report or communicate this directly to your remote storage location.",
   "remote.warning.titles": "This includes {count, plural, =0 {<strong>no</strong> titles} one {<strong>#</strong> title} other {<strong>#</strong> titles}}.",
   "remote.holdings": "the holdings",
-  "remote.items": "{count, plural, one {this item} other {<strong>#</strong> items}}"
+  "remote.items": "{count, plural, one {this item} other {<strong>#</strong> items}}",
+  "instance.suppressedFromDiscovery": "Instance is marked suppressed from discovery",
+  "holdingsRecord.suppressedFromDiscovery": "Holdings is marked suppressed from discovery",
+  "item.suppressedFromDiscovery": "Item is marked suppressed from discovery",
+  "discoverySuppressed": "Suppressed from discovery",
+  "staffSuppressed": "Staff suppressed"
 }


### PR DESCRIPTION
This PR adds better visual indicators for suppressed instances. It takes care of two stories since they were very similar:

https://issues.folio.org/browse/UIIN-1377
https://issues.folio.org/browse/UIIN-1386

![instances](https://user-images.githubusercontent.com/63545/110511978-ca45ed80-80d2-11eb-9b56-51acbd9ad3c5.png)
