### PR TITLE
UIIN-1380: Add warn icon for Suppressed from discovery instance/holdings/item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add visual display when holdings record is suppressed from discovery. Refs UIIN-1378.
 * Add visual display when instance is suppressed from discovery. Refs UIIN-1377 and UIIN-1386.
 * Use the `contributorsNames` index, available in `inventory` since `10.10`. Refs UIIN-1451.
+* Add a warning icon for instance/holdings/item marked as Suppressed from discovery. Refs UIIN-1380.
 
 ## [6.0.0](https://github.com/folio-org/ui-inventory/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.6...v6.0.0)

--- a/src/Instance/HoldingsList/Holding/HoldingAccordion.js
+++ b/src/Instance/HoldingsList/Holding/HoldingAccordion.js
@@ -11,6 +11,7 @@ import {
   Accordion,
   Row,
   Col,
+  Icon,
 } from '@folio/stripes/components';
 
 import { DataContext } from '../../../contexts';
@@ -66,14 +67,25 @@ const HoldingAccordion = ({
       open={open}
       onToggle={handleAccordionToggle}
       label={(
-        <FormattedMessage
-          id="ui-inventory.holdingsHeader"
-          values={{
-            location: labelLocation,
-            callNumber: callNumberLabel(holding),
-            copyNumber: holding.copyNumber,
-          }}
-        />
+        <>
+          <FormattedMessage
+            id="ui-inventory.holdingsHeader"
+            values={{
+              location: labelLocation,
+              callNumber: callNumberLabel(holding),
+              copyNumber: holding.copyNumber,
+            }}
+          />
+          {holding.discoverySuppress &&
+          <span>
+            <Icon
+              size="medium"
+              icon="exclamation-circle"
+              status="warn"
+            />
+          </span>
+          }
+        </>
       )}
       displayWhenOpen={holdingButtonsGroup}
       displayWhenClosed={holdingButtonsGroup}

--- a/src/Instance/ItemsList/ItemsList.js
+++ b/src/Instance/ItemsList/ItemsList.js
@@ -57,12 +57,22 @@ const getFormatter = (
   'barcode': item => {
     return (
       item.id && (
+      <>
         <ItemBarcode
           item={item}
           holdingId={holding.id}
           instanceId={holding.instanceId}
         />
-      )
+        {item.discoverySuppress &&
+        <span>
+          <Icon
+            size="medium"
+            icon="exclamation-circle"
+            status="warn"
+          />
+        </span>
+        }
+      </>)
     ) || noValue;
   },
   'status': x => x.status?.name || noValue,

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -582,7 +582,7 @@ class InstancesList extends React.Component {
           />
         </CheckboxColumn>
       ),
-      'title': ({ title }) => (
+      'title': ({ title, discoverySuppress }) => (
         <AppIcon
           size="small"
           app="inventory"
@@ -590,6 +590,15 @@ class InstancesList extends React.Component {
           iconAlignment="baseline"
         >
           {title}
+          {discoverySuppress &&
+          <span className={css.warnIcon}>
+            <Icon
+              size="medium"
+              icon="exclamation-circle"
+              status="warn"
+            />
+          </span>
+          }
         </AppIcon>
       ),
       'relation': r => formatters.relationsFormatter(r, data.instanceRelationshipTypes),

--- a/src/components/InstancesList/instances.css
+++ b/src/components/InstancesList/instances.css
@@ -3,6 +3,9 @@
 .actionIcon {
   margin-right: 10px;
 }
+.warnIcon {
+  margin-left: var(--gutter-static-one-third);
+}
 .cellAlign {
   align-items: flex-start;
 }

--- a/test/bigtest/interactors/instance-view-page.js
+++ b/test/bigtest/interactors/instance-view-page.js
@@ -69,6 +69,7 @@ import KeyValue from './KeyValue';
   alternativeTitlesList = new MultiColumnListInteractor('#list-alternative-titles');
   items = collection('[id^="list-items"] div[class^=mclRow]', Item);
   draggableItems = collection('[id^="list-items"] div[draggable]', Item);
+  hasWarnIcon = isPresent('[class*=status-warn]');
   hasViewHoldingsButton = isPresent('[data-test-view-holdings]');
   clickViewHoldings = clickable('[data-test-view-holdings]');
   hasButtonAddItem = isPresent('[data-test-add-item]');

--- a/test/bigtest/interactors/inventory.js
+++ b/test/bigtest/interactors/inventory.js
@@ -78,6 +78,7 @@ export default @interactor class InventoryInteractor {
   source = new CheckboxFilterInteractor('#source');
   callout = new CalloutInteractor();
   resetAll = clickable('#clickable-reset-all');
+  hasWarnIcon = isPresent('[class^=warnIcon---]');
 
   whenLoaded() {
     return this.when(() => this.isLoaded);

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -195,6 +195,8 @@ export default function configure() {
 
       if (field === 'source') return instances.where({ source: term });
 
+      if (field === 'discoverySuppress') return instances.where({ discoverySuppress: term });
+
       if (field === 'identifiers') {
         const idType = identifierTypes.where({ name: term }).models[0];
 

--- a/test/bigtest/network/factories/instance.js
+++ b/test/bigtest/network/factories/instance.js
@@ -145,6 +145,26 @@ export default Factory.extend({
     }
   }),
 
+  withDiscoverySuppressHolding: trait({
+    afterCreate(instance, server) {
+      const holding = server.create('holding', { discoverySuppress: true });
+      instance.holdings = [holding];
+      instance.save();
+    }
+  }),
+
+  withHoldingAndDiscoverySuppressItem: trait({
+    afterCreate(instance, server) {
+      const holding = server.create('holding');
+      const item = server.create('item', { discoverySuppress: true });
+
+      holding.items = [item];
+      holding.save();
+      instance.holdings = [holding];
+      instance.save();
+    }
+  }),
+
   withHoldingAndItem: trait({
     afterCreate(instance, server) {
       const holding = server.create(

--- a/test/bigtest/tests/filters/instances/instance-filters-test.js
+++ b/test/bigtest/tests/filters/instances/instance-filters-test.js
@@ -28,7 +28,6 @@ describe('Instance filters', () => {
         updatedDate: '2020-04-15',
       },
       source: 'MARC',
-      staffSuppress: true,
       discoverySuppress: true,
     }, 'withHoldingAndItem');
 
@@ -134,6 +133,20 @@ describe('Instance filters', () => {
       it('should not find any instance by source', () => {
         expect(instancesRoute.rows().length).to.equal(0);
       });
+    });
+  });
+
+  describe('filtering by discovery suppress', () => {
+    beforeEach(async function () {
+      await inventory.clickSelectDiscoverySuppressFilter();
+    });
+
+    it('should find an instance with discovery suppress equal to true', () => {
+      expect(instancesRoute.rows().length).to.equal(1);
+    });
+
+    it('instance title should have a warning icon', () => {
+      expect(inventory.hasWarnIcon).to.be.true;
     });
   });
 

--- a/test/bigtest/tests/instance-view-page-test.js
+++ b/test/bigtest/tests/instance-view-page-test.js
@@ -654,6 +654,34 @@ describe('InstanceViewPage', () => {
     });
   });
 
+  describe('Suppress from discovery holding', () => {
+    setupApplication();
+
+    beforeEach(async function () {
+      instance = this.server.create('instance', 'withDiscoverySuppressHolding');
+      this.visit(`/inventory/view/${instance.id}`);
+      await InstanceViewPage.whenLoaded();
+    });
+
+    it('should have a warning icon in the title field', () => {
+      expect(InstanceViewPage.hasWarnIcon).to.be.true;
+    });
+  });
+
+  describe('Suppress from discovery item', () => {
+    setupApplication();
+
+    beforeEach(async function () {
+      instance = this.server.create('instance', 'withHoldingAndDiscoverySuppressItem');
+      this.visit(`/inventory/view/${instance.id}`);
+      await InstanceViewPage.whenLoaded();
+    });
+
+    it('should have a warning icon in the barcode field', () => {
+      expect(InstanceViewPage.hasWarnIcon).to.be.true;
+    });
+  });
+
   describe('Empty fields', () => {
     setupApplication({ scenarios: ['fetch-items-success'] });
 


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1380

### Purpose
Add ability to clearly see when instance/holdings/item marked as Suppressed from discovery.

### Screenshot
![Screen Shot 2021-03-03 at 11 10 45](https://user-images.githubusercontent.com/49517355/109783809-11d00380-7c13-11eb-96f7-5588a891d38f.png)