### PR TITLE
UIIN-1635 WIP explain OL conflicts in a modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Item count bug when there are multiple holdings on an instance. Refs UIIN-1617.
 * Incorporate `ui-inventory-search` facets. Refs UIIN-1567.
 * Update received piece table columns. Refs UIIN-1632.
+* Show an explanatory modal when PUT requests fail due to update conflicts. Refs UIIN-1635.
 
 ## [7.1.4](https://github.com/folio-org/ui-inventory/tree/v7.1.4) (2021-08-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.3...v7.1.4)

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -9,6 +9,7 @@ import { OnChange } from 'react-final-form-listeners';
 import { withRouter } from 'react-router';
 
 import {
+  Modal,
   Paneset,
   Pane,
   PaneFooter,
@@ -855,6 +856,16 @@ class ItemForm extends React.Component {
                   </Accordion>
                 </AccordionSet>
               </AccordionStatus>
+              <Modal
+                data-test-missingConfirmation-modal
+                open={this.props.olModal}
+                label="Optimistic Locking Conflict"
+                dismissible
+                size="small"
+                onClose={this.props.hideOlModal}
+              >
+                <h1>Boom shakalaka</h1>
+              </Modal>
             </Pane>
           </Paneset>
         </HasCommand>

--- a/src/routes/ItemRoute.js
+++ b/src/routes/ItemRoute.js
@@ -26,7 +26,7 @@ class ItemRoute extends React.Component {
       type: 'okapi',
       path: 'inventory/items/:{itemid}',
       POST: { path: 'inventory/items' },
-      resourceShouldRefresh: true,
+      throwErrors: false,
     },
     markItemAsWithdrawn: {
       type: 'okapi',

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -96,6 +96,7 @@ class ItemView extends React.Component {
       confirmDeleteItemModal: false,
       cannotDeleteItemModal: false,
       selectedItemStatus: '',
+      olModal: false,
     };
 
     this.craftLayerUrl = craftLayerUrl.bind(this);
@@ -117,16 +118,22 @@ class ItemView extends React.Component {
       delete item.barcode;
     }
 
-    return this.props.mutator.items.PUT(item).then(() => {
-      this.context.sendCallout({
-        type: 'success',
-        message: <FormattedMessage
-          id="ui-inventory.item.successfullySaved"
-          values={{ hrid: item.hrid }}
-        />,
+    return this.props.mutator.items.PUT(item)
+      .then(() => {
+        this.context.sendCallout({
+          type: 'success',
+          message: <FormattedMessage
+            id="ui-inventory.item.successfullySaved"
+            values={{ hrid: item.hrid }}
+          />,
+        });
+        this.onClickCloseEditItem();
+      })
+      .catch((res) => {
+        res.text().then(text => {
+          this.setState({ olModal: true });
+        });
       });
-      this.onClickCloseEditItem();
-    });
   };
 
   copyItem = item => {
@@ -193,6 +200,10 @@ class ItemView extends React.Component {
       this.props.mutator.requests.PUT(newRequestRecord);
     }
   }
+
+  hideOlModal = () => {
+    this.setState({ olModal: false });
+  };
 
   hideMissingModal = () => {
     this.setState({ itemMissingModal: false });
@@ -1456,6 +1467,8 @@ class ItemView extends React.Component {
                   holdingsRecord={holdingsRecord}
                   referenceTables={referenceTables}
                   stripes={this.props.stripes}
+                  olModal={this.state.olModal}
+                  hideOlModal={this.hideOlModal}
                 />
               </Layer>
               <Layer


### PR DESCRIPTION
When a PUT request fails due to an optimistic locking conflict (i.e. the
representation of the object in storage has changed) show a modal
explaining the situation, i.e. changes cannot be saved.

WIP: ATM, this branch only handles item record changes, needs i18n, needs tests, doesn't quite match the expected UI, etc. _It's just a POC._ But hopefully it provides a useful template for instance and holdings-record implementation. It's possible/likely the modal should be refactored into a stand-alone component so it can easily be reused. I don't know if the state can be lifted up a level too, so it doesn't have to be copied around into instance/holdings/item views. 

Refs [UIIN-1635](https://issues.folio.org/browse/UIIN-1635)