### PR TITLE
UIIN-1859 SRS display. MARC indicators may be misaligned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Fix bug preventing circ history service point & source from appearing. Fixes UIIN-1558.
 * Fix The Acquisition accordion is not unfolded automatically when there is data to be shown. Refs UIIN-1869.
 * Expand acquisition accordion when displaying Order information on Instance record. Refs UIIN-1886.
+* SRS display. MARC indicators may be misaligned. Refs UIIN-1859.
 
 ## [8.0.0](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.4...v8.0.0)

--- a/src/components/ViewSource/ViewSource.css
+++ b/src/components/ViewSource/ViewSource.css
@@ -1,0 +1,7 @@
+.viewSource {
+  & table[class*="marc"] {
+    & tr td:not(:last-child) {
+      white-space: pre;
+    }
+  }
+}

--- a/src/components/ViewSource/ViewSource.js
+++ b/src/components/ViewSource/ViewSource.js
@@ -15,6 +15,8 @@ import {
   useGoBack,
 } from '../../common/hooks';
 
+import styles from './ViewSource.css';
+
 const ViewSource = ({
   mutator,
   instanceId,
@@ -68,12 +70,14 @@ const ViewSource = ({
     : <FormattedMessage id="ui-inventory.marcSourceRecord" />;
 
   return (
-    <MarcView
-      paneTitle={paneTitle}
-      marcTitle={marcTitle}
-      marc={marc}
-      onClose={goBack}
-    />
+    <div className={styles.viewSource}>
+      <MarcView
+        paneTitle={paneTitle}
+        marcTitle={marcTitle}
+        marc={marc}
+        onClose={goBack}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
## Overview
Sometimes the display of the indicators in the MARC View source UI are misaligned, dropping down 1 line.

## Approach
- div.viewSource has been added into return of ViewSource component
- white-space: pre; css property has ben added to td (for all except last in a row) for proper alignment

## Screenshots
### Before
![before](https://user-images.githubusercontent.com/63101175/147578578-781b6ae1-9c6e-4f0d-b974-580faed1da62.png)
### After
![after](https://user-images.githubusercontent.com/63101175/147578671-359aa79d-7eda-4fc8-a965-5f11d79293eb.png)
