### PR TITLE
Configure maximum number of location to fetch in Stripes config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## (IN PROGRESS)
+
+* It is possible to configure the maximum number of location to fetch in the Stripes config file, typically `stripes.config.js`, using the `maxLocationsToLoad` entry in the `config` area. Fixes UIIN-1480.
+
 ## [6.0.0](https://github.com/folio-org/ui-inventory/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.6...v6.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## (IN PROGRESS)
 
-* It is possible to configure the maximum number of location to fetch in the Stripes config file, typically `stripes.config.js`, using the `maxLocationsToLoad` entry in the `config` area. Fixes UIIN-1480.
+* It is possible to configure the maximum number of location to fetch in the Stripes config file, typically `stripes.config.js`, using the `maxUnpagedResourceCount` entry in the `config` area. Fixes UIIN-1480.
 
 ## [6.0.0](https://github.com/folio-org/ui-inventory/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.6...v6.0.0)

--- a/src/providers/DataProvider.js
+++ b/src/providers/DataProvider.js
@@ -102,7 +102,11 @@ DataProvider.manifest = {
   locations: {
     type: 'okapi',
     records: 'locations',
-    path: 'locations?limit=1000&query=cql.allRecords=1 sortby name',
+    path: 'locations',
+    params: {
+      limit: (q, p, r, l, props) => props?.stripes?.config?.maxLocationsToLoad || 1000,
+      query: 'cql.allRecords=1 sortby name',
+    },
   },
   instanceRelationshipTypes: {
     type: 'okapi',

--- a/src/providers/DataProvider.js
+++ b/src/providers/DataProvider.js
@@ -104,7 +104,7 @@ DataProvider.manifest = {
     records: 'locations',
     path: 'locations',
     params: {
-      limit: (q, p, r, l, props) => props?.stripes?.config?.maxLocationsToLoad || 1000,
+      limit: (q, p, r, l, props) => props?.stripes?.config?.maxUnpagedResourceCount || 1000,
       query: 'cql.allRecords=1 sortby name',
     },
   },


### PR DESCRIPTION
It is now possible to configure the maximum number of location to
fetch in the Stripes config file, typically `stripes.config.js`, using
the `maxLocationsToLoad` entry in the `config` area.

Fixes UIIN-1480.
