### PR TITLE
UIIN-1381: Add a warn icon for Staff suppressed instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 * Change label Duplicate MARC bib record to Derive new MARC bib record. Refs UIIN-1436.
 * Add a warning icon for instance/holdings/item marked as Suppressed from discovery. Refs UIIN-1380.
 * Fix nature of content filter. Fixes UIIN-1441.
+* Add a warning icon for instance marked as Staff suppressed. Refs UIIN-1381.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -580,7 +580,11 @@ class InstancesList extends React.Component {
           />
         </CheckboxColumn>
       ),
-      'title': ({ title, discoverySuppress }) => (
+      'title': ({
+        title,
+        discoverySuppress,
+        staffSuppress,
+      }) => (
         <AppIcon
           size="small"
           app="inventory"
@@ -588,7 +592,7 @@ class InstancesList extends React.Component {
           iconAlignment="baseline"
         >
           {title}
-          {discoverySuppress &&
+          {(discoverySuppress || staffSuppress) &&
           <span className={css.warnIcon}>
             <Icon
               size="medium"

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -193,6 +193,8 @@ export default function configure() {
 
       if (field === 'source') return instances.where({ source: term });
 
+      if (field === 'staffSuppress') return instances.where({ staffSuppress: term });
+
       if (field === 'discoverySuppress') return instances.where({ discoverySuppress: term });
 
       if (field === 'identifiers') {

--- a/test/bigtest/tests/filters/instances/instance-filters-test.js
+++ b/test/bigtest/tests/filters/instances/instance-filters-test.js
@@ -28,6 +28,7 @@ describe('Instance filters', () => {
         updatedDate: '2020-04-15',
       },
       source: 'MARC',
+      staffSuppress: true,
       discoverySuppress: true,
     }, 'withHoldingAndItem');
 
@@ -133,6 +134,20 @@ describe('Instance filters', () => {
       it('should not find any instance by source', () => {
         expect(instancesRoute.rows().length).to.equal(0);
       });
+    });
+  });
+
+  describe('filtering by staff suppress', () => {
+    beforeEach(async function () {
+      await inventory.clickSelectStaffSuppressFilter();
+    });
+
+    it('should find an instance with staff suppress equal to true', () => {
+      expect(instancesRoute.rows().length).to.equal(1);
+    });
+
+    it('instance title should have a warning icon', () => {
+      expect(inventory.hasWarnIcon).to.be.true;
     });
   });
 


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1381

### Purpose
Add ability to clearly see when instance marked as Staff suppressed.

### Screenshot
![Screen Shot 2021-03-05 at 17 55 08](https://user-images.githubusercontent.com/49517355/110139651-f2380700-7ddb-11eb-90c7-08650c96d8dc.png)