### PR TITLE
UIIN-1569 Make sure building inventory module works with babel-plugin-lodash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Fix instance duplication when child or parent records are present. Fixes UIIN-1562.
 * Add bound-with icons and item detail view header note. Refs UIIN-1522, UIIN-1523, UIIN-1524.
 * Retrieve and display select Piece information on Holding. Refs UIIN-1502.
-
+* Make sure building inventory module works with `babel-plugin-lodash`. Refs UIIN-1569.
 
 ## [7.1.2](https://github.com/folio-org/ui-inventory/tree/v7.1.2) (2021-07-14)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.1...v7.1.2)

--- a/src/hooks/useLoadSubInstances.js
+++ b/src/hooks/useLoadSubInstances.js
@@ -1,7 +1,10 @@
 import {
   keyBy,
   isEqual,
-  chain,
+  map,
+  flow,
+  sortBy,
+  filter,
 } from 'lodash';
 import {
   useEffect,
@@ -17,9 +20,9 @@ const useLoadSubInstances = (instanceIds = [], subId) => {
   const [subInstances, setSubInstances] = useState([]);
   const results = useInstancesQuery(instanceIds.map(inst => inst[subId]));
   const allLoaded = results.reduce((acc, { isSuccess }) => (isSuccess && acc), true);
-  const instances = chain(results)
-    .filter(({ data }) => data)
-    .map(({
+  const instances = flow(
+    items => filter(items, ({ data }) => data),
+    items => map(items, ({
       data: {
         id,
         title,
@@ -33,10 +36,9 @@ const useLoadSubInstances = (instanceIds = [], subId) => {
       hrid,
       publication,
       identifiers,
-    }))
-    .sortBy('title')
-    .value();
-
+    })),
+    items => sortBy(items, 'title')
+  )(results);
   const shouldUpdateSubInstances = allLoaded && !isEqual(subInstances, instances);
 
   useEffect(() => {


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1569

`babel-plugin-lodash` currently complains about lodash using chain sequences. 

This PR refactors it to use `flow`.

````
inventory/src/hooks/useLoadSubInstances.js: Lodash chain sequences are not supported by babel-plugin-lodash.
Consider substituting chain sequences with composition patterns.
See https://medium.com/making-internets/why-using-chain-is-a-mistake-9bc1f80d51ba
  22 |   const results = useInstancesQuery(instanceIds.map(inst => inst[subId]));
  23 |   const allLoaded = results.reduce((acc, { isSuccess }) => (isSuccess && acc), true);
> 24 |   const instances = chain(results)
````

More info:

https://medium.com/bootstart/why-using-chain-is-a-mistake-9bc1f80d51ba

We need this in place in order to finalize work on https://issues.folio.org/browse/STRWEB-20