### PR TITLE
UXPROD-3148: POC for enabling translations of library-defined controlled vocabularies on stripes apps

### DIFF
--- a/src/components/InstanceFilters/InstanceFilters.js
+++ b/src/components/InstanceFilters/InstanceFilters.js
@@ -50,28 +50,30 @@ const InstanceFilters = props => {
     onClear,
   } = props;
 
+  const intl = useIntl();
+
   const effectiveLocationOptions = locations.map(({ name, id }) => ({
-    label: name,
+    label: intl.formatMessage({ id: `ui-tenant-settings.locations.name.${name}`, defaultMessage: `${name}` }),
     value: id,
   }));
 
   const resourceTypeOptions = resourceTypes.map(({ name, id }) => ({
-    label: name,
+    label: intl.formatMessage({ id: `ui-inventory.instanceTypes.name.${name}`, defaultMessage: `${name}` }),
     value: id,
   }));
 
   const instanceFormatOptions = instanceFormats.map(({ name, id }) => ({
-    label: name,
+    label: intl.formatMessage({ id: `ui-inventory.instanceFormats.name.${name}`, defaultMessage: `${name}` }),
     value: id,
   }));
 
   const modeOfIssuanceOptions = modesOfIssuance.map(({ name, id }) => ({
-    label: name,
+    label: intl.formatMessage({ id: `ui-inventory.issuanceModes.name.${name}`, defaultMessage: `${name}` }),
     value: id,
   }));
 
   const natureOfContentOptions = natureOfContentTerms.map(({ name, id }) => ({
-    label: name,
+    label: intl.formatMessage({ id: `ui-inventory.natureOfContentTerms.name.${name}`, defaultMessage: `${name}` }),
     value: id,
   }));
 
@@ -97,7 +99,6 @@ const InstanceFilters = props => {
     },
   ];
 
-  const intl = useIntl();
   const stripes = useStripes();
   const langOptions = languageOptions(intl, stripes.locale);
 

--- a/src/edit/InstanceForm.js
+++ b/src/edit/InstanceForm.js
@@ -6,7 +6,7 @@ import {
   filter,
   isEmpty,
 } from 'lodash';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl } from 'react-intl';
 
 import { stripesConnect } from '@folio/stripes/core';
 import { ViewMetaData } from '@folio/stripes/smart-components';
@@ -264,16 +264,33 @@ class InstanceForm extends React.Component {
       onCancel,
       initialValues,
       referenceTables,
+      intl,
     } = this.props;
+
+    referenceTables.statisticalCodeTypes.forEach(trans => {
+      trans.translatedName = intl.formatMessage({ id: `ui-inventory.statisticalCodeTypes.name.${trans.name}`, defaultMessage: trans.name });
+    });
+
+    referenceTables.statisticalCodes.forEach(trans => {
+      trans.translatedName = intl.formatMessage({ id: `ui-inventory.statisticalCodes.name.${trans.name}`, defaultMessage: trans.name });
+    });
 
     const refLookup = (referenceTable, id) => {
       const ref = (referenceTable && id) ? referenceTable.find(record => record.id === id) : {};
       return ref || {};
     };
 
