### PR TITLE
UIIN-1558: Fix bug preventing service point and source from appearing in item view circ history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Display acquisition accordion on Item record. Refs UIIN-1858.
 * Item. Several keyboard shortcuts does not act on the item. Refs UIIN-1867.
 * Holdings. Keyboard shortcuts does not act on the holdings. Refs UIIN-1866.
+* Fix bug preventing circ history service point & source from appearing. Fixes UIIN-1558.
 
 ## [8.0.0](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.4...v8.0.0)

--- a/src/Item/ViewItem/ItemAcquisition/ItemAcquisition.js
+++ b/src/Item/ViewItem/ItemAcquisition/ItemAcquisition.js
@@ -75,7 +75,7 @@ const ItemAcquisition = ({ accordionId, itemId }) => {
           <KeyValue
             label={<FormattedMessage id="ui-inventory.acq.receiptDate" />}
             value={
-              piece.receiptDate
+              piece?.receiptDate
               && <Link to={`/receiving/${piece.titleId}/view`}>{getDateWithTime(piece.receiptDate)}</Link>
             }
           />

--- a/src/routes/ItemRoute.js
+++ b/src/routes/ItemRoute.js
@@ -117,9 +117,8 @@ class ItemRoute extends React.Component {
         // (if the item has a check-in). Iff that service point ID is found, add a query param
         // to filter down to that one service point in the records returned.
         const servicePointId = get(props.resources, 'items.records[0].lastCheckIn.servicePointId', '');
-        if (servicePointId) {
-          return { query: `id==${servicePointId}` };
-        } else { return {}; }
+        const query = servicePointId && `id==${servicePointId}`;
+        return query ? { query } : {};
       },
       resourceShouldRefresh: true,
     },


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1558

The <ItemRoute> manifest uses a function to determine the right query to use when retrieving service point records, which are then used to populate details in the 'circulation history' section of <ItemView>. But if the service point to use wasn't yet available (i.e., the records were still loading), then the function returned `null`, causing the service point lookup to fail entirely. Returning an empty object instead of `null` fixes this. 