### PR TITLE
UIIN-1620: Create title level request from Instance record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Expand acquisition accordion when displaying Order information on Instance record. Refs UIIN-1886.
 * Also support `circulation` `12.0`. Refs UIIN-1861.
 * SRS display. MARC indicators may be misaligned. Refs UIIN-1859.
+* Create title level request from Instance record. Refs UIIN-1620.
 
 ## [8.0.0](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.4...v8.0.0)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -1,6 +1,6 @@
 import { get } from 'lodash';
 import React, {
-  createRef
+  createRef,
 } from 'react';
 import PropTypes from 'prop-types';
 import { parse } from 'query-string';
@@ -34,8 +34,14 @@ import makeConnectedInstance from './ConnectedInstance';
 import withLocation from './withLocation';
 import InstancePlugin from './components/InstancePlugin';
 import { getPublishingInfo } from './Instance/InstanceDetails/utils';
-import { getDate, handleKeyCommand } from './utils';
-import { indentifierTypeNames, layers } from './constants';
+import {
+  getDate,
+  handleKeyCommand,
+} from './utils';
+import {
+  indentifierTypeNames,
+  layers,
+} from './constants';
 import { DataContext } from './contexts';
 
 import {
@@ -46,6 +52,15 @@ import {
 import { CalloutRenderer } from './components';
 
 import ImportRecordModal from './components/ImportRecordModal';
+import NewInstanceRequestButton from './components/ViewInstance/MenuSection/NewInstanceRequestButton';
+
+const getTlrSettings = (settings) => {
+  try {
+    return JSON.parse(settings);
+  } catch (error) {
+    return {};
+  }
+};
 
 class ViewInstance extends React.Component {
   static manifest = Object.freeze({
@@ -101,7 +116,15 @@ class ViewInstance extends React.Component {
       type: 'okapi',
       records: 'locations',
       path: 'locations?limit=1000',
-    }
+    },
+    configs: {
+      type: 'okapi',
+      records: 'configs',
+      path: 'configurations/entries',
+      params: {
+        query: '(module==SETTINGS and configName==TLR)',
+      },
+    },
   });
 
   constructor(props) {
@@ -318,8 +341,10 @@ class ViewInstance extends React.Component {
       onCopy,
       stripes,
       intl,
+      resources: { configs },
     } = this.props;
     const { marcRecord, requests } = this.state;
+    const { titleLevelRequestsFeatureEnabled } = getTlrSettings(configs.records[0]?.value);
 
     const isSourceMARC = get(instance, ['source'], '') === 'MARC';
     const canEditInstance = stripes.hasPerm('ui-inventory.instance.edit');
@@ -457,6 +482,11 @@ class ViewInstance extends React.Component {
               />
             </Icon>
           </Button>
+
+          <NewInstanceRequestButton
+            isTlrEnabled={titleLevelRequestsFeatureEnabled}
+            instanceId={instance.id}
+          />
         </MenuSection>
 
         {
@@ -730,6 +760,7 @@ ViewInstance.propTypes = {
     allInstanceItems: PropTypes.object.isRequired,
     allInstanceHoldings: PropTypes.object.isRequired,
     locations: PropTypes.object.isRequired,
+    configs: PropTypes.object.isRequired,
   }).isRequired,
   stripes: PropTypes.shape({
     connect: PropTypes.func.isRequired,

--- a/src/components/ViewInstance/MenuSection/NewInstanceRequestButton.js
+++ b/src/components/ViewInstance/MenuSection/NewInstanceRequestButton.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useIntl } from 'react-intl';
+
+import { IfPermission } from '@folio/stripes/core';
+import {
+  Button,
+  Icon,
+} from '@folio/stripes/components';
+
+import { layers } from '../../../constants';
+
+export const getInstanceRequestLink = (instanceId) => `/requests?instanceId=${instanceId}&layer=${layers.CREATE}`;
+
+const NewInstanceRequestButton = ({
+  isTlrEnabled,
+  instanceId,
+}) => {
+  const { formatMessage } = useIntl();
+
+  if (!isTlrEnabled) {
+    return null;
+  }
+
+  return (
+    <IfPermission perm="ui-requests.create">
+      <Button
+        to={getInstanceRequestLink(instanceId)}
+        buttonStyle="dropdownItem"
+      >
+        <Icon icon="plus-sign">
+          {formatMessage({ id: 'ui-inventory.newRequest' })}
+        </Icon>
+      </Button>
+    </IfPermission>
+  );
+};
+
+NewInstanceRequestButton.propTypes = {
+  isTlrEnabled: PropTypes.bool.isRequired,
+  instanceId: PropTypes.string.isRequired,
+};
+
+export default NewInstanceRequestButton;

--- a/src/components/ViewInstance/MenuSection/NewInstanceRequestButton.test.js
+++ b/src/components/ViewInstance/MenuSection/NewInstanceRequestButton.test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import {
+  render,
+  screen,
+} from '@testing-library/react';
+
+import '../../../../test/jest/__mock__';
+
+import { IfPermission } from '@folio/stripes/core';
+
+import NewInstanceRequestButton, {
+  getInstanceRequestLink,
+} from './NewInstanceRequestButton';
+
+jest.mock('react-intl', () => {
+  const intl = {
+    formatMessage: ({ id }) => id,
+  };
+
+  return {
+    injectIntl: (Component) => (props) => <Component {...props} intl={intl} />,
+    useIntl: () => intl,
+  };
+});
+
+describe('NewInstanceRequestButton', () => {
+  const labelIds = {
+    newRequest: 'ui-inventory.newRequest',
+  };
+  const instanceId = 'testInstanceId';
+
+  afterEach(() => {
+    IfPermission.mockClear();
+  });
+
+  describe('when TLR in disabled', () => {
+    beforeEach(() => {
+      render(
+        <BrowserRouter>
+          <NewInstanceRequestButton
+            isTlrEnabled={false}
+            instanceId={instanceId}
+          />
+        </BrowserRouter>
+      );
+    });
+
+    it('should not render button', () => {
+      expect(screen.queryByText(labelIds.newRequest)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when TLR is enabled', () => {
+    beforeEach(() => {
+      render(
+        <BrowserRouter>
+          <NewInstanceRequestButton
+            isTlrEnabled
+            instanceId={instanceId}
+          />
+        </BrowserRouter>
+      );
+    });
+
+    it('should check user for permission to create requests', () => {
+      const expectedResult = {
+        perm: 'ui-requests.create',
+      };
+
+      expect(IfPermission).toHaveBeenCalledWith(expect.objectContaining(expectedResult), {});
+    });
+
+    it('should render Button with correct props', () => {
+      const expectedResult = getInstanceRequestLink(instanceId);
+
+      expect(screen.getByRole('button')).toHaveAttribute('href', expectedResult);
+      expect(screen.getByText(labelIds.newRequest)).toBeVisible();
+    });
+  });
+});

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -87,7 +87,7 @@ jest.mock('@folio/stripes/core', () => {
     Pluggable: props => <>{props.children}</>,
 
     // eslint-disable-next-line react/prop-types
-    IfPermission: props => <>{props.children}</>,
+    IfPermission: jest.fn(props => <>{props.children}</>),
 
     useNamespace: () => ['@folio/inventory'],
   };


### PR DESCRIPTION
## Purpose
Add posibility to create title-level request from `Instance` record

## Approach
Done the same way as with `Item`: generates link to `request` module with `create` layer and pass `instanceId` in it.
New button appears only if TLR is switched on in settings, and we have permission to create requests.

## Refs
https://issues.folio.org/browse/UIIN-1620

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/144827706-c283e0c2-2888-48db-96c7-47071546a1d1.png)