### PR TITLE
UIIN-1812 include missing permission in module.inventory.enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix tag filter. Fixes UIIN-1809.
 * Fix MARC Holdings record > View Source and Edit in quickMARC actions are not available. Fixes UIIN-1806
 * Call read-only fields for FOLIO holdings endpoint to get list of read-only fields. Refs UIIN-1655.
+* Add missing `search.instances.ids.collection.get` permission to `module.inventory.enabled`. Refs UIIN-1812.
 
 ## [8.0.0](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.4...v8.0.0)

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
           "search.index.mappings.item.post",
           "search.index.records.collection.post",
           "search.instances.collection.get",
+          "search.instances.ids.collection.get",
           "search.config.languages.item.post",
           "search.config.languages.collection.get",
           "search.config.languages.item.delete",
@@ -832,7 +833,7 @@
   "optionalDependencies": {
     "@folio/plugin-create-inventory-records": "^3.0.0",
     "@folio/plugin-find-instance": "^6.0.0",
-    "@folio/quick-marc": "^4.0.0"
+    "@folio/quick-marc": "^5.0.0"
   },
   "resolutions": {
     "babel-eslint/@babel/parser": "7.7.5",


### PR DESCRIPTION
The "default" permission set which is applied when the module is
enabled, `module.inventory.enabled`, was missing permission to retrieve
instance UUIDs, `search.instances.ids.collection.get`.

Refs [UIIN-1812](https://issues.folio.org/browse/UIIN-1812)