### PR TITLE
UIIN-1647: Holdings record: Duplicate action should create a Inventory Holdings record with Source = FOLIO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change history for ui-inventory
 
-## [7.1.4](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
+## [8.1.0] IN PROGRESS
+
+* Change Holdings record source to FOLIO when Duplicate Holdings record. Refs UIIN-1647.
+
+## [8.0.0](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.4...v8.0.0)
 
 * Add bound-with indicator to item view. Refs UIIN-1518.

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -171,14 +171,14 @@ class ViewHoldingsRecord extends React.Component {
     const {
       referenceTables,
       resources: {
-        instances1,
+        holdingsRecords,
       },
     } = this.props;
 
-    const instance = instances1.records[0];
-    const instanceSource = referenceTables?.holdingsSources?.find(holdingsSource => holdingsSource.name === instance?.source);
+    const holdingsRecord = holdingsRecords.records[0];
+    const holdingsSource = referenceTables?.holdingsSources?.find(source => source.id === holdingsRecord?.sourceId);
 
-    return instanceSource?.name === 'MARC';
+    return holdingsSource?.name === 'MARC';
   };
 
   getMARCRecord = () => {
@@ -251,13 +251,23 @@ class ViewHoldingsRecord extends React.Component {
   }
 
   onCopy(record) {
+    const {
+      updateLocation,
+      referenceTables,
+    } = this.props;
+
+    const FOLIOSourceId = referenceTables?.holdingsSourcesByName.FOLIO.id;
+
     this.setState((state) => {
       const newState = cloneDeep(state);
+
       newState.copiedRecord = omit(record, ['id', 'hrid', 'formerIds']);
+      newState.copiedRecord.sourceId = FOLIOSourceId;
+
       return newState;
     });
 
-    this.props.updateLocation({ layer: 'copyHoldingsRecord' });
+    updateLocation({ layer: 'copyHoldingsRecord' });
   }
 
   hideConfirmHoldingsRecordDeleteModal = () => {


### PR DESCRIPTION
## Purpose

- Change Holdings record source to FOLIO when Duplicate Holdings record
- Change implementation for `isMARCSource` metod to check Holdings record source

Issue: [UIIN-1647](https://issues.folio.org/browse/UIIN-1647)