+    referenceTables.statisticalCodeTypes.forEach(trans => {
+      trans.translatedName = intl.formatMessage({ id: `ui-inventory.statisticalCodeTypes.name.${trans.name}`, defaultMessage: trans.name });
+    });
+
+    referenceTables.statisticalCodes.forEach(trans => {
+      trans.translatedName = intl.formatMessage({ id: `ui-inventory.statisticalCodes.name.${trans.name}`, defaultMessage: trans.name });
+    });
+
     const instanceTypeOptions = referenceTables.instanceTypes ? referenceTables.instanceTypes.map(
       it => ({
-        label: it.name,
+        label: intl.formatMessage({ id: `ui-inventory.instanceTypes.name.${it.name}`, defaultMessage: it.name }),
         value: it.id,
         selected: it.id === initialValues.instanceTypeId,
       }),
@@ -281,7 +298,7 @@ class InstanceForm extends React.Component {
 
     const instanceStatusOptions = referenceTables.instanceStatuses ? referenceTables.instanceStatuses.map(
       it => ({
-        label: `${it.name} (${it.source}: ${it.code})`,
+        label: `${intl.formatMessage({ id: `ui-inventory.instanceStatuses.name.${it.name}`, defaultMessage: it.name })} (${it.source}: ${it.code})`,
         value: it.id,
         selected: it.id === initialValues.instanceFormatId,
       }),
@@ -289,7 +306,7 @@ class InstanceForm extends React.Component {
 
     const modeOfIssuanceOptions = referenceTables.modesOfIssuance ? referenceTables.modesOfIssuance.map(
       it => ({
-        label: it.name,
+        label: `${intl.formatMessage({ id: `ui-inventory.issuanceModes.name.${it.name}`, defaultMessage: it.name })} (${it.source})`,
         value: it.id,
         selected: it.id === initialValues.modeOfIssuanceId,
       }),
@@ -298,21 +315,30 @@ class InstanceForm extends React.Component {
     const statisticalCodeOptions = referenceTables.statisticalCodes
       .map(
         code => ({
-          label: refLookup(referenceTables.statisticalCodeTypes, code.statisticalCodeTypeId).name + ':    ' + code.code + ' - ' + code.name,
+          label: refLookup(referenceTables.statisticalCodeTypes, code.statisticalCodeTypeId).translatedName + ':    ' + code.code + ' - ' + code.translatedName,
           value: code.id,
           selected: code.id === initialValues.statisticalCodeId,
         })
       )
       .sort((a, b) => a.label.localeCompare(b.label));
+      /** kware end editing */
+
 
     // Since preceding/succeeding title relationships are split out from other parent/child instances,
     // we don't want the type selection box for parent/child to include the preceding-succeeding type
     const rTypes = referenceTables.instanceRelationshipTypes;
     const mostParentChildRelationships = filter(rTypes, rt => rt.id !== psTitleRelationshipId(rTypes));
+    // const relationshipTypes = mostParentChildRelationships.map(it => ({
+    //   label: it.name,
+    //   value: it.id,
+    // }));
+
+    /** kware start editing */
     const relationshipTypes = mostParentChildRelationships.map(it => ({
-      label: it.name,
+      label: intl.formatMessage({ id: `ui-inventory.instanceRelationshipTypes.name.${it.name}`, defaultMessage: it.name }),
       value: it.id,
     }));
+    /** kware end editing */
 
     return (
       <form
@@ -460,9 +486,12 @@ class InstanceForm extends React.Component {
                         {
                           label: <FormattedMessage id="ui-inventory.statisticalCode" />,
                           component: Select,
-                          dataOptions: [{
-                            label: 'Select code', value: '',
-                          }, ...statisticalCodeOptions],
+                          // dataOptions: [{
+                          //   label: 'Select code', value: '',
+                          // }, ...statisticalCodeOptions],
+                          /** kware start editing */
+                          dataOptions: [{ label: this.props.intl.formatMessage({ id: 'ui-inventory.selectCode', defaultMessage: 'Select code' }), value: '' }, ...statisticalCodeOptions],
+                          /** kware end editing */
                           disabled: this.isFieldBlocked('statisticalCodeIds'),
                         }
                       ]}
@@ -759,13 +788,23 @@ InstanceForm.propTypes = {
     }),
   }),
   instanceSource: PropTypes.string,
+  /** kware start editing */
+  intl: PropTypes.object,
+  /** kware end editing */
 };
 InstanceForm.defaultProps = {
   instanceSource: 'FOLIO',
   initialValues: {},
 };
 
+// export default stripesFinalForm({
+//   validate,
+//   navigationCheck: true,
+// })(InstanceForm);
+
+/** kware start editing */
 export default stripesFinalForm({
   validate,
   navigationCheck: true,
-})(InstanceForm);
+})(injectIntl(InstanceForm));
+/** kware end editing */

