### PR TITLE
UIIN-1546: Parse parentInstances and childInstances before instance record is saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## [7.2.0] IN PROGRESS
+
+* Parse `parentInstances` and `childInstances` before instance record is saved. Fixes UIIN-1546.
+
 ## [7.1.0](https://github.com/folio-org/ui-inventory/tree/v7.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.0.3...v7.1.0)
 

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -162,11 +162,11 @@ class InstancesList extends React.Component {
     this.props.updateLocation({ layer: null });
   };
 
-  createInstance = (instance) => {
+  createInstance = (instanceData) => {
     const { data: { identifierTypesByName } } = this.props;
 
     // Massage record to add preceeding and succeeding title fields
-    marshalInstance(instance, identifierTypesByName);
+    const instance = marshalInstance(instanceData, identifierTypesByName);
 
     // POST item record
     return this.props.parentMutator.records.POST(instance);

--- a/src/utils.js
+++ b/src/utils.js
@@ -567,7 +567,6 @@ export const marshalTitles = (instance, identifierTypesByName, type) => {
  * @param relationshipIdKey string ("subInstanceId" or "superInstanceId")
  *
  */
-
 export const marshalRelationship = (instance, relationshipName, relationshipIdKey) => {
   instance[relationshipName] = (instance?.[relationshipName] ?? []).map((inst) => {
     const {
@@ -580,7 +579,7 @@ export const marshalRelationship = (instance, relationshipName, relationshipIdKe
       instanceRelationshipTypeId,
     };
 
-    // if relationshipId is different from the id it means this an existing relationship record
+    // if relationshipId is different from the id it means this is an existing relationship record
     // https://issues.folio.org/browse/UIIN-1546?focusedCommentId=106757&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-106757
     if (inst[relationshipIdKey] !== id) {
       relationshipRecord.id = id;

--- a/src/utils.js
+++ b/src/utils.js
@@ -559,6 +559,38 @@ export const marshalTitles = (instance, identifierTypesByName, type) => {
 };
 
 /**
+ * Marshal parent/child instances
+ * to the format required by the server.
+ *
+ * @param instance instance object
+ * @param relationshipName string ("parentInstances" or "childInstances")
+ * @param relationshipIdKey string ("subInstanceId" or "superInstanceId")
+ *
+ */
+
+export const marshalRelationship = (instance, relationshipName, relationshipIdKey) => {
+  instance[relationshipName] = (instance?.[relationshipName] ?? []).map((inst) => {
+    const {
+      id,
+      instanceRelationshipTypeId,
+    } = inst;
+
+    const relationshipRecord = {
+      [relationshipIdKey]: inst[relationshipIdKey],
+      instanceRelationshipTypeId,
+    };
+
+    // if relationshipId is different from the id it means this an existing relationship record
+    // https://issues.folio.org/browse/UIIN-1546?focusedCommentId=106757&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-106757
+    if (inst[relationshipIdKey] !== id) {
+      relationshipRecord.id = id;
+    }
+
+    return relationshipRecord;
+  });
+};
+
+/**
  * Marshal given instance to the format required by the server.
  *
  * @param instance instance object
@@ -570,6 +602,9 @@ export const marshalInstance = (instance, identifierTypesByName) => {
 
   marshalTitles(marshaledInstance, identifierTypesByName, 'preceding');
   marshalTitles(marshaledInstance, identifierTypesByName, 'succeeding');
+
+  marshalRelationship(marshaledInstance, 'parentInstances', 'superInstanceId');
+  marshalRelationship(marshaledInstance, 'childInstances', 'subInstanceId');
 
   return marshaledInstance;
 };


### PR DESCRIPTION
As @nielserik outlined in https://issues.folio.org/browse/UIIN-1546?focusedCommentId=106757&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-106757

The previous implementation was sending a full instance records under `parentInstances` and `childInstances` which was causing issues with incorrect `id` being used. 

This PR parses the `parentInstances` and `childInstances` in order to only send what the server expects:

````js
{
  "id"    (id of the Instance we are adding parents/children to)
  "title" 
  ... etc
  "parentInstances" : [
     {
      "id":  (if adding new relation: nothing here or new unique UUID for this relation, if updating relation: use existing id)
      "superInstanceId":  (id of the related parent)
      "instanceRelationshipTypeId":   (type of relationship)
     }
  ],
  "childInstances": [
     {
        "id": (if adding new relation: nothing here or new unique UUID for this relation, if updating relation: use existing id)
        "subInstanceId":  (id of the related child)
        "instanceRelationshipTypeId": (type of relationship)
     }
 ]        
}
````

Thank you @nielserik for identifying what was wrong here.