### PR TITLE
UIIN-1838: Fix successful toast appears after clicking on In transit items report (CSV)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Change search operators for ISBN and ISSN to '='. Fixes UIIN-1846.
 * Allow user to sort receiving history table. Refs UIIN-1824.
 * Change search operator for "Identifier (all)" index to '='. Fixes UIIN-1855.
+* Fix successful toast appears after clicking on `In transit items report (CSV)`. Refs UIIN-1838.
 
 ## [8.0.0](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.4...v8.0.0)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -236,7 +236,6 @@ class InstancesList extends React.Component {
     } = this.props;
     const { sendCallout, removeCallout } = this.context;
     const calloutId = sendCallout({
-      type: 'info',
       message: <FormattedMessage id="ui-inventory.exportInProgress" />,
       timeout: 0,
     });

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -520,6 +520,7 @@
   "item.status.withdrawn": "Withdrawn",
   "item.status.statusUpdatedLabel": "status updated {statusDate}",
   "item.status.inTransitTo": "In transit to {servicePoint}",
+  "exportInProgress": "Export in progress",
   "inTransitReport": "In transit items report (CSV)",
   "saveInstancesUIIDS": "Save instances UUIDs",
   "saveInstancesUIIDS.info": "Request to save instances UUIDs has been received. File download may take a few minutes.",


### PR DESCRIPTION
## Purpose
Fix successful toast appears after clicking on In transit items report (CSV)

## Approach
- Changed toast from info to success 
- Added missing translation

## Stories
https://issues.folio.org/browse/UIIN-1838
