### PR TITLE
UIIN-1448 rely on data-export interface 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 * Add a warning icon for instance/holdings/item marked as Suppressed from discovery. Refs UIIN-1380.
 * Fix nature of content filter. Fixes UIIN-1441.
 * Add a warning icon for instance marked as Staff suppressed. Refs UIIN-1381.
+* Update `data-export` interface to `4.0`. Refs UIIN-1448.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
       "configuration": "2.0",
       "tags": "1.0",
       "inventory-record-bulk": "1.0",
-      "data-export": "3.0"
+      "data-export": "4.0"
     },
     "optionalOkapiInterfaces": {
       "copycat-imports": "1.0",


### PR DESCRIPTION
Update the okapi dependency on `data-export` to `4.0`. No information is
available about the breaking changes but in fact the changes were made
some time ago and the interface version only bumped recently, i.e. we've
been using the updated interface for some time now, but it just hadn't
been correctly labeled as updated.

Refs [UIIN-1448](https://issues.folio.org/browse/UIIN-1448)
