### PR TITLE
UIIN-1832: Fix suppressed from discovery filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Bump data-export interface version to 5.0.
 * Revert elastic search. Refs UIIN-1822.
 * Use correct `css-loader` syntax. Refs UIIN-1826.
+* Fix suppressed from discovery filter. Fixes UIIN-1832.
 
 ## [8.0.0](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.4...v8.0.0)

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     ],
     "okapiInterfaces": {
       "inventory": "10.10 11.0",
+      "search": "0.5",
       "source-storage-records": "3.0",
       "instance-storage": "7.0 8.0",
       "holdings-storage": "3.0 4.4 5.0",
@@ -834,7 +835,7 @@
   "optionalDependencies": {
     "@folio/plugin-create-inventory-records": "^3.0.0",
     "@folio/plugin-find-instance": "^6.0.0",
-    "@folio/quick-marc": "^5.0.0"
+    "@folio/quick-marc": "^4.0.1"
   },
   "resolutions": {
     "babel-eslint/@babel/parser": "7.7.5",

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -6,7 +6,6 @@ import {
 
 import {
   buildDateRangeQuery,
-  buildOptionalBooleanQuery,
 } from './utils';
 
 export const instanceFilterConfig = [
@@ -52,13 +51,13 @@ export const instanceFilterConfig = [
     name: 'staffSuppress',
     cql: 'staffSuppress',
     values: [],
-    parse: buildOptionalBooleanQuery('staffSuppress'),
+    operator: '==',
   },
   {
     name: 'discoverySuppress',
     cql: 'discoverySuppress',
     values: [],
-    parse: buildOptionalBooleanQuery('discoverySuppress'),
+    operator: '==',
   },
   {
     name: 'createdDate',
@@ -133,7 +132,7 @@ export const holdingFilterConfig = [
     name: 'discoverySuppress',
     cql: 'holdings.discoverySuppress',
     values: [],
-    parse: buildOptionalBooleanQuery('holdings.discoverySuppress'),
+    operator: '==',
   },
   {
     name: 'tags',
@@ -182,7 +181,7 @@ export const itemFilterConfig = [
     name: 'discoverySuppress',
     cql: 'items.discoverySuppress',
     values: [],
-    parse: buildOptionalBooleanQuery('items.discoverySuppress'),
+    operator: '==',
   },
   {
     name: 'tags',


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1832

When `discoverySupress` is undefined it is interpreted as false in mod-search. This differs from how mod-inventory was dealing with it.
