### PR TITLE
UIIN-1881: Inventory action menu link `View & reorder queue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Also support `circulation` `12.0`. Refs UIIN-1861.
 * SRS display. MARC indicators may be misaligned. Refs UIIN-1859.
 * Create title level request from Instance record. Refs UIIN-1620.
+* Inventory action menu link View & reorder queue. Refs UIIN-1881.
 
 ## [8.0.0](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.4...v8.0.0)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -41,6 +41,7 @@ import {
 import {
   indentifierTypeNames,
   layers,
+  REQUEST_OPEN_STATUSES,
 } from './constants';
 import { DataContext } from './contexts';
 
@@ -53,6 +54,7 @@ import { CalloutRenderer } from './components';
 
 import ImportRecordModal from './components/ImportRecordModal';
 import NewInstanceRequestButton from './components/ViewInstance/MenuSection/NewInstanceRequestButton';
+import RequestsReorderButton from './components/ViewInstance/MenuSection/RequestsReorderButton';
 
 const getTlrSettings = (settings) => {
   try {
@@ -61,6 +63,8 @@ const getTlrSettings = (settings) => {
     return {};
   }
 };
+const requestOpenStatuses = Object.values(REQUEST_OPEN_STATUSES);
+const instanceRequestsQuery = requestOpenStatuses.map(status => `status=="${status}"`).join(' OR ');
 
 class ViewInstance extends React.Component {
   static manifest = Object.freeze({
@@ -86,10 +90,14 @@ class ViewInstance extends React.Component {
       type: 'okapi',
       shouldRefresh: () => false,
     },
-    allInstanceRequests: {
+    instanceRequests: {
       accumulate: true,
       fetch: false,
       path: 'circulation/requests',
+      params: {
+        query: `instanceId==:{id} AND (${instanceRequestsQuery})`,
+        limit: '1',
+      },
       records: 'requests',
       throwErrors: false,
       type: 'okapi',
@@ -154,11 +162,21 @@ class ViewInstance extends React.Component {
     if (isMARCSource) {
       this.getMARCRecord();
     }
+
+    this.setTlrSettings();
   }
 
   componentDidUpdate(prevProps) {
-    const { selectedInstance: prevInstance } = prevProps;
-    const { selectedInstance: instance } = this.props;
+    const {
+      selectedInstance: prevInstance,
+      resources: { configs: prevConfigs },
+      match: { params: prevParams },
+    } = prevProps;
+    const {
+      selectedInstance: instance,
+      resources: { configs },
+      match: { params },
+    } = this.props;
     const instanceRecordsId = instance?.id;
     const prevInstanceRecordsId = prevInstance?.id;
     const prevIsMARCSource = this.isMARCSource(prevInstance);
@@ -175,6 +193,14 @@ class ViewInstance extends React.Component {
       !parse(this.props?.location?.search)?.layer && !this.state.afterCreate) {
       // eslint-disable-next-line
       this.setState({ afterCreate: true });
+    }
+
+    if (prevConfigs.hasLoaded !== configs.hasLoaded && configs.hasLoaded) {
+      this.setTlrSettings();
+    }
+
+    if (prevParams.id !== params.id) {
+      this.getInstanceRequests();
     }
   }
 
@@ -197,6 +223,30 @@ class ViewInstance extends React.Component {
         console.error('MARC record getting ERROR: ', error);
       });
   };
+
+  setTlrSettings = () => {
+    const {
+      resources : { configs },
+    } = this.props;
+
+    if (configs.hasLoaded) {
+      const { titleLevelRequestsFeatureEnabled } = getTlrSettings(configs.records[0]?.value);
+
+      this.setState({ titleLevelRequestsFeatureEnabled }, this.getInstanceRequests);
+    }
+  }
+
+  getInstanceRequests = () => {
+    const {
+      mutator: { instanceRequests },
+    } = this.props;
+    const { titleLevelRequestsFeatureEnabled } = this.state;
+
+    if (titleLevelRequestsFeatureEnabled) {
+      instanceRequests.reset();
+      instanceRequests.GET();
+    }
+  }
 
   // Edit Instance Handlers
   onClickEditInstance = () => {
@@ -341,10 +391,14 @@ class ViewInstance extends React.Component {
       onCopy,
       stripes,
       intl,
-      resources: { configs },
+      resources: {
+        instanceRequests,
+      },
     } = this.props;
-    const { marcRecord, requests } = this.state;
-    const { titleLevelRequestsFeatureEnabled } = getTlrSettings(configs.records[0]?.value);
+    const {
+      marcRecord,
+      titleLevelRequestsFeatureEnabled,
+    } = this.state;
 
     const isSourceMARC = get(instance, ['source'], '') === 'MARC';
     const canEditInstance = stripes.hasPerm('ui-inventory.instance.edit');
@@ -354,6 +408,7 @@ class ViewInstance extends React.Component {
     const canMoveHoldings = stripes.hasPerm('ui-inventory.holdings.move');
     const canEditMARCRecord = stripes.hasPerm('records-editor.records.item.put');
     const canDeriveMARCRecord = stripes.hasPerm('records-editor.records.item.post');
+    const hasReorderPermissions = stripes.hasPerm('ui-requests.create') || stripes.hasPerm('ui-requests.edit') || stripes.hasPerm('ui-requests.all');
 
     const canCreateMARCHoldingsForInstanceWithSourceMARC = isSourceMARC && canCreateMARCHoldings;
     const canEditDeriveMARCRecord = isSourceMARC && (canEditMARCRecord || canDeriveMARCRecord);
@@ -466,22 +521,31 @@ class ViewInstance extends React.Component {
               </IfPermission>
             )
           }
-
-          <Button
-            id="view-requests"
-            onClick={() => {
-              onToggle();
-              this.onClickViewRequests();
-            }}
-            buttonStyle="dropdownItem"
-          >
-            <Icon icon="eye-open">
-              <FormattedMessage
-                id="ui-inventory.viewRequests"
-                values={{ count: requests?.length ?? '' }}
-              />
-            </Icon>
-          </Button>
+          {
+            titleLevelRequestsFeatureEnabled
+              ? (
+                <RequestsReorderButton
+                  hasReorderPermissions={hasReorderPermissions}
+                  requestId={instanceRequests.records[0]?.id}
+                  instanceId={instance.id}
+                  numberOfRequests={instanceRequests.other?.totalRecords}
+                />
+              )
+              : (
+                <Button
+                  id="view-requests"
+                  onClick={() => {
+                    onToggle();
+                    this.onClickViewRequests();
+                  }}
+                  buttonStyle="dropdownItem"
+                >
+                  <Icon icon="eye-open">
+                    <FormattedMessage id="ui-inventory.viewRequests" />
+                  </Icon>
+                </Button>
+              )
+          }
 
           <NewInstanceRequestButton
             isTlrEnabled={titleLevelRequestsFeatureEnabled}
@@ -752,6 +816,10 @@ ViewInstance.propTypes = {
     }),
     query: PropTypes.object.isRequired,
     movableItems: PropTypes.object.isRequired,
+    instanceRequests: PropTypes.shape({
+      GET: PropTypes.func.isRequired,
+      reset: PropTypes.func.isRequired,
+    }).isRequired,
   }),
   onClose: PropTypes.func,
   onCopy: PropTypes.func,
@@ -761,6 +829,12 @@ ViewInstance.propTypes = {
     allInstanceHoldings: PropTypes.object.isRequired,
     locations: PropTypes.object.isRequired,
     configs: PropTypes.object.isRequired,
+    instanceRequests: PropTypes.shape({
+      other: PropTypes.shape({
+        totalRecords: PropTypes.number.isRequired,
+      }),
+      records: PropTypes.arrayOf(PropTypes.object).isRequired,
+    }).isRequired,
   }).isRequired,
   stripes: PropTypes.shape({
     connect: PropTypes.func.isRequired,

--- a/src/components/ViewInstance/MenuSection/RequestsReorderButton.js
+++ b/src/components/ViewInstance/MenuSection/RequestsReorderButton.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useIntl } from 'react-intl';
+
+import { IfPermission } from '@folio/stripes/core';
+import {
+  Button,
+  Icon,
+} from '@folio/stripes/components';
+
+export const getInstanceQueueReorderLink = (requestId, instanceId) => `/requests/view/${requestId}/${instanceId}/reorder`;
+
+const RequestsReorderButton = ({
+  hasReorderPermissions,
+  requestId,
+  instanceId,
+  numberOfRequests,
+}) => {
+  const { formatMessage } = useIntl();
+
+  if (!hasReorderPermissions || !numberOfRequests) {
+    return null;
+  }
+
+  return (
+    <IfPermission perm="ui-requests.reorderQueue">
+      <Button
+        to={getInstanceQueueReorderLink(requestId, instanceId)}
+        buttonStyle="dropdownItem"
+      >
+        <Icon icon="eye-open">
+          {formatMessage({
+            id: 'ui-inventory.viewAndReorderRequestsQueue',
+          },
+          {
+            number: numberOfRequests,
+          })}
+        </Icon>
+      </Button>
+    </IfPermission>
+  );
+};
+
+RequestsReorderButton.propTypes = {
+  hasReorderPermissions: PropTypes.bool.isRequired,
+  requestId: PropTypes.string.isRequired,
+  instanceId: PropTypes.string.isRequired,
+  numberOfRequests: PropTypes.number.isRequired,
+};
+
+export default RequestsReorderButton;

--- a/src/components/ViewInstance/MenuSection/RequestsReorderButton.test.js
+++ b/src/components/ViewInstance/MenuSection/RequestsReorderButton.test.js
@@ -1,0 +1,146 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import {
+  render,
+  screen,
+} from '@testing-library/react';
+
+import '../../../../test/jest/__mock__';
+
+import { IfPermission } from '@folio/stripes/core';
+
+import RequestsReorderButton, {
+  getInstanceQueueReorderLink,
+} from './RequestsReorderButton';
+
+jest.mock('react-intl', () => {
+  const intl = {
+    formatMessage: ({ id }) => id,
+  };
+
+  return {
+    injectIntl: (Component) => (props) => <Component {...props} intl={intl} />,
+    useIntl: () => intl,
+  };
+});
+
+const requestId = 'testRequestId';
+const instanceId = 'testInstanceId';
+
+describe('RequestsReorderButton', () => {
+  const labelIds = {
+    viewAndReorderRequestsQueue: 'ui-inventory.viewAndReorderRequestsQueue',
+  };
+  const defaultProps = {
+    requestId,
+    instanceId,
+  };
+
+  afterEach(() => {
+    IfPermission.mockClear();
+  });
+
+  describe('When `hasReorderPermissions` is true', () => {
+    const hasReorderPermissions = true;
+
+    describe('when `numberOfRequests` is 0', () => {
+      const numberOfRequests = 0;
+
+      beforeEach(() => {
+        render(
+          <BrowserRouter>
+            <RequestsReorderButton
+              hasReorderPermissions={hasReorderPermissions}
+              numberOfRequests={numberOfRequests}
+              {...defaultProps}
+            />
+          </BrowserRouter>
+        );
+      });
+
+      it('should not render button', () => {
+        expect(screen.queryByText(labelIds.viewAndReorderRequestsQueue)).not.toBeInTheDocument();
+      });
+    });
+
+    describe('when `numberOfRequests` is more than 0', () => {
+      const numberOfRequests = 1;
+
+      beforeEach(() => {
+        render(
+          <BrowserRouter>
+            <RequestsReorderButton
+              hasReorderPermissions={hasReorderPermissions}
+              numberOfRequests={numberOfRequests}
+              {...defaultProps}
+            />
+          </BrowserRouter>
+        );
+      });
+
+      it('should check for permission to reorder requests queue', () => {
+        const expectedResult = { perm: 'ui-requests.reorderQueue' };
+
+        expect(IfPermission).toHaveBeenCalledWith(expect.objectContaining(expectedResult), {});
+      });
+
+      it('should render button with passed props', () => {
+        const expectedResult = getInstanceQueueReorderLink(defaultProps.requestId, defaultProps.instanceId);
+
+        expect(screen.getByRole('button')).toHaveAttribute('href', expectedResult);
+        expect(screen.getByText(labelIds.viewAndReorderRequestsQueue)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('When `hasReorderPermissions` is false', () => {
+    const hasReorderPermissions = false;
+    describe('when `numberOfRequests` is 0', () => {
+      const numberOfRequests = 0;
+
+      beforeEach(() => {
+        render(
+          <BrowserRouter>
+            <RequestsReorderButton
+              hasReorderPermissions={hasReorderPermissions}
+              numberOfRequests={numberOfRequests}
+              {...defaultProps}
+            />
+          </BrowserRouter>
+        );
+      });
+
+      it('should not render button', () => {
+        expect(screen.queryByText(labelIds.viewAndReorderRequestsQueue)).not.toBeInTheDocument();
+      });
+    });
+
+    describe('when `numberOfRequests` is more than 0', () => {
+      const numberOfRequests = 1;
+
+      beforeEach(() => {
+        render(
+          <BrowserRouter>
+            <RequestsReorderButton
+              hasReorderPermissions={hasReorderPermissions}
+              numberOfRequests={numberOfRequests}
+              {...defaultProps}
+            />
+          </BrowserRouter>
+        );
+      });
+
+      it('should not render button', () => {
+        expect(screen.queryByText(labelIds.viewAndReorderRequestsQueue)).not.toBeInTheDocument();
+      });
+    });
+  });
+});
+
+describe('getInstanceQueueReorderLink', () => {
+  it('should return correct link', () => {
+    const expectedResult = `/requests/view/${requestId}/${instanceId}/reorder`;
+
+    expect(getInstanceQueueReorderLink(requestId, instanceId)).toBe(expectedResult);
+  });
+});

--- a/src/constants.js
+++ b/src/constants.js
@@ -39,7 +39,7 @@ export const itemStatusMutators = {
   UNKNOWN: 'markAsUnknown',
 };
 
-export const requestStatuses = {
+export const REQUEST_OPEN_STATUSES = {
   OPEN_AWAITING_PICKUP: `Open - ${AWAITING_PICKUP}`,
   OPEN_NOT_YET_FILLED: 'Open - Not yet filled',
   OPEN_IN_TRANSIT: `Open - ${IN_TRANSIT}`,
@@ -202,7 +202,7 @@ export const FACETS_CQL = {
   ITEMS_TAGS: 'itemTags',
   MATERIAL_TYPES: 'items.materialTypeId',
   ITEMS_STATUSES: 'items.status.name',
-  HOLDINGS_PERMANENT_LOCATION: 'holdings.permanentLocationId'
+  HOLDINGS_PERMANENT_LOCATION: 'holdings.permanentLocationId',
 };
 
 export const FACETS_TO_REQUEST = {

--- a/src/routes/ItemRoute.js
+++ b/src/routes/ItemRoute.js
@@ -9,14 +9,14 @@ import {
 import { stripesConnect } from '@folio/stripes/core';
 
 import {
-  requestStatuses,
+  REQUEST_OPEN_STATUSES,
 } from '../constants';
 import withLocation from '../withLocation';
 import { ItemView } from '../views';
 import { PaneLoading } from '../components';
 import { DataContext } from '../contexts';
 
-export const requestsStatusString = map(requestStatuses, requestStatus => `"${requestStatus}"`).join(' or ');
+export const requestsStatusString = map(REQUEST_OPEN_STATUSES, requestStatus => `"${requestStatus}"`).join(' or ');
 const getRequestsPath = `circulation/requests?query=(itemId==:{itemid}) and status==(${requestsStatusString}) sortby requestDate desc&limit=1`;
 
 class ItemRoute extends React.Component {
@@ -164,7 +164,7 @@ class ItemRoute extends React.Component {
       match: {
         params: { id },
       },
-      location: { pathname, search }
+      location: { pathname, search },
     } = this.props;
 
     // extract instance url

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -72,7 +72,7 @@ import {
   itemStatusesMap,
   itemStatusMutators,
   noValue,
-  requestStatuses,
+  REQUEST_OPEN_STATUSES,
   wrappingCell,
   actionMenuDisplayPerms,
 } from '../constants';
@@ -80,7 +80,7 @@ import ItemStatus from './ItemStatus';
 import { WarningMessage } from '../components';
 import css from '../View.css';
 
-export const requestStatusFiltersString = map(requestStatuses, requestStatus => `requestStatus.${requestStatus}`).join(',');
+export const requestStatusFiltersString = map(REQUEST_OPEN_STATUSES, requestStatus => `requestStatus.${requestStatus}`).join(',');
 
 class ItemView extends React.Component {
   static contextType = CalloutContext;
@@ -187,7 +187,7 @@ class ItemView extends React.Component {
     if (canMarkRequestAsOpen(request)) {
       const newRequestRecord = cloneDeep(request);
 
-      newRequestRecord.status = requestStatuses.OPEN_NOT_YET_FILLED;
+      newRequestRecord.status = REQUEST_OPEN_STATUSES.OPEN_NOT_YET_FILLED;
       this.props.mutator.requestOnItem.replace({ id: newRequestRecord.id });
       this.props.mutator.requests.PUT(newRequestRecord);
     }

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -51,6 +51,7 @@
   "editInstance": "Edit instance",
   "moveItems": "Move holdings/items to another instance",
   "viewRequests": "View requests",
+  "viewAndReorderRequestsQueue": "View requests & reorder ({number})",
   "instanceDetails": "Instance details",
   "addHoldings": "Add holdings",
   "itemDotStatus": "Item • {barcode} • {status}",


### PR DESCRIPTION
## Purpose
Add action menu link `View & reorder queue` for instance

## Approach
To show this button we muse enable TLR and have at least one request on this `instance`. To minimize the load we fetch only one request and use field `totalRecords`. Also in `request` module our route looks like `/requests/view/${requestId}/${instanceId}/reorder` and we have a lot of logic connected with `requestId` which we pass here.
I'am shure that pass of `requestId` is not the best way, but to make it another way we forced to do a lot of code refactoring.

## Refs
https://issues.folio.org/browse/UIIN-1881

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/147340548-042fd771-06eb-44c9-9422-7ce5e8f3d592.png)