### PR TITLE
UIIN-1814: Fix parent and child relationship rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix MARC Holdings record > View Source and Edit in quickMARC actions are not available. Fixes UIIN-1806
 * Call read-only fields for FOLIO holdings endpoint to get list of read-only fields. Refs UIIN-1655.
 * Add missing `search.instances.ids.collection.get` permission to `module.inventory.enabled`. Refs UIIN-1812.
+* Fix parent and child relationship rendering. Fixes UIIN-1816 and UIIN-1814.
 
 ## [8.0.0](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.4...v8.0.0)

--- a/src/ViewInstanceWrapper.js
+++ b/src/ViewInstanceWrapper.js
@@ -13,7 +13,7 @@ const ViewInstanceWrapper = (props) => {
     resources,
   } = props;
   const instance = resources.instance?.records?.[0];
-  const selectedInstance = instance?.id === id ? instance : null;
+  let selectedInstance = instance?.id === id ? instance : null;
 
   // only load after instance is present
   const parentInstances = useLoadSubInstances(selectedInstance?.parentInstances, 'superInstanceId');
@@ -21,11 +21,11 @@ const ViewInstanceWrapper = (props) => {
 
   if (selectedInstance) {
     if (parentInstances?.length) {
-      selectedInstance.parentInstances = parentInstances;
+      selectedInstance = { ...selectedInstance, parentInstances };
     }
 
     if (childInstances?.length) {
-      selectedInstance.childInstances = childInstances;
+      selectedInstance = { ...childInstances, childInstances };
     }
   }
 

--- a/src/ViewInstanceWrapper.js
+++ b/src/ViewInstanceWrapper.js
@@ -25,7 +25,7 @@ const ViewInstanceWrapper = (props) => {
     }
 
     if (childInstances?.length) {
-      selectedInstance = { ...childInstances, childInstances };
+      selectedInstance = { ...selectedInstance, childInstances };
     }
   }
 


### PR DESCRIPTION
The issue here was that the existing `selectedInstance` var was mutated instead of recreated when sub instances were loaded. With in place mutations the child component was never re-rendered.

I think this was working fine before in react 16 so I wonder if this is some side effect of react 17.

https://issues.folio.org/browse/UIIN-1814
https://issues.folio.org/browse/UIIN-1816