### PR TITLE
UIIN-1634 only search requests should use mod-search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Item count bug when there are multiple holdings on an instance. Refs UIIN-1617.
 * Incorporate `ui-inventory-search` facets. Refs UIIN-1567.
 * Update received piece table columns. Refs UIIN-1632.
+* Restore `mod-inventory` endpoints for non-search requests. UIIN-1634.
 
 ## [7.1.4](https://github.com/folio-org/ui-inventory/tree/v7.1.4) (2021-08-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.3...v7.1.4)

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -66,8 +66,9 @@ export function buildManifestObject() {
       records: 'instances',
       resultOffset: '%{resultOffset}',
       perRequest: 100,
-      path: 'search/instances',
+      path: 'inventory/instances',
       GET: {
+        path: 'search/instances',
         params: { query: buildQuery },
         staticFallback: { params: {} },
       },


### PR DESCRIPTION
When we implemented ElasticSearch, all requests, instead of only `GET`
requests, were redirected to the mod-search endpoints. This restores the
mod-inventory endpoints for `POST`, `PUT`, and `DELETE` requests,
restoring the ability to create, edit, and remove records.

Refs [UIIN-1634](https://issues.folio.org/browse/UIIN-1634)