### PR TITLE
use deps compatible with @folio/stripes v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 * Change label Duplicate MARC bib record to Derive new MARC bib record. Refs UIIN-1436.
 * Fix nature of content filter. Fixes UIIN-1441.
 * Update `data-export` interface to `4.0`. Refs UIIN-1448.
+* Update `@folio/react-intl-safe-html`, `@folio/plugin-find-instance`, and `@folio/quick-marc` for compatibility with `@folio/stripes` `v6`.
 
 ## [5.0.1](https://github.com/folio-org/ui-inventory/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.0...v5.0.1)

--- a/package.json
+++ b/package.json
@@ -773,7 +773,7 @@
     "sinon": "^7.0.0"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^2.0.0",
+    "@folio/react-intl-safe-html": "^3.0.0",
     "@testing-library/dom": "^7.29.4",
     "file-saver": "^2.0.0",
     "final-form": "^4.18.2",
@@ -802,8 +802,8 @@
   },
   "optionalDependencies": {
     "@folio/plugin-create-inventory-records": "^2.0.0",
-    "@folio/plugin-find-instance": "^4.0.0",
-    "@folio/quick-marc": "^2.0.0"
+    "@folio/plugin-find-instance": "^5.0.0",
+    "@folio/quick-marc": "^3.0.0"
   },
   "resolutions": {
     "babel-eslint/@babel/parser": "7.7.5",


### PR DESCRIPTION
Update deps for compatibility with `@folio/stripes` `v6`, including:
* `@folio/react-intl-safe-html`
* `@folio/plugin-find-instance`
* `@folio/quick-marc`
