### PR TITLE
UIIN-1854: After saving and updating a holdings record, the user is returned to the holdings instead of instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Change search operator for "Identifier (all)" index to '='. Fixes UIIN-1855.
 * Fix successful toast appears after clicking on `In transit items report (CSV)`. Refs UIIN-1838.
 * Add permission for marking item as `In process`. Fixes UIIN-1654.
+* Fix after saving and updating a holdings record, the user is returned to the instance record. Fixes UIIN-1854
 
 ## [8.0.0](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.4...v8.0.0)

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -226,6 +226,8 @@ class ViewHoldingsRecord extends React.Component {
     if (holdings.permanentLocationId === '') delete holdings.permanentLocationId;
     if (holdings.temporaryLocationId === '') delete holdings.temporaryLocationId;
 
+    // adding a local state variable to overcome a delay in `isPending`
+    // is false between PUT to update and GET request to refresh a record
     this.setState({ isLoadingUpdatedHoldingsRecord: true });
 
     return this.props.mutator.holdingsRecords.PUT(holdings).then(() => {

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -6,6 +6,7 @@ import {
   cloneDeep,
   omit,
   orderBy,
+  last,
 } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
@@ -182,19 +183,16 @@ class ViewHoldingsRecord extends React.Component {
     }
   }
 
-  componentWillUnmount() {
-    this.props.mutator.holdingsRecords.reset();
+  getMostRecentHolding = () => {
+    return last(this.props.resources.holdingsRecords.records);
   }
 
   isMARCSource = () => {
     const {
       referenceTables,
-      resources: {
-        holdingsRecords,
-      },
     } = this.props;
 
-    const holdingsRecord = holdingsRecords.records[0];
+    const holdingsRecord = this.getMostRecentHolding();
     const holdingsSource = referenceTables?.holdingsSources?.find(source => source.id === holdingsRecord?.sourceId);
 
     return holdingsSource?.name === 'MARC';
@@ -238,10 +236,11 @@ class ViewHoldingsRecord extends React.Component {
           values={{ hrid: holdingsRecord.hrid }}
         />,
       });
+
       this.props.mutator.holdingsRecords.GET().then(() => {
         this.setState({ isLoadingUpdatedHoldingsRecord: false });
+        this.onClickCloseEditHoldingsRecord();
       });
-      this.onClickCloseEditHoldingsRecord();
     });
   }
 
@@ -349,12 +348,11 @@ class ViewHoldingsRecord extends React.Component {
       location,
       goTo,
       resources: {
-        holdingsRecords,
         instances1,
       },
     } = this.props;
 
-    const holdingsRecord = holdingsRecords.records[0];
+    const holdingsRecord = this.getMostRecentHolding();
 
     const searchParams = new URLSearchParams(location.search);
     searchParams.append('relatedRecordVersion', holdingsRecord._version);
@@ -381,7 +379,7 @@ class ViewHoldingsRecord extends React.Component {
       return null;
     }
 
-    const firstRecordOfHoldings = resources.holdingsRecords.records[0];
+    const firstRecordOfHoldings = this.getMostRecentHolding();
 
     return (
       <>
@@ -483,7 +481,7 @@ class ViewHoldingsRecord extends React.Component {
       return true;
     }
 
-    const holdingsRecord = holdingsRecords.records[0];
+    const holdingsRecord = this.getMostRecentHolding();
 
     if (!instances1 || !instances1.hasLoaded
       || (holdingsRecord.permanentLocationId && (!permanentLocation || !permanentLocation.hasLoaded))
@@ -494,14 +492,13 @@ class ViewHoldingsRecord extends React.Component {
     return false;
   };
 
-  getEntity = () => this.props.resources.holdingsRecords.records[0];
-  getEntityTags = () => this.props.resources.holdingsRecords.records[0]?.tags?.tagList || [];
+  getEntity = () => this.getMostRecentHolding();
+  getEntityTags = () => this.getMostRecentHolding()?.tags?.tagList || [];
 
   render() {
     const {
       location,
       resources: {
-        holdingsRecords,
         instances1,
         permanentLocation,
         temporaryLocation,
@@ -520,7 +517,7 @@ class ViewHoldingsRecord extends React.Component {
 
     const instance = instances1.records[0];
     const instanceSource = referenceTables?.holdingsSources?.find(source => source.name === instance.source);
-    const holdingsRecord = holdingsRecords.records[0];
+    const holdingsRecord = this.getMostRecentHolding();
     const holdingsSource = referenceTables?.holdingsSources?.find(source => source.id === holdingsRecord.sourceId);
     const holdingsPermanentLocation = holdingsRecord.permanentLocationId ? permanentLocation.records[0] : null;
     const holdingsTemporaryLocation = holdingsRecord.temporaryLocationId ? temporaryLocation.records[0] : null;


### PR DESCRIPTION
## Description
Fix issue when updating a Holdings record. After successful update user should see an updated record, but instead they see a Instance record first and Holdings record later.
This issue is probably caused by delays in `stripes-connect` between `UPDATE_SUCCESS` and `REFRESH` actions. Initially I tried adding a `isUpdating` property to `holdingsRecords` resource, but this delay made it difficult to write correct conditions to check when a record has been updated and refreshed.

## Approach
So eventually I decided to handle updating and refreshing Holdings record manually with a combination of `GET` and `reset` methods.
Added a `isLoadingUpdatedHoldingsRecord` which tells us if a record was updated and refreshed. In `isAwaitingResource` we're using this flag to show a loading message.
Also, calling `GET` in `didMount` to fetch Holdings record and call `reset` in `willUnmount` to clear `holdingsRecords.records` array otherwise when viewing several records user will only see the first loaded because of `holdingsRecords.records[0]`.

## Issues
[UIIN-1854](https://issues.folio.org/browse/UIIN-1854)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
