### PR TITLE
UIIN-1562: Fix instance duplication when child or parent records are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Keyboard cannot move item to other holding by drag 'n' drop. Refs UIIN-1490.
 * Sort statistical codes by code-type, then code, then name. Refs UIIN-1550.
 * Populate a value in Source field when View/Edit Inventory Holdings Record. Refs UIIN-1548.
+* Improve performance on instance view. Fixes UIIN-1560.
 * Fix instance duplication when child or parent records are present. Fixes UIIN-1562.
 * Add bound-with icons and item detail view header note. Refs UIIN-1522, UIIN-1523, UIIN-1524.
 * Retrieve and display select Piece information on Holding. Refs UIIN-1502.

--- a/src/ConnectedInstance/StripesConnectedInstance.js
+++ b/src/ConnectedInstance/StripesConnectedInstance.js
@@ -4,9 +4,8 @@ export default class StripesConnectedInstance {
     this.logger = logger;
 
     const id = this.props.match.params.id;
-    const selInstance = (this.props.resources.selectedInstance || {}).records;
-    // Why do we need to do this find?
-    this.obj = (selInstance && id) ? selInstance.find(i => i.id === id) : null;
+    const selInstance = this.props.selectedInstance;
+    this.obj = (selInstance?.id === id) ? selInstance : null;
   }
 
   instance() {

--- a/src/Instance/InstanceDetails/InstanceRelationshipView/InstanceRelationshipView.js
+++ b/src/Instance/InstanceDetails/InstanceRelationshipView/InstanceRelationshipView.js
@@ -9,7 +9,6 @@ import {
   Accordion,
 } from '@folio/stripes/components';
 
-import useLoadSubInstances from '../../../hooks/useLoadSubInstances';
 import SubInstanceGroup from '../SubInstanceGroup';
 
 const InstanceRelationshipView = ({
@@ -17,9 +16,6 @@ const InstanceRelationshipView = ({
   parentInstances,
   childInstances,
 }) => {
-  const parents = useLoadSubInstances(parentInstances, 'superInstanceId');
-  const children = useLoadSubInstances(childInstances, 'subInstanceId');
-
   return (
     <Accordion
       id={id}
@@ -31,7 +27,7 @@ const InstanceRelationshipView = ({
             id="childInstances"
             titleKey="subInstanceId"
             label={<FormattedMessage id="ui-inventory.childInstances" />}
-            titles={children}
+            titles={childInstances}
           />
         </Col>
       </Row>
@@ -41,7 +37,7 @@ const InstanceRelationshipView = ({
             id="parentInstances"
             titleKey="superInstanceId"
             label={<FormattedMessage id="ui-inventory.parentInstances" />}
-            titles={parents}
+            titles={parentInstances}
           />
         </Col>
       </Row>

--- a/src/ViewInstanceWrapper.js
+++ b/src/ViewInstanceWrapper.js
@@ -1,0 +1,62 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { omit } from 'lodash';
+
+import { withTags } from '@folio/stripes/smart-components';
+
+import ViewInstance from './ViewInstance';
+import useLoadSubInstances from './hooks/useLoadSubInstances';
+
+const ViewInstanceWrapper = (props) => {
+  const {
+    match: { params: { id } },
+    resources,
+  } = props;
+  const instance = resources.instance?.records?.[0];
+  const selectedInstance = instance?.id === id ? instance : null;
+
+  // only load after instance is present
+  const parentInstances = useLoadSubInstances(selectedInstance?.parentInstances, 'superInstanceId');
+  const childInstances = useLoadSubInstances(selectedInstance?.childInstances, 'subInstanceId');
+
+  if (selectedInstance) {
+    if (parentInstances?.length) {
+      selectedInstance.parentInstances = parentInstances;
+    }
+
+    if (childInstances?.length) {
+      selectedInstance.childInstances = childInstances;
+    }
+  }
+
+  return (
+    <ViewInstance
+      {...omit(props, ['resources', 'mutator'])}
+      selectedInstance={selectedInstance}
+    />
+  );
+};
+
+ViewInstanceWrapper.manifest = Object.freeze({
+  instance: {
+    type: 'okapi',
+    path: 'inventory/instances/:{id}',
+    resourceShouldRefresh: true,
+    throwErrors: false,
+  },
+});
+
+ViewInstanceWrapper.propTypes = {
+  resources: PropTypes.shape({
+    instance: PropTypes.shape({
+      records: PropTypes.arrayOf(PropTypes.object),
+    }),
+  }).isRequired,
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      id: PropTypes.string,
+    }),
+  }),
+};
+
+export default withTags(ViewInstanceWrapper);

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -36,7 +36,7 @@ import {
 import FilterNavigation from '../FilterNavigation';
 import packageInfo from '../../../package';
 import InstanceForm from '../../edit/InstanceForm';
-import ViewInstance from '../../ViewInstance';
+import ViewInstanceWrapper from '../../ViewInstanceWrapper';
 import formatters from '../../referenceFormatters';
 import withLocation from '../../withLocation';
 import {
@@ -691,7 +691,7 @@ class InstancesList extends React.Component {
             searchableIndexesPlaceholder={null}
             initialResultCount={INITIAL_RESULT_COUNT}
             resultCountIncrement={RESULT_COUNT_INCREMENT}
-            viewRecordComponent={ViewInstance}
+            viewRecordComponent={ViewInstanceWrapper}
             editRecordComponent={InstanceForm}
             newRecordInitialValues={(this.state && this.state.copiedInstance) ? this.state.copiedInstance : {
               discoverySuppress: false,


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1562

This PR introduces `ViewInstanceWrapper` which preloads child and parent instances before `ViewInstance` is mounted. This is required so the correct data is present during instance duplication.

![dup](https://user-images.githubusercontent.com/63545/129297312-d62f167e-a928-4773-9a4b-e897e956346e.gif)
