### PR TITLE
UIIN-1880 - add Browse by subject option to search field select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 * Add Browse call numbers option. Refs UIIN-1879.
 * Add new data element `<AdministrativeNote>` to holdings. Refs UIIN-1443.
 * Add new data element `<AdministrativeNote>` to items. Refs UIIN-1444.
-
+* Add Browse subjects option. Refs UIIN-1880.
 
 ## [8.0.0](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.4...v8.0.0)

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -95,6 +95,7 @@ export const instanceIndexes = [
   { label: 'ui-inventory.querySearch', value: 'querySearch', queryTemplate: '%{query.query}' },
   { label: '-------------------------------------------', value: 'noValue', disabled: true },
   { label: 'ui-inventory.browseCallNumbers', value: 'callNumbers', queryTemplate: '%{query.query}' },
+  { label: 'ui-inventory.browseSubjects', value: 'browseSubject', queryTemplate: '%{query.query}' },
 ];
 
 export const instanceSortMap = {

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -95,7 +95,7 @@ export const instanceIndexes = [
   { label: 'ui-inventory.querySearch', value: 'querySearch', queryTemplate: '%{query.query}' },
   { label: '-------------------------------------------', value: 'noValue', disabled: true },
   { label: 'ui-inventory.browseCallNumbers', value: 'callNumbers', queryTemplate: '%{query.query}' },
-  { label: 'ui-inventory.browseSubjects', value: 'browseSubject', queryTemplate: '%{query.query}' },
+  { label: 'ui-inventory.browseSubjects', value: 'browseSubjects', queryTemplate: '%{query.query}' },
 ];
 
 export const instanceSortMap = {

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -403,6 +403,7 @@
   "instanceId": "Instance UUID",
   "instanceHrid": "Instance HRID",
   "browseCallNumbers": "Browse call numbers",
+  "browseSubjects": "Browse subjects",
   "instanceTitleLabel": "Instance title",
   "instanceMatchKey": "Instance match key",
   "addStatisticalCode": "Add statistical code",


### PR DESCRIPTION
## Purpose
Add the 'Browse by subjects" option for for "Browse" functionality feature.

## Approach
Entry added to filter config, applicable translation key added.

I set the value as `browseSubjects` to disambiguate from the already present `subjects` value.