### PR TITLE
UIIN-1853: Add canDelete property to HoldingsStatements fields

### DIFF
--- a/src/edit/holdings/holdingsStatementFields.js
+++ b/src/edit/holdings/holdingsStatementFields.js
@@ -6,7 +6,7 @@ import { TextArea } from '@folio/stripes/components';
 
 import RepeatableField from '../../components/RepeatableField';
 
-const HoldingsStatementFields = ({ canAdd, canEdit }) => (
+const HoldingsStatementFields = ({ canAdd, canEdit, canDelete }) => (
   <RepeatableField
     name="holdingsStatements"
     label={<FormattedMessage id="ui-inventory.holdingsStatements" />}
@@ -34,17 +34,20 @@ const HoldingsStatementFields = ({ canAdd, canEdit }) => (
     ]}
     canAdd={canAdd}
     canEdit={canEdit}
+    canDelete={canDelete}
   />
 );
 
 HoldingsStatementFields.propTypes = {
   canAdd: PropTypes.bool,
   canEdit: PropTypes.bool,
+  canDelete: PropTypes.bool,
 };
 
 HoldingsStatementFields.defaultProps = {
   canAdd: true,
   canEdit: true,
+  canDelete: true,
 };
 
 export default HoldingsStatementFields;

--- a/src/edit/holdings/holdingsStatementForIndexesFields.js
+++ b/src/edit/holdings/holdingsStatementForIndexesFields.js
@@ -6,7 +6,7 @@ import { TextArea } from '@folio/stripes/components';
 
 import RepeatableField from '../../components/RepeatableField';
 
-const HoldingsStatementForIndexesFields = ({ canAdd, canEdit }) => (
+const HoldingsStatementForIndexesFields = ({ canAdd, canEdit, canDelete }) => (
   <RepeatableField
     name="holdingsStatementsForIndexes"
     addLabel={<FormattedMessage id="ui-inventory.addHoldingsStatementForIndexes" />}
@@ -33,17 +33,20 @@ const HoldingsStatementForIndexesFields = ({ canAdd, canEdit }) => (
     ]}
     canAdd={canAdd}
     canEdit={canEdit}
+    canDelete={canDelete}
   />
 );
 
 HoldingsStatementForIndexesFields.propTypes = {
   canAdd: PropTypes.bool,
   canEdit: PropTypes.bool,
+  canDelete: PropTypes.bool,
 };
 
 HoldingsStatementForIndexesFields.defaultProps = {
   canAdd: true,
   canEdit: true,
+  canDelete: true,
 };
 
 export default HoldingsStatementForIndexesFields;

--- a/src/edit/holdings/holdingsStatementForSupplementsFields.js
+++ b/src/edit/holdings/holdingsStatementForSupplementsFields.js
@@ -6,7 +6,7 @@ import { TextArea } from '@folio/stripes/components';
 
 import RepeatableField from '../../components/RepeatableField';
 
-const HoldingsStatementForSupplementsFields = ({ canAdd, canEdit }) => (
+const HoldingsStatementForSupplementsFields = ({ canAdd, canEdit, canDelete }) => (
   <RepeatableField
     name="holdingsStatementsForSupplements"
     addLabel={<FormattedMessage id="ui-inventory.addHoldingsStatementForSupplements" />}
@@ -33,17 +33,20 @@ const HoldingsStatementForSupplementsFields = ({ canAdd, canEdit }) => (
     ]}
     canAdd={canAdd}
     canEdit={canEdit}
+    canDelete={canDelete}
   />
 );
 
 HoldingsStatementForSupplementsFields.propTypes = {
   canAdd: PropTypes.bool,
   canEdit: PropTypes.bool,
+  canDelete: PropTypes.bool,
 };
 
 HoldingsStatementForSupplementsFields.defaultProps = {
   canAdd: true,
   canEdit: true,
+  canDelete: true,
 };
 
 export default HoldingsStatementForSupplementsFields;


### PR DESCRIPTION
## Description
Add `canDelete` props to components for HoldingsStatements fields. Previously they didn't pass on these properties to RepeatableField

## Issues
[UIIN-1853](https://issues.folio.org/browse/UIIN-1853)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
