### PR TITLE
UIIN-816 include shelving order in itemData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Display correct open-request count for items. Refs UIIN-1469.
 * Fix items in transit export. Fixes UIIN-1492.
 * Warn with yellow toast when result of Single Record Import is unknown. Fixes UIIN-1495.
+* Patch: Display shelving order on the item record. Refs UIIN-816.
 
 ## [6.0.0](https://github.com/folio-org/ui-inventory/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.6...v6.0.0)

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -580,6 +580,7 @@ class ItemView extends React.Component {
       copyNumber: get(item, 'copyNumber', '-'),
       numberOfPieces: get(item, 'numberOfPieces', '-'),
       descriptionOfPieces: get(item, 'descriptionOfPieces', '-'),
+      effectiveShelvingOrder: get(item, 'effectiveShelvingOrder', '-'),
     };
 
     const enumerationData = {


### PR DESCRIPTION
The original work (#1323) added the field to the display but
accidentally neglected to configure the `itemData` itself.

Refs [UIIN-816](https://issues.folio.org/browse/UIIN-816), [MODINVSTOR-521](https://issues.folio.org/browse/MODINVSTOR-521)