### PR TITLE
UIIN-1806: Holdings record with MARC = Source > View Source and Edit in quickMARC actions are not readily available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Change Holdings record source to FOLIO when Duplicate Holdings record. Refs UIIN-1647.
 * Save Holdings UUIDs in the Inventory search result. Refs UIIN-1662.
 * Fix tag filter. Fixes UIIN-1809.
+* Fix MARC Holdings record > View Source and Edit in quickMARC actions are not available. Fixes UIIN-1806
 
 ## [8.0.0](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.4...v8.0.0)

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -160,7 +160,11 @@ class ViewHoldingsRecord extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.resources.instances1?.records[0]?.source !== this.props.resources.instances1?.records[0]?.source) {
+    const wasHoldingsRecordsPending = prevProps.resources.holdingsRecords?.isPending;
+    const isHoldingsRecordsPending = this.props.resources.holdingsRecords?.isPending;
+    const hasHoldingsRecordsLoaded = this.props.resources.holdingsRecords?.hasLoaded;
+
+    if (wasHoldingsRecordsPending !== isHoldingsRecordsPending && hasHoldingsRecordsLoaded) {
       if (this.isMARCSource() && !this.state.markRecord) {
         this.getMARCRecord();
       }
@@ -448,7 +452,7 @@ class ViewHoldingsRecord extends React.Component {
       temporaryLocation,
     } = this.props.resources;
 
-    if (!holdingsRecords || !holdingsRecords.hasLoaded) {
+    if (!holdingsRecords || holdingsRecords.isPending) {
       return true;
     }
 


### PR DESCRIPTION
## Description
Fix issue with MARC Holdings when upon opening a record `Source` value sometimes changes from `FOLIO` to `MARC` and vice versa. Also, in MARC Holdings records `View source` and `Edit in quickMARC` actions are disabled

There were two problems in the code:

1. In `componentDidUpdate` we were checking instance's source to see if we should load source marc record. That's not correct and we should check holdings' source
2. In `isAwaitingResource` we were checking `holdingsRecords.hasLoaded` to see if holdings record has loaded. This will give false positives in cases when we previously visited a holdings record and now are loading a second one. To fix this we need to check `isPending` property.

## Issues
[UIIN-1806](https://issues.folio.org/browse/UIIN-1806)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
