### PR TITLE
UIIN-1871: Also support circulation 13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Add Browse subjects option. Refs UIIN-1880.
 * Create title level request from Instance record. Refs UIIN-1620.
 * Inventory action menu link View & reorder queue. Refs UIIN-1881.
+* Also support `circulation` `13.0`. Refs UIIN-1871.
 
 ## [8.0.0](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.4...v8.0.0)

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
       "holdings-sources": "1.0",
       "users": "15.0",
       "location-units": "2.0",
-      "circulation": "9.0 10.0 11.0 12.0",
+      "circulation": "9.0 10.0 11.0 12.0 13.0",
       "configuration": "2.0",
       "tags": "1.0",
       "inventory-record-bulk": "1.0",


### PR DESCRIPTION
## Purpose
Support okapi interfaces `circulation` `13.0`

## Approach
* Title level requests changes affect ui-requests (UIREQ) without breaking change for this module.
* Was changed API associated with request queue.

## Refs
https://issues.folio.org/browse/UIIN-1871