### PR TITLE
UIIN-1044: Group sub instances by relationship type

### DIFF
--- a/src/Instance/InstanceDetails/InstanceDetails.js
+++ b/src/Instance/InstanceDetails/InstanceDetails.js
@@ -209,7 +209,8 @@ const InstanceDetails = ({
 
             <InstanceRelationshipView
               id={accordions.relationship}
-              instance={instance}
+              parentInstances={instance.parentInstances}
+              childInstances={instance.childInstances}
             />
           </AccordionSet>
         </AccordionStatus>

--- a/src/Instance/InstanceDetails/InstanceRelationshipView/InstanceRelationshipView.js
+++ b/src/Instance/InstanceDetails/InstanceRelationshipView/InstanceRelationshipView.js
@@ -10,7 +10,7 @@ import {
 } from '@folio/stripes/components';
 
 import useLoadSubInstances from '../../../hooks/useLoadSubInstances';
-import SubInstanceList from '../SubInstanceList';
+import SubInstanceGroup from '../SubInstanceGroup';
 
 const InstanceRelationshipView = ({
   id,
@@ -26,7 +26,7 @@ const InstanceRelationshipView = ({
     >
       <Row>
         <Col xs={12}>
-          <SubInstanceList
+          <SubInstanceGroup
             id="childInstances"
             titleKey="subInstanceId"
             label={<FormattedMessage id="ui-inventory.childInstances" />}
@@ -36,7 +36,7 @@ const InstanceRelationshipView = ({
       </Row>
       <Row>
         <Col xs={12}>
-          <SubInstanceList
+          <SubInstanceGroup
             id="parentInstances"
             titleKey="superInstanceId"
             label={<FormattedMessage id="ui-inventory.parentInstances" />}

--- a/src/Instance/InstanceDetails/InstanceRelationshipView/InstanceRelationshipView.js
+++ b/src/Instance/InstanceDetails/InstanceRelationshipView/InstanceRelationshipView.js
@@ -14,10 +14,11 @@ import SubInstanceGroup from '../SubInstanceGroup';
 
 const InstanceRelationshipView = ({
   id,
-  instance,
+  parentInstances,
+  childInstances,
 }) => {
-  const parentInstances = useLoadSubInstances(instance.parentInstances, 'superInstanceId');
-  const childInstances = useLoadSubInstances(instance.childInstances, 'subInstanceId');
+  const parents = useLoadSubInstances(parentInstances, 'superInstanceId');
+  const children = useLoadSubInstances(childInstances, 'subInstanceId');
 
   return (
     <Accordion
@@ -30,7 +31,7 @@ const InstanceRelationshipView = ({
             id="childInstances"
             titleKey="subInstanceId"
             label={<FormattedMessage id="ui-inventory.childInstances" />}
-            titles={childInstances}
+            titles={children}
           />
         </Col>
       </Row>
@@ -40,17 +41,18 @@ const InstanceRelationshipView = ({
             id="parentInstances"
             titleKey="superInstanceId"
             label={<FormattedMessage id="ui-inventory.parentInstances" />}
-            titles={parentInstances}
+            titles={parents}
           />
         </Col>
-      </Row>
+      </Row>3
     </Accordion>
   );
 };
 
 InstanceRelationshipView.propTypes = {
   id: PropTypes.string.isRequired,
-  instance: PropTypes.object.isRequired,
+  parentInstances: PropTypes.arrayOf(PropTypes.object),
+  childInstances: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default withRouter(InstanceRelationshipView);

--- a/src/Instance/InstanceDetails/InstanceRelationshipView/InstanceRelationshipView.test.js
+++ b/src/Instance/InstanceDetails/InstanceRelationshipView/InstanceRelationshipView.test.js
@@ -18,6 +18,8 @@ import {
 import {
   identifierTypes,
   instances,
+  instanceRelationshipTypes,
+  childInstances,
 } from '../../../../test/fixtures';
 
 import InstanceRelationshipView from './InstanceRelationshipView';
@@ -30,8 +32,10 @@ const InstanceRelationshipViewSetup = () => (
       <DataContext.Provider value={{
         contributorTypes: [],
         identifierTypes,
+        instanceRelationshipTypes,
         identifierTypesById: keyBy(identifierTypes, 'id'),
         identifierTypesByName: keyBy(identifierTypes, 'name'),
+        instanceRelationshipTypesById: keyBy(instanceRelationshipTypes, 'name'),
         instanceFormats: [],
         modesOfIssuance: [],
         natureOfContentTerms: [],
@@ -40,7 +44,7 @@ const InstanceRelationshipViewSetup = () => (
       >
         <InstanceRelationshipView
           id="accordion-id"
-          instance={instances[0]}
+          childInstances={childInstances}
         />
       </DataContext.Provider>
     </StripesContext.Provider>
@@ -65,6 +69,6 @@ describe('InstanceRelationshipView', () => {
   });
 
   it('should render child instances', () => {
-    expect(document.querySelectorAll('[role="row"]').length).toEqual(8);
+    expect(document.querySelectorAll('[role="gridcell"]').length).toEqual(6);
   });
 });

--- a/src/Instance/InstanceDetails/SubInstanceGroup/SubInstanceGroup.js
+++ b/src/Instance/InstanceDetails/SubInstanceGroup/SubInstanceGroup.js
@@ -1,0 +1,51 @@
+import { groupBy } from 'lodash';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import { KeyValue } from '@folio/stripes/components';
+
+import useReferenceData from '../../../hooks/useReferenceData';
+import SubInstanceList from '../SubInstanceList';
+
+const SubInstanceGroup = ({
+  titles,
+  id,
+  titleKey,
+  label,
+}) => {
+  const { instanceRelationshipTypes } = useReferenceData();
+  const titlesByInstanceRelationshipTypeId = groupBy(titles, 'instanceRelationshipTypeId');
+
+  return (
+    <KeyValue id={id} label={label}>
+      {
+        instanceRelationshipTypes.map(({ id: typeId, name }) => (
+          titlesByInstanceRelationshipTypeId[typeId] &&
+          <>
+            <FormattedMessage
+              id="ui-inventory.instances.typeOfRelation"
+              values={{ name }}
+              tagName="p"
+            />
+            <SubInstanceList
+              id={`${id}-${typeId}`}
+              titles={titlesByInstanceRelationshipTypeId[typeId]}
+              titleKey={titleKey}
+              label={name}
+            />
+          </>
+        ))
+      }
+    </KeyValue>
+  );
+};
+
+SubInstanceGroup.propTypes = {
+  id: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
+  titles: PropTypes.arrayOf(PropTypes.object).isRequired,
+  titleKey: PropTypes.string.isRequired,
+};
+
+export default SubInstanceGroup;

--- a/src/Instance/InstanceDetails/SubInstanceGroup/index.js
+++ b/src/Instance/InstanceDetails/SubInstanceGroup/index.js
@@ -1,0 +1,1 @@
+export { default } from './SubInstanceGroup';

--- a/src/Instance/InstanceDetails/SubInstanceList/SubInstanceList.css
+++ b/src/Instance/InstanceDetails/SubInstanceList/SubInstanceList.css
@@ -1,0 +1,3 @@
+.cellAlign {
+  align-items: flex-start;
+}

--- a/src/Instance/InstanceDetails/SubInstanceList/SubInstanceList.js
+++ b/src/Instance/InstanceDetails/SubInstanceList/SubInstanceList.js
@@ -5,7 +5,6 @@ import { Link } from 'react-router-dom';
 
 import {
   MultiColumnList,
-  KeyValue,
   NoValue,
 } from '@folio/stripes/components';
 
@@ -68,18 +67,16 @@ const SubInstanceList = ({
   };
 
   return (
-    <KeyValue label={label}>
-      <MultiColumnList
-        id={id}
-        contentData={titles}
-        visibleColumns={visibleColumns}
-        columnMapping={columnMapping}
-        columnWidths={columnWidths}
-        formatter={formatter}
-        ariaLabel={label}
-        interactive={false}
-      />
-    </KeyValue>
+    <MultiColumnList
+      id={id}
+      contentData={titles}
+      visibleColumns={visibleColumns}
+      columnMapping={columnMapping}
+      columnWidths={columnWidths}
+      formatter={formatter}
+      ariaLabel={label}
+      interactive={false}
+    />
   );
 };
 

--- a/src/Instance/InstanceDetails/SubInstanceList/SubInstanceList.js
+++ b/src/Instance/InstanceDetails/SubInstanceList/SubInstanceList.js
@@ -8,9 +8,14 @@ import {
   NoValue,
 } from '@folio/stripes/components';
 
-import { getIdentifiers } from '../../../utils';
+import {
+  getIdentifiers,
+  formatCellStyles,
+} from '../../../utils';
 import { indentifierTypeNames } from '../../../constants';
 import useReferenceData from '../../../hooks/useReferenceData';
+
+import css from './SubInstanceList.css';
 
 const noValue = <NoValue />;
 
@@ -74,6 +79,7 @@ const SubInstanceList = ({
       columnMapping={columnMapping}
       columnWidths={columnWidths}
       formatter={formatter}
+      getCellClass={formatCellStyles(css.cellAlign)}
       ariaLabel={label}
       interactive={false}
     />

--- a/src/Instance/InstanceDetails/index.js
+++ b/src/Instance/InstanceDetails/index.js
@@ -13,3 +13,4 @@ export * from './InstanceNewHolding';
 
 export { default as SubInstanceList } from './SubInstanceList';
 export { default as InstanceDetails } from './InstanceDetails';
+export { default as SubInstanceGroup } from './SubInstanceGroup';

--- a/src/edit/InstanceForm.js
+++ b/src/edit/InstanceForm.js
@@ -716,18 +716,19 @@ class InstanceForm extends React.Component {
                 open={this.state.sections.instanceSection11}
                 id="instanceSection11"
               >
-                <ParentInstanceFields
-                  relationshipTypes={relationshipTypes}
-                  canAdd={!this.isFieldBlocked('parentInstances')}
-                  canEdit={!this.isFieldBlocked('parentInstances')}
-                  canDelete={!this.isFieldBlocked('publicInstances')}
-                />
                 <ChildInstanceFields
                   relationshipTypes={relationshipTypes}
                   canAdd={!this.isFieldBlocked('childInstances')}
                   canEdit={!this.isFieldBlocked('childInstances')}
                   canDelete={!this.isFieldBlocked('childInstances')}
                 />
+                <ParentInstanceFields
+                  relationshipTypes={relationshipTypes}
+                  canAdd={!this.isFieldBlocked('parentInstances')}
+                  canEdit={!this.isFieldBlocked('parentInstances')}
+                  canDelete={!this.isFieldBlocked('publicInstances')}
+                />
+
               </Accordion>
             </div>
           </Pane>

--- a/src/hooks/useLoadSubInstances.js
+++ b/src/hooks/useLoadSubInstances.js
@@ -1,7 +1,6 @@
 import {
   keyBy,
   isEqual,
-  sortBy,
   chain,
 } from 'lodash';
 import {
@@ -10,7 +9,6 @@ import {
 } from 'react';
 
 import useInstancesQuery from './useInstancesQuery';
-import useReferenceData from './useReferenceData';
 
 // Loads full instance records
 // for given sub instance ids (parentInstances/childInstaces).

--- a/src/hooks/useLoadSubInstances.js
+++ b/src/hooks/useLoadSubInstances.js
@@ -15,7 +15,6 @@ import useReferenceData from './useReferenceData';
 // Loads full instance records
 // for given sub instance ids (parentInstances/childInstaces).
 const useLoadSubInstances = (instanceIds = [], subId) => {
-  const { instanceRelationshipTypesById } = useReferenceData();
   const instanstcesById = keyBy(instanceIds, subId);
   const [subInstances, setSubInstances] = useState([]);
   const results = useInstancesQuery(instanceIds.map(inst => inst[subId]));
@@ -30,22 +29,16 @@ const useLoadSubInstances = (instanceIds = [], subId) => {
         publication,
         identifiers,
       },
-    }) => {
-      const instance = {
-        ...instanstcesById[id],
-        title,
-        hrid,
-        publication,
-        identifiers,
-      };
-      const { instanceRelationshipTypeId } = instance;
-
-      instance.instanceRelationshipType = instanceRelationshipTypesById?.[instanceRelationshipTypeId]?.name;
-
-      return instance;
-    })
+    }) => ({
+      ...instanstcesById[id],
+      title,
+      hrid,
+      publication,
+      identifiers,
+    }))
     .sortBy('title')
     .value();
+
   const shouldUpdateSubInstances = allLoaded && !isEqual(subInstances, instances);
 
   useEffect(() => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -621,3 +621,5 @@ export const getNextSelectedRowsState = (selectedRows, row) => {
 };
 
 export const isTestEnv = () => process.env.NODE_ENV === 'test';
+
+export const formatCellStyles = css => defaultCellStyle => `${defaultCellStyle} ${css}`;

--- a/test/fixtures/childInstances.js
+++ b/test/fixtures/childInstances.js
@@ -1,0 +1,7 @@
+export const childInstances = [
+  {
+    id: '7fbd5d84-62d1-44c6-9c45-6cb173998bbd',
+    instanceRelationshipTypeId: '758f13db-ffb4-440e-bb10-8a364aa6cb4a',
+    subInstanceId: '3afe2364-c584-46b7-8699-9667d4244d35',
+  }
+];

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -3,3 +3,4 @@ export { instanceRelationshipTypes } from './instanceRelationshipTypes';
 export { instances } from './instances';
 export { subInstances } from './subInstances';
 export { relationshipTypes } from './relationshipTypes';
+export { childInstances } from './childInstances';

--- a/test/fixtures/instances.js
+++ b/test/fixtures/instances.js
@@ -74,6 +74,7 @@ export const instances = [
       'staffOnly': false
     }],
     'modeOfIssuanceId': '9d18a02f-5897-4c31-9106-c9abb5c7ae8b',
+    'instanceRelationshipTypeId': '30773a27-b485-4dab-aeb6-b8c04fa3cb17',
     'discoverySuppress': false,
     'statisticalCodeIds': [],
     'statusUpdatedDate': '2020-12-24T13:14:31.537+0000',

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -11,6 +11,7 @@
   "instances.rows.recordsSelected": "{count, number} {count, plural, one {record} other {records}} selected",
   "instances.resourceType": "Resource Type",
   "instances.language": "Language",
+  "instances.typeOfRelation": "Type of relation: {name}",
   "holdingsRecord.awaitingResources": "Awaiting resources",
   "holdings.permanentLocation": "Holdings permanent location",
   "resultCount": "{count, number} {count, plural, one {record found} other {records found}}",


### PR DESCRIPTION
This PR is a continuation of work done in https://github.com/folio-org/ui-inventory/pull/1354 based on some additional feedback from PO.

The work done here groups child/parent sub instances by relationship type.

https://issues.folio.org/browse/UIIN-1044
https://issues.folio.org/browse/UIIN-1045

![relationships](https://user-images.githubusercontent.com/63545/116432163-69a37900-a816-11eb-85ff-97894a84349f.png)
