### PR TITLE
UIIN-1532: quickMARC Latency: Unable to view source, edit or derive MARC bib without a page refresh or new search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Focus on on search box when changing inventory segments. Fixes UIIN-1358.
 * Update detail view headers. Refs UIIN-1309, UIIN-1311, UIIN-1470.
 * Update version of interfaces due to supporting MARC Authority records. Refs UIIN-1528.
+* Fix instance MARC record not loading when adding OCLC number. Refs UIIN-1532.
 
 ## [6.0.0](https://github.com/folio-org/ui-inventory/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v5.0.6...v6.0.0)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -133,7 +133,7 @@ class ViewInstance extends React.Component {
   }
 
   componentDidMount() {
-    const isMARCSource = this.isMARCSource();
+    const isMARCSource = this.isMARCSource(this.props.resources);
 
     if (isMARCSource) {
       this.getMARCRecord();
@@ -146,9 +146,13 @@ class ViewInstance extends React.Component {
     const instanceRecords = resources?.selectedInstance?.records;
     const instanceRecordsId = instanceRecords[0]?.id;
     const prevInstanceRecordsId = prevResources?.selectedInstance?.records[0]?.id;
-    const isMARCSource = this.isMARCSource();
+    const prevIsMARCSource = this.isMARCSource(prevResources);
+    const isMARCSource = this.isMARCSource(resources);
 
-    if (isMARCSource && instanceRecordsId !== prevInstanceRecordsId) {
+    const isViewingAnotherRecord = instanceRecordsId !== prevInstanceRecordsId;
+    const recordSourceWasChanged = isMARCSource !== prevIsMARCSource;
+
+    if (isMARCSource && (isViewingAnotherRecord || recordSourceWasChanged)) {
       this.getMARCRecord();
     }
 
@@ -183,8 +187,7 @@ class ViewInstance extends React.Component {
     this.props.mutator.allInstanceItems.reset();
   }
 
-  isMARCSource = () => {
-    const { resources } = this.props;
+  isMARCSource = (resources) => {
     const instanceRecords = resources?.selectedInstance?.records;
     const instanceRecordsSource = instanceRecords?.[0]?.source;
 


### PR DESCRIPTION
## Description
Fix instance MARC record not loading when adding OCLC number. If instance's source is changed from `FOLIO` to `MARC` the marc record was not loaded.

## Issues
[UIIN-1532](https://issues.folio.org/browse/UIIN-1532)