### PR TITLE
UIIN-1846: Change search operators for ISBN and ISSN to '='

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Use correct `css-loader` syntax. Refs UIIN-1826.
 * Fix suppressed from discovery filter. Fixes UIIN-1832.
 * Create a MARC Holdings Record. Refs UIIN-1828.
+* Change search operators for ISBN and ISSN to '='. Fixes UIIN-1846.
 
 ## [8.0.0](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.4...v8.0.0)

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -90,8 +90,8 @@ export const instanceIndexes = [
   { label: 'ui-inventory.contributor', value: 'contributor', queryTemplate: 'contributors="%{query.query}"' },
   { label: 'ui-inventory.title', value: 'title', queryTemplate: 'title all "%{query.query}"' },
   { label: 'ui-inventory.identifierAll', value: 'identifier', queryTemplate: 'identifiers.value=="%{query.query}"' },
-  { label: 'ui-inventory.isbn', value: 'isbn', queryTemplate: 'isbn=="%{query.query}"' },
-  { label: 'ui-inventory.issn', value: 'issn', queryTemplate: 'issn=="%{query.query}"' },
+  { label: 'ui-inventory.isbn', value: 'isbn', queryTemplate: 'isbn="%{query.query}"' },
+  { label: 'ui-inventory.issn', value: 'issn', queryTemplate: 'issn="%{query.query}"' },
   { label: 'ui-inventory.subject', value: 'subject', queryTemplate: 'subjects="%{query.query}"' },
   { label: 'ui-inventory.instanceHrid', value: 'hrid', queryTemplate: 'hrid=="%{query.query}"' },
   { label: 'ui-inventory.instanceId', value: 'id', queryTemplate: 'id="%{query.query}"' },
@@ -106,8 +106,8 @@ export const instanceSortMap = {
 
 export const holdingIndexes = [
   { label: 'ui-inventory.search.all', value: 'all', queryTemplate: 'keyword all "%{query.query}"' },
-  { label: 'ui-inventory.isbn', value: 'isbn', queryTemplate: 'isbn=="%{query.query}"' },
-  { label: 'ui-inventory.issn', value: 'issn', queryTemplate: 'issn=="%{query.query}"' },
+  { label: 'ui-inventory.isbn', value: 'isbn', queryTemplate: 'isbn="%{query.query}"' },
+  { label: 'ui-inventory.issn', value: 'issn', queryTemplate: 'issn="%{query.query}"' },
   { label: 'ui-inventory.callNumberEyeReadable',
     value: 'callNumberER',
     queryTemplate: 'holdings.fullCallNumber=="%{query.query}"' },
@@ -145,8 +145,8 @@ export const holdingFilterConfig = [
 export const itemIndexes = [
   { label: 'ui-inventory.search.all', value: 'all', queryTemplate: 'keyword all "%{query.query}"' },
   { label: 'ui-inventory.barcode', value: 'items.barcode', queryTemplate: 'items.barcode=="%{query.query}"' },
-  { label: 'ui-inventory.isbn', value: 'isbn', queryTemplate: 'isbn=="%{query.query}"' },
-  { label: 'ui-inventory.issn', value: 'issn', queryTemplate: 'issn=="%{query.query}"' },
+  { label: 'ui-inventory.isbn', value: 'isbn', queryTemplate: 'isbn="%{query.query}"' },
+  { label: 'ui-inventory.issn', value: 'issn', queryTemplate: 'issn="%{query.query}"' },
   { label: 'ui-inventory.itemEffectiveCallNumberEyeReadable',
     value: 'itemCallNumberER',
     queryTemplate: 'items.effectiveCallNumberComponents=="%{query.query}"' },


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1846

Based on the feedback from @magdazacharska it looks like `==` has to be replaced by `=` to make sure ISBN and ISSN work correctly.