### PR TITLE
UIIN-1468: Add callout after instance record is saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 * Fix items in transit export. Fixes UIIN-1492.
 * Warn with yellow toast when result of Single Record Import is unknown. Fixes UIIN-1495.
 * Patch: Display shelving order on the item record. Refs UIIN-816.
-* Add <Pluggable> instance to the Instance action menu for plugin type `copyright-permissions-checker`
+* Add <Pluggable> instance to the Instance action menu for plugin type `copyright-permissions-checker`.
+* Add callout after instance record is saved. Refs UIIN-1468.
 
 ## [6.0.0](https://github.com/folio-org/ui-inventory/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.6...v6.0.0)

--- a/src/Instance/InstanceEdit/InstanceEdit.js
+++ b/src/Instance/InstanceEdit/InstanceEdit.js
@@ -5,6 +5,7 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
+import { FormattedMessage } from 'react-intl';
 
 import {
   stripesConnect,
@@ -25,6 +26,7 @@ import {
   unmarshalInstance,
 } from '../../utils';
 import useLoadSubInstances from '../../hooks/useLoadSubInstances';
+import useCallout from '../../hooks/useCallout';
 
 const InstanceEdit = ({
   instanceId,
@@ -35,6 +37,7 @@ const InstanceEdit = ({
   const { identifierTypesById, identifierTypesByName } = referenceData;
 
   const [initialValues, setInitialValues] = useState();
+  const callout = useCallout();
   const { instance, isLoading: isInstanceLoading } = useInstance(instanceId, mutator.instanceEdit);
   const parentInstances = useLoadSubInstances(instance?.parentInstances, 'superInstanceId');
   const childInstances = useLoadSubInstances(instance?.childInstances, 'subInstanceId');
@@ -52,9 +55,16 @@ const InstanceEdit = ({
   const onSubmit = useCallback((updatedInstance) => {
     return mutator.instanceEdit.PUT(marshalInstance(updatedInstance, identifierTypesByName))
       .then(() => {
+        callout.sendCallout({
+          type: 'success',
+          message: <FormattedMessage
+            id="ui-inventory.instance.successfullySaved"
+            values={{ hrid: updatedInstance.hrid }}
+          />,
+        });
         goBack();
       });
-  }, [goBack, identifierTypesByName]);
+  }, [goBack, identifierTypesByName, callout]);
 
   if (isInstanceLoading) return <LoadingView />;
 

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -31,9 +31,8 @@ import {
   batchFetchItems,
   batchFetchRequests,
 } from './Instance/ViewRequests/utils';
-import { indentifierTypeNames } from './constants';
+import { indentifierTypeNames, layers } from './constants';
 import { DataContext } from './contexts';
-import { layers } from './constants';
 
 import {
   HoldingsListContainer,

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -2,9 +2,10 @@ import {
   get,
 } from 'lodash';
 import React, {
-  createRef,
+  createRef
 } from 'react';
 import PropTypes from 'prop-types';
+import { parse } from 'query-string';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { FormattedMessage } from 'react-intl';
 
@@ -32,12 +33,14 @@ import {
 } from './Instance/ViewRequests/utils';
 import { indentifierTypeNames } from './constants';
 import { DataContext } from './contexts';
+import { layers } from './constants';
 
 import {
   HoldingsListContainer,
   MoveItemsContext,
   InstanceDetails,
 } from './Instance';
+import { CalloutRenderer } from './components';
 
 import ImportRecordModal from './components/ImportRecordModal';
 
@@ -116,7 +119,8 @@ class ViewInstance extends React.Component {
       findInstancePluginOpened: false,
       isItemsMovement: false,
       isImportRecordModalOpened: false,
-      isCopyrightModalOpened: false
+      isCopyrightModalOpened: false,
+      afterCreate: false,
     };
     this.instanceId = null;
     this.cViewHoldingsRecord = this.props.stripes.connect(ViewHoldingsRecord);
@@ -142,6 +146,13 @@ class ViewInstance extends React.Component {
 
     if (isMARCSource && instanceRecordsId !== prevInstanceRecordsId) {
       this.getMARCRecord();
+    }
+
+    // component got updated after a new record was created
+    if (parse(prevProps?.location?.search)?.layer === layers.CREATE &&
+      !parse(this.props?.location?.search)?.layer && !this.state.afterCreate) {
+      // eslint-disable-next-line
+      this.setState({ afterCreate: true });
     }
 
     const { allInstanceHoldings, allInstanceItems } = resources;
@@ -598,6 +609,12 @@ class ViewInstance extends React.Component {
         </InstanceDetails>
 
         <Callout ref={this.calloutRef} />
+
+        {this.state.afterCreate &&
+          <CalloutRenderer
+            message={<FormattedMessage id="ui-inventory.instance.successfullySaved" values={{ hrid: instance.hrid }} />}
+          />
+        }
 
         {
           this.state.findInstancePluginOpened && (

--- a/src/components/CalloutRenderer/CalloutRenderer.js
+++ b/src/components/CalloutRenderer/CalloutRenderer.js
@@ -1,0 +1,30 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+import useCallout from '../../hooks/useCallout';
+
+// Declarative way to render a callout with a given message
+const CalloutRenderer = ({
+  message,
+  type = 'success',
+}) => {
+  const callout = useCallout();
+
+  useEffect(() => {
+    if (callout?.sendCallout) {
+      callout.sendCallout({
+        type,
+        message,
+      });
+    }
+  }, [callout]);
+
+  return null;
+};
+
+CalloutRenderer.propTypes = {
+  message: PropTypes.node,
+  type: PropTypes.string,
+};
+
+export default CalloutRenderer;

--- a/src/components/CalloutRenderer/index.js
+++ b/src/components/CalloutRenderer/index.js
@@ -1,0 +1,1 @@
+export { default } from './CalloutRenderer';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -13,3 +13,4 @@ export { default as TitlesView } from './TitlesView';
 export { default as ModalContent } from './ModalContent';
 export { PaneLoading, ViewLoading } from './Loading';
 export { default as WarningMessage } from './WarningMessage';
+export { default as CalloutRenderer } from './CalloutRenderer';

--- a/src/constants.js
+++ b/src/constants.js
@@ -144,6 +144,10 @@ export const actionMenuDisplayPerms = [
 
 export const DATE_FORMAT = 'YYYY-MM-DD';
 
+export const layers = {
+  CREATE: 'create',
+};
+
 export const INSTANCES_ID_REPORT_TIMEOUT = 2000;
 
 export const QUICK_EXPORT_LIMIT = process.env.NODE_ENV !== 'test' ? 100 : 2;

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -221,6 +221,8 @@
   "itemBarcode": "Item barcode",
   "item.barcode": "Item: barcode",
   "item.requestQueue": "Request queue",
+  "item.successfullySaved": "The <strong>item</strong> - HRID <strong>{hrid}</strong> has been successfully saved.",
+  "instance.successfullySaved": "The <strong>instance</strong> - HRID <strong>{hrid}</strong> has been successfully saved.",
   "noBarcode": "No barcode",
   "itemHrid": "Item HRID",
   "itemIdentifier": "Item identifier",

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -222,6 +222,7 @@
   "item.barcode": "Item: barcode",
   "item.requestQueue": "Request queue",
   "item.successfullySaved": "The <strong>item</strong> - HRID <strong>{hrid}</strong> has been successfully saved.",
+  "holdingsRecord.successfullySaved": "The <strong>holdings</strong> - HRID <strong>{hrid}</strong> has been successfully saved.",
   "instance.successfullySaved": "The <strong>instance</strong> - HRID <strong>{hrid}</strong> has been successfully saved.",
   "noBarcode": "No barcode",
   "itemHrid": "Item HRID",


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1468

The POST request currently does not return the newly created instance so this is kind of a workaround in order to be able to access that record. This is required because the HRID has to be displayed on the callout.