### PR TITLE
Avoid error message from trying to fetch /copycat/profiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -716,6 +716,7 @@
         "displayName": "Inventory: Import single bibliographic records",
         "subPermissions": [
           "ui-inventory.instance.view",
+          "copycat.profiles.collection.get",
           "copycat.imports.post"
         ],
         "visible": true

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -448,18 +448,20 @@ class ViewInstance extends React.Component {
         )}
 
         <IfInterface name="copycat-imports">
-          <Button
-            id="dropdown-clickable-reimport-record"
-            onClick={() => {
-              onToggle();
-              this.setState({ isImportRecordModalOpened: true });
-            }}
-            buttonStyle="dropdownItem"
-          >
-            <Icon icon="lightning">
-              <FormattedMessage id="ui-inventory.copycat.reimport" />
-            </Icon>
-          </Button>
+          <IfPermission perm="copycat.profiles.collection.get">
+            <Button
+              id="dropdown-clickable-reimport-record"
+              onClick={() => {
+                onToggle();
+                this.setState({ isImportRecordModalOpened: true });
+              }}
+              buttonStyle="dropdownItem"
+            >
+              <Icon icon="lightning">
+                <FormattedMessage id="ui-inventory.copycat.reimport" />
+              </Icon>
+            </Button>
+          </IfPermission>
         </IfInterface>
       </>
     );
@@ -548,13 +550,15 @@ class ViewInstance extends React.Component {
         }
 
         <IfInterface name="copycat-imports">
-          <ImportRecordModal
-            isOpen={this.state.isImportRecordModalOpened}
-            currentExternalIdentifier={undefined}
-            handleSubmit={this.handleImportRecordModalSubmit}
-            handleCancel={this.handleImportRecordModalCancel}
-            id={id}
-          />
+          <IfPermission perm="copycat.profiles.collection.get">
+            <ImportRecordModal
+              isOpen={this.state.isImportRecordModalOpened}
+              currentExternalIdentifier={undefined}
+              handleSubmit={this.handleImportRecordModalSubmit}
+              handleCancel={this.handleImportRecordModalCancel}
+              id={id}
+            />
+          </IfPermission>
         </IfInterface>
       </>
     );

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -424,12 +424,14 @@ class InstancesList extends React.Component {
             isDisabled: !selectedRowsCount || isQuickExportLimitExceeded,
           })}
           <IfInterface name="copycat-imports">
-            {this.getActionItem({
-              id: 'dropdown-clickable-import-record',
-              icon: 'lightning',
-              messageId: 'ui-inventory.copycat.import',
-              onClickHandler: buildOnClickHandler(() => this.setState({ isImportRecordModalOpened: true })),
-            })}
+            <IfPermission perm="copycat.profiles.collection.get">
+              {this.getActionItem({
+                id: 'dropdown-clickable-import-record',
+                icon: 'lightning',
+                messageId: 'ui-inventory.copycat.import',
+                onClickHandler: buildOnClickHandler(() => this.setState({ isImportRecordModalOpened: true })),
+              })}
+            </IfPermission>
           </IfInterface>
           {isQuickExportLimitExceeded && (
             <span
@@ -676,12 +678,14 @@ class InstancesList extends React.Component {
           onCancel={this.handleSelectedRecordsModalCancel}
         />
         <IfInterface name="copycat-imports">
-          <ImportRecordModal
-            isOpen={isImportRecordModalOpened}
-            currentExternalIdentifier={undefined}
-            handleSubmit={this.handleImportRecordModalSubmit}
-            handleCancel={this.handleImportRecordModalCancel}
-          />
+          <IfPermission perm="copycat.profiles.collection.get">
+            <ImportRecordModal
+              isOpen={isImportRecordModalOpened}
+              currentExternalIdentifier={undefined}
+              handleSubmit={this.handleImportRecordModalSubmit}
+              handleCancel={this.handleImportRecordModalCancel}
+            />
+          </IfPermission>
         </IfInterface>
       </>
     );


### PR DESCRIPTION
This is fetched in ImportRecordModal.js. That component was already,
rightly, not being included when the the `copycat-imports` interface
is unavailable. We now also omit it if the user doesn't have the
necessary permission, `copycat.profiles.collection.get`.

This permission is added as a sub-permission to
`ui-inventory.single-record-import`, since it's not possible to
perform an import without fetching a copycat profile.

Fixes UIIN-1447.
