### PR TITLE
STRIPES-741: Add <Pluggable> for checking copyright

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix items in transit export. Fixes UIIN-1492.
 * Warn with yellow toast when result of Single Record Import is unknown. Fixes UIIN-1495.
 * Patch: Display shelving order on the item record. Refs UIIN-816.
+* Add <Pluggable> instance to the Instance action menu for plugin type `copyright-permissions-checker`
 
 ## [6.0.0](https://github.com/folio-org/ui-inventory/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.6...v6.0.0)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -309,26 +309,23 @@ class ViewInstance extends React.Component {
     if (!records) {
       return null;
     }
-    const allIdentifiers = [].concat(
-      records.map(record => record.identifiers)
-    )[0];
-    const result = [];
-    allIdentifiers.forEach(({ identifierTypeId, value }) => {
-      const ident = identifierTypesById[identifierTypeId];
-      if (
-        (ident?.name === ISBN ||
-        ident?.name === ISSN) &&
-        value
-      ) {
-        result.push({
-          type: ident.name,
-          value
-        });
-      }
-    });
     // We can't make any meaningful assessment of which is
     // the best identifier to return, so just return the first
-    return result.length > 0 ? result[0] : null;
+    // we find
+    for (const record of records) {
+      for (const identifiers of record.identifiers) {
+        const { identifierTypeId, value } = identifiers;
+        const ident = identifierTypesById[identifierTypeId];
+        if (
+          (ident?.name === ISBN ||
+            ident?.name === ISSN) &&
+          value
+        ) {
+          return { type: ident.name, value };
+        }
+      }
+    }
+    return null;
   };
 
   createActionMenuGetter = instance => ({ onToggle }) => {

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -12,6 +12,7 @@ import {
   AppIcon,
   IfPermission,
   IfInterface,
+  Pluggable,
 } from '@folio/stripes/core';
 import {
   Pane,
@@ -29,6 +30,8 @@ import {
   batchFetchItems,
   batchFetchRequests,
 } from './Instance/ViewRequests/utils';
+import { indentifierTypeNames } from './constants';
+import { DataContext } from './contexts';
 
 import {
   HoldingsListContainer,
@@ -113,6 +116,7 @@ class ViewInstance extends React.Component {
       findInstancePluginOpened: false,
       isItemsMovement: false,
       isImportRecordModalOpened: false,
+      isCopyrightModalOpened: false
     };
     this.instanceId = null;
     this.cViewHoldingsRecord = this.props.stripes.connect(ViewHoldingsRecord);
@@ -289,8 +293,42 @@ class ViewInstance extends React.Component {
     this.setState({ isImportRecordModalOpened: false });
   }
 
+  toggleCopyrightModal = () => {
+    this.setState(prevState => ({ isCopyrightModalOpened: !prevState.isCopyrightModalOpened }));
+  };
+
   toggleFindInstancePlugin = () => {
     this.setState(prevState => ({ findInstancePluginOpened: !prevState.findInstancePluginOpened }));
+  };
+
+  // Get all identifiers for all records
+  getIdentifiers = (data) => {
+    const { identifierTypesById } = data;
+    const { ISBN, ISSN } = indentifierTypeNames;
+    const records = this.props?.resources?.selectedInstance?.records;
+    if (!records) {
+      return null;
+    }
+    const allIdentifiers = [].concat(
+      records.map(record => record.identifiers)
+    )[0];
+    const result = [];
+    allIdentifiers.forEach(({ identifierTypeId, value }) => {
+      const ident = identifierTypesById[identifierTypeId];
+      if (
+        (ident?.name === ISBN ||
+        ident?.name === ISSN) &&
+        value
+      ) {
+        result.push({
+          type: ident.name,
+          value
+        });
+      }
+    });
+    // We can't make any meaningful assessment of which is
+    // the best identifier to return, so just return the first
+    return result.length > 0 ? result[0] : null;
   };
 
   createActionMenuGetter = instance => ({ onToggle }) => {
@@ -463,6 +501,31 @@ class ViewInstance extends React.Component {
             </Button>
           </IfPermission>
         </IfInterface>
+        <DataContext.Consumer>
+          {data => (
+            <Pluggable
+              id="copyright-permissions-checker"
+              toggle={this.toggleCopyrightModal}
+              open={this.state.isCopyrightModalOpened}
+              identifier={this.getIdentifiers(data)}
+              type="copyright-permissions-checker"
+              renderTrigger={({ menuText }) => (
+                <Button
+                  id="copyright-permissions-check"
+                  buttonStyle="dropdownItem"
+                  onClick={() => {
+                    onToggle();
+                    this.toggleCopyrightModal();
+                  }}
+                >
+                  <Icon icon="report">
+                    {menuText}
+                  </Icon>
+                </Button>
+              )}
+            />
+          )}
+        </DataContext.Consumer>
       </>
     );
   };


### PR DESCRIPTION
STRIPES-741

## Purpose

This commit adds a `<Pluggable>` to the main Instance action menu to
enable plugins that provide copyright checking functionality to add
themselves to the menu, via the `copyright-permissions-checker` plugin type.

This was added to enable the CLA Permissions Check plugin
(https://github.com/PTFS-Europe/ui-plugin-cla-permissions-check) to add
itself.

Additional state was added to the component to maintain the open status
of a modal that the plugin may present, this state is passed to the
plugin, along with a function to set it.

Since such plugins will require an identifier for the instance to enable
them to check copyright status, a new function getIdentifiers was added
which, when passed an instance's data, will extract a suitable
identifier to pass to the plugin

https://issues.folio.org/browse/STRIPES-741


## Approach

See above, this approach follows the established pattern of using the `<Pluggable>` to allow hooks into existing UI

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [X] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater (the file in question, ViewInstance.js currently has 0 coverage, it seems out of scope of this PR to give it coverage).
  - [X] Duplications on new code is 3% or less
  - [X] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [X] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
