### PR TITLE
UIIN-1488 also support circulation 10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Use the `contributorsNames` index, available in `inventory` since `10.10`. Refs UIIN-1451.
 * Add a warning icon for instance/holdings/item marked as Suppressed from discovery. Refs UIIN-1380.
 * Add a warning icon for instance marked as Staff suppressed. Refs UIIN-1381.
+* Also support `circulation` `10.0`. Refs UIIN-1488.
 
 ## [6.0.0](https://github.com/folio-org/ui-inventory/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.6...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
       "holdings-sources": "1.0",
       "users": "15.0",
       "location-units": "2.0",
-      "circulation": "9.0",
+      "circulation": "9.0 10.0",
       "configuration": "2.0",
       "tags": "1.0",
       "inventory-record-bulk": "1.0",


### PR DESCRIPTION
The only breaking change in `circulation` `10.0` was the removal of the
`override-check-out-by-barcode` which is not used here, hence continuing
to support `9.0`.

Refs [UIIN-1488](https://issues.folio.org/browse/UIIN-1488)