--- a/src/edit/alternativeTitles.js
+++ b/src/edit/alternativeTitles.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import {
   TextArea,
@@ -16,8 +16,10 @@ const AlternativeTitles = props => {
     canEdit,
     canDelete,
   } = props;
+
+  const intl = useIntl();
   const alternativeTitleTypeOptions = alternativeTitleTypes.map(it => ({
-    label: it.name,
+    label: intl.formatMessage({ id: `ui-inventory.alternativeTitleTypes.name.${it.name}`, defaultMessage: it.name }),
     value: it.id,
   }));
 

--- a/src/edit/classificationFields.js
+++ b/src/edit/classificationFields.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import { IntlConsumer } from '@folio/stripes/core';
 import {
@@ -17,8 +17,10 @@ const ClassificationFields = props => {
     canEdit,
     canDelete,
   } = props;
+
+  const translate = useIntl();
   const classificationTypeOptions = classificationTypes.map(it => ({
-    label: it.name,
+    label: translate.formatMessage({ id: `ui-inventory.classificationTypes.name.${it.name}`, defaultMessage: `${it.name}` }),
     value: it.id,
   }));
 

--- a/src/edit/contributorFields.js
+++ b/src/edit/contributorFields.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import {
   TextArea,
   Select,
@@ -17,13 +17,15 @@ const ContributorFields = props => {
     canEdit,
     canDelete,
   } = props;
+
+  const translate = useIntl();
   const contributorNameTypeOptions = contributorNameTypes.map(it => ({
-    label: it.name,
+    label: translate.formatMessage({ id: `ui-inventory.contributorNameTypes.name.${it.name}`, defaultMessage: it.name }),
     value: it.id,
   }));
 
   const contributorTypeOptions = contributorTypes.map(it => ({
-    label: it.name,
+    label: translate.formatMessage({ id: `ui-inventory.contributorTypes.name.${it.name}`, defaultMessage: it.name }),
     value: it.id,
   }));
 

--- a/src/edit/electronicAccessFields.js
+++ b/src/edit/electronicAccessFields.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import {
   TextArea,
@@ -16,8 +16,10 @@ const ElectronicAccessFields = props => {
     canEdit,
     canDelete,
   } = props;
+
+  const intl = useIntl();
   const relationshipOptions = relationship.map(it => ({
-    label: it.name,
+    label: intl.formatMessage({ id: `ui-inventory.electronicAccessRelationships.name.${it.name}`, defaultMessage: it.name }),
     value: it.id,
   }));
 

--- a/src/edit/identifierFields.js
+++ b/src/edit/identifierFields.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import { IntlConsumer } from '@folio/stripes/core';
 import {
@@ -17,10 +17,18 @@ const IdentifierFields = props => {
     canEdit,
     canDelete,
   } = props;
+  // const identifierTypeOptions = identifierTypes.map(it => ({
+  //   label: it.name,
+  //   value: it.id,
+  // }));
+
+  /** kware start editing */
+  const translate = useIntl();
   const identifierTypeOptions = identifierTypes.map(it => ({
-    label: it.name,
+    label: translate.formatMessage({ id: `ui-inventory.identifierTypes.name.${it.name}`, defaultMessage: `${it.name}` }),
     value: it.id,
   }));
+    /** kware end editing */
 
   return (
     <IntlConsumer>

--- a/src/edit/instanceFormatFields.js
+++ b/src/edit/instanceFormatFields.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'react-final-form';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Select } from '@folio/stripes/components';
 
 import RepeatableField from '../components/RepeatableField';
 
-const renderInstanceFormatField = ({ field, fieldIndex, canEdit }, instanceFormats) => {
+const renderInstanceFormatField = ({ field, fieldIndex, canEdit }, instanceFormats, translate) => {
   const instanceFormatOptions = instanceFormats
     ? instanceFormats.map(it => ({
-      label: it.name,
+      label: translate.formatMessage({ id: `ui-inventory.instanceFormats.name.${it.name}`, defaultMessage: it.name }),
       value: it.id,
     }))
     : [];
@@ -51,6 +51,8 @@ const InstanceFormatFields = props => {
     canDelete,
   } = props;
 
+  const translate = useIntl();
+
   return (
     <RepeatableField
       name="instanceFormatIds"
@@ -58,7 +60,7 @@ const InstanceFormatFields = props => {
       addLabel={<FormattedMessage id="ui-inventory.addInstanceFormat" />}
       addButtonId="clickable-add-instanceformat"
       template={[{
-        render(fieldObj) { return renderInstanceFormatField({ ...fieldObj, canEdit }, instanceFormats); },
+        render(fieldObj) { return renderInstanceFormatField({ ...fieldObj, canEdit }, instanceFormats, translate); },
       }]}
       canAdd={canAdd}
       canDelete={canDelete}

--- a/src/edit/natureOfContentFields.js
+++ b/src/edit/natureOfContentFields.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'react-final-form';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Select } from '@folio/stripes/components';
 
 import RepeatableField from '../components/RepeatableField';
 
-const renderNatureOfContentField = ({ field, fieldIndex, canEdit }, natureOfContentTerms) => {
+const renderNatureOfContentField = ({ field, fieldIndex, canEdit }, natureOfContentTerms, translate) => {
   const natureOfContentTermOptions = natureOfContentTerms
     ? natureOfContentTerms.map(it => ({
-      label: it.name,
+      label: translate.formatMessage({ id: `ui-inventory.natureOfContentTerms.name.${it.name}`, defaultMessage: it.name }),
       value: it.id,
     }))
     : [];
@@ -50,6 +50,8 @@ const NatureOfContentFields = props => {
     natureOfContentTerms,
   } = props;
 
+  const translate = useIntl();
+
   return (
     <RepeatableField
       name="natureOfContentTermIds"
@@ -57,7 +59,7 @@ const NatureOfContentFields = props => {
       addLabel={<FormattedMessage id="ui-inventory.addNatureOfContentTerm" />}
       addButtonId="clickable-add-nature-of-content"
       template={[{
-        render(fieldObj) { return renderNatureOfContentField({ ...fieldObj, canEdit }, natureOfContentTerms); },
+        render(fieldObj) { return renderNatureOfContentField({ ...fieldObj, canEdit }, natureOfContentTerms, translate); },
       }]}
       canAdd={canAdd}
       canDelete={canDelete}

--- a/src/edit/noteFields.js
+++ b/src/edit/noteFields.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
 import {
@@ -18,8 +18,9 @@ const NoteFields = props => {
     canDelete,
   } = props;
 
+  const translate = useIntl();
   const instanceNoteTypeOptions = instanceNoteTypes.map(it => ({
-    label: it.name,
+    label: translate.formatMessage({ id: `ui-inventory.instanceNoteTypes.name.${it.name}`, defaultMessage: it.name }),
     value: it.id,
   }));
 
@@ -35,7 +36,7 @@ const NoteFields = props => {
           label: <FormattedMessage id="ui-inventory.noteType" />,
           component: Select,
           disabled: !canEdit,
-          dataOptions: [{ label: 'Select type', value: '' }, ...instanceNoteTypeOptions],
+          dataOptions: [{ label: translate.formatMessage({ id: 'ui-inventory.selectType', defaultMessage: 'Select type' }), value: '' }, ...instanceNoteTypeOptions],
         },
         {
           name: 'note',

--- a/src/settings/AlternativeTitleTypesSettings.js
+++ b/src/settings/AlternativeTitleTypesSettings.js
@@ -29,6 +29,9 @@ class AlternativeTitleTypesSettings extends React.Component {
             {...this.props}
             baseUrl="alternative-title-types"
             records="alternativeTitleTypes"
+            appName="ui-inventory"
+            tableName="alternativeTitleTypes"
+            translatableFields={['name']}
             label={<FormattedMessage id="ui-inventory.alternativeTitleTypes" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.alternativeTitleType' })}
             objectLabel={<FormattedMessage id="ui-inventory.alternativeTitleTypes" />}

--- a/src/settings/CallNumberTypes.js
+++ b/src/settings/CallNumberTypes.js
@@ -29,6 +29,9 @@ class CallNumberTypes extends React.Component {
             {...this.props}
             baseUrl="call-number-types"
             records="callNumberTypes"
+            tableName="callNumberTypes"
+            appName="ui-inventory"
+            translatableFields={['name']}
             label={<FormattedMessage id="ui-inventory.callNumberTypes" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.callNumberType' })}
             objectLabel={<FormattedMessage id="ui-inventory.callNumberTypes" />}

--- a/src/settings/ClassificationTypesSettings.js
+++ b/src/settings/ClassificationTypesSettings.js
@@ -32,6 +32,9 @@ class ClassificationTypesSettings extends React.Component {
             {...this.props}
             baseUrl="classification-types"
             records="classificationTypes"
+            tableName="classificationTypes"
+            appName="ui-inventory"
+            translatableFields={['name']}
             label={<FormattedMessage id="ui-inventory.classificationIdentifierTypes" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.classificationIdentifierType' })}
             objectLabel={<FormattedMessage id="ui-inventory.classificationIdentifierTypes" />}

--- a/src/settings/ContributorTypesSettings.js
+++ b/src/settings/ContributorTypesSettings.js
@@ -34,6 +34,9 @@ class ContributorTypesSettings extends React.Component {
             {...this.props}
             baseUrl="contributor-types"
             records="contributorTypes"
+            tableName="contributorTypes"
+            appName="ui-inventory"
+            translatableFields={['name']}
             label={<FormattedMessage id="ui-inventory.contributorTypes" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.contributorType' })}
             objectLabel={<FormattedMessage id="ui-inventory.contributors" />}

--- a/src/settings/FormatsSettings.js
+++ b/src/settings/FormatsSettings.js
@@ -34,6 +34,9 @@ class FormatSettings extends React.Component {
             {...this.props}
             baseUrl="instance-formats"
             records="instanceFormats"
+            tableName="instanceFormats"
+            appName="ui-inventory"
+            translatableFields={['name']}
             label={<FormattedMessage id="ui-inventory.formats" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.format' })}
             objectLabel={<FormattedMessage id="ui-inventory.instances" />}

--- a/src/settings/HoldingsNoteTypesSettings.js
+++ b/src/settings/HoldingsNoteTypesSettings.js
@@ -29,6 +29,9 @@ class HoldingsNoteTypesSettings extends React.Component {
             {...this.props}
             baseUrl="holdings-note-types"
             records="holdingsNoteTypes"
+            tableName="holdingsNoteTypes"
+            appName="ui-inventory"
+            translatableFields={['name']}
             label={<FormattedMessage id="ui-inventory.holdingsNoteTypes" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.holdingsNoteType' })}
             objectLabel={<FormattedMessage id="ui-inventory.holdingsNoteTypes" />}

--- a/src/settings/HoldingsSourcesSettings.js
+++ b/src/settings/HoldingsSourcesSettings.js
@@ -32,6 +32,9 @@ class HoldingsSourcesSettings extends React.Component {
             {...this.props}
             baseUrl="holdings-sources"
             records="holdingsRecordsSources"
+            tableName="holdingsRecordsSources"
+            appName="ui-inventory"
+            translatableFields={['name', 'source']}
             label={<FormattedMessage id="ui-inventory.holdingsSources" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.holdingsSource' })}
             objectLabel={<FormattedMessage id="ui-inventory.holdingsSources" />}

--- a/src/settings/HoldingsTypeSettings.js
+++ b/src/settings/HoldingsTypeSettings.js
@@ -29,6 +29,9 @@ class HoldingsTypeSettings extends React.Component {
             {...this.props}
             baseUrl="holdings-types"
             records="holdingsTypes"
+            tableName="holdingsTypes"
+            appName="ui-inventory"
+            translatableFields={['name']}
             label={<FormattedMessage id="ui-inventory.holdingsTypes" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.holdingsNoteType' })}
             objectLabel={<FormattedMessage id="ui-inventory.holdingsTypes" />}

--- a/src/settings/ILLPolicy.js
+++ b/src/settings/ILLPolicy.js
@@ -29,6 +29,9 @@ class ILLPolicy extends React.Component {
             {...this.props}
             baseUrl="ill-policies"
             records="illPolicies"
+            tableName="illPolicies"
+            appName="ui-inventory"
+            translatableFields={['name']}
             label={<FormattedMessage id="ui-inventory.ILLPolicy" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.ILLPolicy' })}
             objectLabel={<FormattedMessage id="ui-inventory.ILLPolicy" />}

--- a/src/settings/IdentifierTypesSettings.js
+++ b/src/settings/IdentifierTypesSettings.js
@@ -32,6 +32,9 @@ class IdentifierTypesSettings extends React.Component {
             {...this.props}
             baseUrl="identifier-types"
             records="identifierTypes"
+            tableName="identifierTypes"
+            appName="ui-inventory"
+            translatableFields={['name']}
             label={<FormattedMessage id="ui-inventory.resourceIdentifierTypes" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.resourceIdentifierType' })}
             objectLabel={<FormattedMessage id="ui-inventory.resourceIdentifierTypes" />}

--- a/src/settings/InstanceNoteTypesSettings.js
+++ b/src/settings/InstanceNoteTypesSettings.js
@@ -29,6 +29,9 @@ class InstanceNoteTypesSettings extends React.Component {
             {...this.props}
             baseUrl="instance-note-types"
             records="instanceNoteTypes"
+            tableName="instanceNoteTypes"
+            appName="ui-inventory"
+            translatableFields={['name']}
             label={<FormattedMessage id="ui-inventory.instanceNoteTypes" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.instanceNoteType' })}
             objectLabel={<FormattedMessage id="ui-inventory.instanceNoteTypes" />}

--- a/src/settings/InstanceStatusTypesSettings.js
+++ b/src/settings/InstanceStatusTypesSettings.js
@@ -34,6 +34,9 @@ class InstanceStatusTypesSettings extends React.Component {
             {...this.props}
             baseUrl="instance-statuses"
             records="instanceStatuses"
+            tableName="instanceStatuses"
+            appName="ui-inventory"
+            translatableFields={['name']}
             label={<FormattedMessage id="ui-inventory.instanceStatusTypes" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.instanceStatusType' })}
             objectLabel={<FormattedMessage id="ui-inventory.contributors" />}

--- a/src/settings/ItemNoteTypesSettings.js
+++ b/src/settings/ItemNoteTypesSettings.js
@@ -29,6 +29,9 @@ class ItemNoteTypesSettings extends React.Component {
             {...this.props}
             baseUrl="item-note-types"
             records="itemNoteTypes"
+            tableName="itemNoteTypes"
+            appName="ui-inventory"
+            translatableFields={['name']}
             label={<FormattedMessage id="ui-inventory.itemNoteTypes" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.itemNoteType' })}
             objectLabel={<FormattedMessage id="ui-inventory.itemNoteTypes" />}

--- a/src/settings/LoanTypesSettings.js
+++ b/src/settings/LoanTypesSettings.js
@@ -29,6 +29,9 @@ class LoanTypesSettings extends React.Component {
             {...this.props}
             baseUrl="loan-types"
             records="loantypes"
+            tableName="loantypes"
+            appName="ui-inventory"
+            translatableFields={['name']}
             label={<FormattedMessage id="ui-inventory.loanTypes" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.loanType' })}
             objectLabel={<FormattedMessage id="ui-inventory.loans" />}

--- a/src/settings/MaterialTypesSettings.js
+++ b/src/settings/MaterialTypesSettings.js
@@ -29,6 +29,9 @@ class MaterialTypesSettings extends React.Component {
             {...this.props}
             baseUrl="material-types"
             records="mtypes"
+            tableName="materialTypes"
+            appName="ui-inventory"
+            translatableFields={['name']}
             label={<FormattedMessage id="ui-inventory.materialTypes" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.materialType' })}
             objectLabel={<FormattedMessage id="ui-inventory.items" />}

--- a/src/settings/ModesOfIssuanceSettings.js
+++ b/src/settings/ModesOfIssuanceSettings.js
@@ -32,6 +32,9 @@ class ModesOfIssuanceSettings extends React.Component {
             {...this.props}
             baseUrl="modes-of-issuance"
             records="issuanceModes"
+            tableName="issuanceModes"
+            appName="ui-inventory"
+            translatableFields={['name']}
             label={<FormattedMessage id="ui-inventory.modesOfIssuance" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.modeOfIssuance' })}
             objectLabel={<FormattedMessage id="ui-inventory.modesOfIssuance" />}

--- a/src/settings/NatureOfContentTermsSettings.js
+++ b/src/settings/NatureOfContentTermsSettings.js
@@ -32,6 +32,9 @@ class NatureOfContentTermsSettings extends React.Component {
             {...this.props}
             baseUrl="nature-of-content-terms"
             records="natureOfContentTerms"
+            tableName="natureOfContentTerms"
+            appName="ui-inventory"
+            translatableFields={['name']}
             label={<FormattedMessage id="ui-inventory.natureOfContentTerms" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.natureOfContentTerm' })}
             objectLabel={<FormattedMessage id="ui-inventory.natureOfContentTerms" />}

--- a/src/settings/ResourceTypesSettings.js
+++ b/src/settings/ResourceTypesSettings.js
@@ -34,6 +34,9 @@ class ResourceTypesSettings extends React.Component {
             {...this.props}
             baseUrl="instance-types"
             records="instanceTypes"
+            tableName="instanceTypes"
+            appName="ui-inventory"
+            translatableFields={['name']}
             label={<FormattedMessage id="ui-inventory.resourceTypes" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.resourceType' })}
             objectLabel={<FormattedMessage id="ui-inventory.resourceTypes" />}

--- a/src/settings/StatisticalCodeSettings.js
+++ b/src/settings/StatisticalCodeSettings.js
@@ -117,6 +117,9 @@ class StatisticalCodeSettings extends React.Component {
             stripes={this.props.stripes}
             baseUrl="statistical-codes"
             records="statisticalCodes"
+            tableName="statisticalCodes"
+            appName="ui-inventory"
+            translatableFields={['name']}
             formatter={formatter}
             fieldComponents={fieldComponents}
             label={<FormattedMessage id="ui-inventory.statisticalCodes" />}

--- a/src/settings/StatisticalCodeTypes.js
+++ b/src/settings/StatisticalCodeTypes.js
@@ -29,6 +29,9 @@ class StatisticalCodeTypes extends React.Component {
             {...this.props}
             baseUrl="statistical-code-types"
             records="statisticalCodeTypes"
+            tableName="statisticalCodeTypes"
+            appName="ui-inventory"
+            translatableFields={['name']}
             label={<FormattedMessage id="ui-inventory.statisticalCodeTypes" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.statisticalCodeTypes' })}
             objectLabel={<FormattedMessage id="ui-inventory.statisticalCodeTypes" />}

--- a/src/settings/URLRelationshipSettings.js
+++ b/src/settings/URLRelationshipSettings.js
@@ -29,6 +29,9 @@ class URLRelationshipSettings extends React.Component {
             {...this.props}
             baseUrl="electronic-access-relationships"
             records="electronicAccessRelationships"
+            tableName="electronicAccessRelationships"
+            appName="ui-inventory"
+            translatableFields={['name']}
             label={<FormattedMessage id="ui-inventory.URLrelationship" />}
             labelSingular={intl.formatMessage({ id: 'ui-inventory.urlRelationshipTerm' })}
             objectLabel={<FormattedMessage id="ui-inventory.URLrelationship" />}


### PR DESCRIPTION
## Description
Each FOLIO installation has lists of controlled vocabulary terms (for instance, “Formats” and “Resource types” in Inventory, “Patron Groups” and “Refund Reasons” in Users — see FOLIO-2802 for a more complete list).  In installations that use more than one language, these terms do not display translated values when the locale of the session is changed.

## Use case(s)
For stripes apps that have a controlled vocabulary that has been translated by the translation app, we need to show the translated vocabularies instead of the values fetched from the DB by replacing the fetched values with their own translation key (The translation key can be found by the translation app).
>This PR is concerned with instanceForm and instanceFilters components, so if you translate the inventory-controlled -vocabularies, you can see the translations effect directly on these components. 

## Workflow
For the complete translation workflow, see [Workflow](https://github.com/folio-org/ui-translations/blob/master/README.md#workflow)

## Jira Related Issues Links
https://issues.folio.org/browse/UXPROD-3148 <br />
https://issues.folio.org/browse/FOLIO-3258 <br />
https://issues.folio.org/browse/UXPROD-515 <br />
https://issues.folio.org/browse/FOLIO-2802