### PR TITLE
UIIN-1511: Update circulation interface dependency to support v11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Add <Pluggable> instance to the Instance action menu for plugin type `copyright-permissions-checker`.
 * Add callout after instance record is saved. Refs UIIN-1468.
 * Add callout after item or holdings record are saved. Refs UIIN-1485, UIIN-1486.
+* Also support `circulation` `11.0`. Refs UIIN-1511.
 
 ## [6.0.0](https://github.com/folio-org/ui-inventory/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.6...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
       "holdings-sources": "1.0",
       "users": "15.0",
       "location-units": "2.0",
-      "circulation": "9.0 10.0",
+      "circulation": "9.0 10.0 11.0",
       "configuration": "2.0",
       "tags": "1.0",
       "inventory-record-bulk": "1.0",


### PR DESCRIPTION
## Purpose
There is a breaking change in mod-circulation (https://github.com/folio-org/mod-circulation/pull/854), circulation interface version will be updated to 11.0.  Other modules should update their dependencies to support this change.

**Do not merge. We have several associated pull request and we need merge them at the same time.**

**API changes**
circulation/override-renewal-by-barcode - will be removed
circulation/renew-by-barcode - request and response will be changed
Current changes will be effect ui-users module

## Refs
https://issues.folio.org/browse/UIIN-1511