### PR TITLE
UIIN-1481: Fix date display on item view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add a warning icon for instance marked as Staff suppressed. Refs UIIN-1381.
 * Add visual display when item is suppressed from discovery. Refs UIIN-1379.
 * Also support `circulation` `10.0`. Refs UIIN-1488.
+* Fix date display on item view. Fixes UIIN-1481.
 
 ## [6.0.0](https://github.com/folio-org/ui-inventory/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.6...v6.0.0)

--- a/src/utils.js
+++ b/src/utils.js
@@ -382,6 +382,7 @@ export const getDate = dateValue => {
       day="numeric"
       month="numeric"
       year="numeric"
+      timeZone="UTC"
     />
   ) : '-';
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   FormattedMessage,
   FormattedTime,
-  FormattedDate,
 } from 'react-intl';
 import {
   includes,
@@ -19,6 +18,8 @@ import {
   omit,
 } from 'lodash';
 import moment from 'moment';
+
+import { FormattedUTCDate } from '@folio/stripes/components';
 
 import {
   itemStatusesMap,
@@ -377,12 +378,11 @@ export const convertArrayToBlocks = elements => (!isEmpty(elements)
 
 export const getDate = dateValue => {
   return dateValue ? (
-    <FormattedDate
+    <FormattedUTCDate
       value={dateValue}
       day="numeric"
       month="numeric"
       year="numeric"
-      timeZone="UTC"
     />
   ) : '-';
 };


### PR DESCRIPTION
The dates on view and edit screens were out of sync because the missing `timeZone`.

https://issues.folio.org/browse/UIIN-1481