### PR TITLE
UIIN-1556: Fix collapse and expand buttons on instance view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## [7.1.3] IN PROGRESS
+
+* Fix collapse and expand buttons on instance view. Fixes UIIN-1556.
+
 ## [7.1.2](https://github.com/folio-org/ui-inventory/tree/v7.1.2) (2021-07-14)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.1...v7.1.2)
 

--- a/src/Instance/InstanceDetails/InstanceDetails.js
+++ b/src/Instance/InstanceDetails/InstanceDetails.js
@@ -122,7 +122,7 @@ const InstanceDetails = ({
             instanceTypes={referenceData.instanceTypes}
           />
 
-          <AccordionSet initialStatus={accordionState} accordionStatus={accordionState}>
+          <AccordionSet initialStatus={accordionState}>
             {children}
 
             <InstanceNewHolding instance={instance} />

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -54,7 +54,7 @@ class ViewInstance extends React.Component {
     selectedInstance: {
       type: 'okapi',
       path: 'inventory/instances/:{id}',
-      clear: false,
+      resourceShouldRefresh: true,
       throwErrors: false,
     },
     allInstanceHoldings: {


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1556

This is a regression I introduced in https://github.com/folio-org/ui-inventory/pull/1416 when I tried to address https://issues.folio.org/browse/UIIN-1534.

This PR should address it correctly now for both UIIN-1556 and UIIN-1554.

The `selectedInstance` resource was not cleared out between remounts and it would hold the previous version of `instance` on the first render before a new version was fetched. This was causing some issues with the `initialStatus` values passed to `AccordionSet`. 