### PR TITLE
Update babel versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -732,12 +732,12 @@
     "test:e2e:ci": "stripes test karma --karma.singleRun --karma.browsers ChromeDocker --karma.reporters mocha junit --coverage"
   },
   "devDependencies": {
-    "@babel/core": "^7.8.0",
+    "@babel/core": "^7.9.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-decorators": "^7.0.0",
     "@babel/plugin-transform-runtime": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
-    "@babel/preset-react": "^7.7.4",
+    "@babel/preset-react": "^7.9.0",
     "@bigtest/interactor": "^0.7.0",
     "@bigtest/mocha": "^0.5.1",
     "@bigtest/react": "^0.1.2",

--- a/test/jest/babel.config.js
+++ b/test/jest/babel.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   presets: [
     '@babel/preset-env',
-    '@babel/preset-react',
+    ['@babel/preset-react', { 'runtime': 'automatic' }],
   ],
   plugins: [
     [
@@ -11,4 +11,5 @@ module.exports = {
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-transform-runtime',
   ],
+
 };


### PR DESCRIPTION
Update babel version used by jest/rtl to avoid errors related to: `ReferenceError: React is not defined`