### PR TITLE
UIIN-1656: Use correct metadata on item form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fix successful toast appears after clicking on `In transit items report (CSV)`. Refs UIIN-1838.
 * Add permission for marking item as `In process`. Fixes UIIN-1654.
 * Holdings record with source MARC - do not allow user to delete mapped field values. Refs UIIN-1853.
+* Use correct metadata on item form. Fixes UIIN-1656.
 
 ## [8.0.0](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.4...v8.0.0)

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -375,7 +375,7 @@ class ItemForm extends React.Component {
                       <Col
                         sm={5}
                       >
-                        {(item.metadata && item.metadata.createdDate) &&
+                        {(item?.metadata && item?.metadata?.createdDate) &&
                         <this.cViewMetaData metadata={item.metadata} />
                         }
                         {/* <Field label="Material Type" name="materialType.name" id="additem_materialType" component={TextField} fullWidth /> */}

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -181,6 +181,7 @@ class ItemForm extends React.Component {
       initialValues,
       instance,
       holdingsRecord,
+
       referenceTables: {
         locationsById,
         materialTypes,
@@ -199,6 +200,7 @@ class ItemForm extends React.Component {
     } = this.props;
 
     const holdingLocation = locationsById[holdingsRecord.permanentLocationId];
+    const item = initialValues;
 
     const refLookup = (referenceTable, id) => {
       const ref = (referenceTable && id) ? referenceTable.find(record => record.id === id) : {};
@@ -373,8 +375,8 @@ class ItemForm extends React.Component {
                       <Col
                         sm={5}
                       >
-                        {(holdingsRecord.metadata && holdingsRecord.metadata.createdDate) &&
-                        <this.cViewMetaData metadata={holdingsRecord.metadata} />
+                        {(item.metadata && item.metadata.createdDate) &&
+                        <this.cViewMetaData metadata={item.metadata} />
                         }
                         {/* <Field label="Material Type" name="materialType.name" id="additem_materialType" component={TextField} fullWidth /> */}
                       </Col>


### PR DESCRIPTION
Use correct metadata on item form. The previous version was using `holdingsRecord` which was wrong since we deal with the item record.

https://issues.folio.org/browse/UIIN-1656

