### PR TITLE
UIIN-791: Add ability to filter holding and items records by date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@
 * Add new data element `<AdministrativeNote>` to items. Refs UIIN-1444.
 * Browse form. Refs UIIN-1887.
 * Add Browse subjects option. Refs UIIN-1880.
+* Add ability to filter holding records by created date. Refs UIIN-791.
+* Add ability to filter holding records by updated date. Refs UIIN-786.
+* Add ability to filter item records by created date. Refs UIIN-789.
+* Add ability to filter item records by updated date. Refs UIIN-786.
 
 ## [8.0.0](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.4...v8.0.0)

--- a/src/common/hooks/useFacets.js
+++ b/src/common/hooks/useFacets.js
@@ -186,11 +186,12 @@ const useFacets = (
 
     const isUrlChanged = prevUrl.current[facetToOpen] !== location.search;
 
+    console.log('facetToOpen', facetToOpen);
     if (
       isFacetOpened &&
       isUrlChanged &&
-      facetToOpen !== FACETS.CREATED_DATE &&
-      facetToOpen !== FACETS.UPDATED_DATE
+      !facetToOpen.match(/createdDate/i) &&
+      !facetToOpen.match(/updatedDate/i)
     ) {
       handleFetchFacets({ facetToOpen });
     } else {

--- a/src/components/HoldingsRecordFilters/HoldingsRecordFilters.js
+++ b/src/components/HoldingsRecordFilters/HoldingsRecordFilters.js
@@ -6,8 +6,9 @@ import { reduce } from 'lodash';
 import {
   Accordion,
   FilterAccordionHeader,
+  AccordionSet,
 } from '@folio/stripes/components';
-import { AccordionSet } from '@folio/stripes-components';
+import { DateRangeFilter } from '@folio/stripes/smart-components';
 
 import TagsFilter from '../TagsFilter';
 import CheckboxFacet from '../CheckboxFacet';
@@ -17,11 +18,16 @@ import {
   processFacetOptions,
 } from '../../facetUtils';
 import {
+  DATE_FORMAT,
   FACETS,
   FACETS_OPTIONS,
   FACETS_CQL,
   FACETS_SETTINGS,
 } from '../../constants';
+import {
+  makeDateRangeFilterString,
+  retrieveDatesFromDateRangeFilterString,
+} from '../../utils';
 
 const HoldingsRecordFilters = (props) => {
   const {
@@ -39,6 +45,8 @@ const HoldingsRecordFilters = (props) => {
     [FACETS.HOLDINGS_PERMANENT_LOCATION]: false,
     [FACETS.HOLDINGS_DISCOVERY_SUPPRESS]: false,
     [FACETS.HOLDINGS_TAGS]: false,
+    [FACETS.HOLDINGS_CREATED_DATE]: false,
+    [FACETS.HOLDINGS_UPDATED_DATE]: false,
   };
 
   const segmentOptions = {
@@ -157,6 +165,41 @@ const HoldingsRecordFilters = (props) => {
           onChange={onChange}
         />
       </Accordion>
+      <Accordion
+        label={<FormattedMessage id={`ui-inventory.${FACETS.CREATED_DATE}`} />}
+        id={FACETS.HOLDINGS_CREATED_DATE}
+        name={FACETS.HOLDINGS_CREATED_DATE}
+        closedByDefault
+        header={FilterAccordionHeader}
+        displayClearButton={activeFilters[FACETS.HOLDINGS_CREATED_DATE]?.length > 0}
+        onClearFilter={() => onClear(FACETS.HOLDINGS_CREATED_DATE)}
+      >
+        <DateRangeFilter
+          name={FACETS.HOLDINGS_CREATED_DATE}
+          dateFormat={DATE_FORMAT}
+          selectedValues={retrieveDatesFromDateRangeFilterString(activeFilters[FACETS.HOLDINGS_CREATED_DATE]?.[0])}
+          onChange={onChange}
+          makeFilterString={makeDateRangeFilterString}
+        />
+      </Accordion>
+      <Accordion
+        label={<FormattedMessage id={`ui-inventory.${FACETS.UPDATED_DATE}`} />}
+        id={FACETS.HOLDINGS_UPDATED_DATE}
+        name={FACETS.HOLDINGS_UPDATED_DATE}
+        closedByDefault
+        header={FilterAccordionHeader}
+        displayClearButton={activeFilters[FACETS.HOLDINGS_UPDATED_DATE]?.length > 0}
+        onClearFilter={() => onClear(FACETS.HOLDINGS_UPDATED_DATE)}
+      >
+        <DateRangeFilter
+          name={FACETS.HOLDINGS_UPDATED_DATE}
+          dateFormat={DATE_FORMAT}
+          selectedValues={retrieveDatesFromDateRangeFilterString(activeFilters[FACETS.HOLDINGS_UPDATED_DATE]?.[0])}
+          onChange={onChange}
+          makeFilterString={makeDateRangeFilterString}
+        />
+      </Accordion>
+
       <TagsFilter
         id={FACETS.HOLDINGS_TAGS}
         name={FACETS.HOLDINGS_TAGS}

--- a/src/components/HoldingsRecordFilters/HoldingsRecordFilters.test.js
+++ b/src/components/HoldingsRecordFilters/HoldingsRecordFilters.test.js
@@ -7,7 +7,7 @@ import { ModuleHierarchyProvider } from '@folio/stripes-core/src/components/Modu
 import '../../../test/jest/__mock__';
 import renderWithIntl from '../../../test/jest/helpers/renderWithIntl';
 
-import InstanceFilters from './InstanceFilters';
+import HoldingsRecordFilters from './HoldingsRecordFilters';
 
 const resources = {
   facets: {
@@ -30,11 +30,11 @@ const data = {
   parentResources: resources,
 };
 
-const renderInstanceFilters = () => {
+const renderHoldingsRecordFilters = () => {
   return renderWithIntl(
     <Router>
       <ModuleHierarchyProvider module="@folio/inventory">
-        <InstanceFilters
+        <HoldingsRecordFilters
           activeFilters={{ 'language': ['eng'] }}
           data={data}
           onChange={noop}
@@ -46,16 +46,16 @@ const renderInstanceFilters = () => {
   );
 };
 
-describe('InstanceFilters', () => {
+describe('HoldingsRecordFilters', () => {
   beforeEach(() => {
-    renderInstanceFilters();
+    renderHoldingsRecordFilters();
   });
 
   it('Contains a filter for creation date ', () => {
-    expect(document.querySelector('#createdDate')).toBeInTheDocument();
+    expect(document.querySelector('#holdingsCreatedDate')).toBeInTheDocument();
   });
 
   it('Contains a filter for update date ', () => {
-    expect(document.querySelector('#updatedDate')).toBeInTheDocument();
+    expect(document.querySelector('#holdingsUpdatedDate')).toBeInTheDocument();
   });
 });

--- a/src/components/InstanceFilters/InstanceFilters.js
+++ b/src/components/InstanceFilters/InstanceFilters.js
@@ -72,8 +72,6 @@ const InstanceFilters = props => {
     [FACETS_OPTIONS.NATURE_OF_CONTENT_OPTIONS]: [],
     [FACETS_OPTIONS.SUPPRESSED_OPTIONS]: [],
     [FACETS_OPTIONS.INSTANCES_DISCOVERY_SUPPRESS_OPTIONS]: [],
-    [FACETS_OPTIONS.CREATED_DATE_OPTIONS]: [],
-    [FACETS_OPTIONS.UPDATED_DATE_OPTIONS]: [],
     [FACETS_OPTIONS.SOURCE_OPTIONS]: [],
     [FACETS_OPTIONS.INSTANCES_TAGS_OPTIONS]: [],
   };
@@ -94,10 +92,13 @@ const InstanceFilters = props => {
   };
 
   const getNewRecords = (records) => {
+    console.log('get new records...');
     return _.reduce(FACETS_SETTINGS, (accum, name, recordName) => {
       if (records[recordName]) {
         const recordValues = records[recordName].values;
         const commonProps = [recordValues, accum, name];
+
+        console.log(recordValues);
 
         switch (recordName) {
           case FACETS_CQL.EFFECTIVE_LOCATION:
@@ -123,12 +124,6 @@ const InstanceFilters = props => {
             break;
           case FACETS_CQL.INSTANCES_DISCOVERY_SUPPRESS:
             accum[name] = getSuppressedOptions(activeFilters[FACETS.INSTANCES_DISCOVERY_SUPPRESS], recordValues);
-            break;
-          case FACETS_CQL.CREATED_DATE:
-            accum[name] = getSourceOptions(activeFilters[FACETS.CREATED_DATE], recordValues);
-            break;
-          case FACETS_CQL.UPDATED_DATE:
-            accum[name] = getSourceOptions(activeFilters[FACETS.UPDATED_DATE], recordValues);
             break;
           case FACETS_CQL.SOURCE:
             accum[name] = getSourceOptions(activeFilters[FACETS.SOURCE], recordValues);

--- a/src/components/ItemFilters/ItemFilters.js
+++ b/src/components/ItemFilters/ItemFilters.js
@@ -7,6 +7,7 @@ import {
   AccordionSet,
   FilterAccordionHeader,
 } from '@folio/stripes/components';
+import { DateRangeFilter } from '@folio/stripes/smart-components';
 
 import TagsFilter from '../TagsFilter';
 import CheckboxFacet from '../CheckboxFacet';
@@ -17,11 +18,16 @@ import {
   processItemsStatuses
 } from '../../facetUtils';
 import {
+  DATE_FORMAT,
   FACETS,
   FACETS_OPTIONS,
   FACETS_SETTINGS,
   FACETS_CQL,
 } from '../../constants';
+import {
+  makeDateRangeFilterString,
+  retrieveDatesFromDateRangeFilterString,
+} from '../../utils';
 
 const ItemFilters = (props) => {
   const {
@@ -211,6 +217,40 @@ const ItemFilters = (props) => {
           selectedValues={activeFilters[FACETS.ITEMS_DISCOVERY_SUPPRESS]}
           onChange={onChange}
           isPending={getIsPending(FACETS.ITEMS_DISCOVERY_SUPPRESS)}
+        />
+      </Accordion>
+      <Accordion
+        label={<FormattedMessage id={`ui-inventory.${FACETS.CREATED_DATE}`} />}
+        id={FACETS.ITEMS_CREATED_DATE}
+        name={FACETS.ITEMS_CREATED_DATE}
+        closedByDefault
+        header={FilterAccordionHeader}
+        displayClearButton={activeFilters[FACETS.ITEMS_CREATED_DATE]?.length > 0}
+        onClearFilter={() => onClear(FACETS.ITEMS_CREATED_DATE)}
+      >
+        <DateRangeFilter
+          name={FACETS.ITEMS_CREATED_DATE}
+          dateFormat={DATE_FORMAT}
+          selectedValues={retrieveDatesFromDateRangeFilterString(activeFilters[FACETS.ITEMS_CREATED_DATE]?.[0])}
+          onChange={onChange}
+          makeFilterString={makeDateRangeFilterString}
+        />
+      </Accordion>
+      <Accordion
+        label={<FormattedMessage id={`ui-inventory.${FACETS.UPDATED_DATE}`} />}
+        id={FACETS.ITEMS_UPDATED_DATE}
+        name={FACETS.ITEMS_UPDATED_DATE}
+        closedByDefault
+        header={FilterAccordionHeader}
+        displayClearButton={activeFilters[FACETS.ITEMS_UPDATED_DATE]?.length > 0}
+        onClearFilter={() => onClear(FACETS.ITEMS_UPDATED_DATE)}
+      >
+        <DateRangeFilter
+          name={FACETS.ITEMS_UPDATED_DATE}
+          dateFormat={DATE_FORMAT}
+          selectedValues={retrieveDatesFromDateRangeFilterString(activeFilters[FACETS.ITEMS_UPDATED_DATE]?.[0])}
+          onChange={onChange}
+          makeFilterString={makeDateRangeFilterString}
         />
       </Accordion>
       <TagsFilter

--- a/src/components/ItemFilters/ItemsFilters.test.js
+++ b/src/components/ItemFilters/ItemsFilters.test.js
@@ -7,7 +7,7 @@ import { ModuleHierarchyProvider } from '@folio/stripes-core/src/components/Modu
 import '../../../test/jest/__mock__';
 import renderWithIntl from '../../../test/jest/helpers/renderWithIntl';
 
-import InstanceFilters from './InstanceFilters';
+import ItemFilters from './ItemFilters';
 
 const resources = {
   facets: {
@@ -30,11 +30,11 @@ const data = {
   parentResources: resources,
 };
 
-const renderInstanceFilters = () => {
+const renderItemFilters = () => {
   return renderWithIntl(
     <Router>
       <ModuleHierarchyProvider module="@folio/inventory">
-        <InstanceFilters
+        <ItemFilters
           activeFilters={{ 'language': ['eng'] }}
           data={data}
           onChange={noop}
@@ -46,16 +46,16 @@ const renderInstanceFilters = () => {
   );
 };
 
-describe('InstanceFilters', () => {
+describe('ItemFilters', () => {
   beforeEach(() => {
-    renderInstanceFilters();
+    renderItemFilters();
   });
 
   it('Contains a filter for creation date ', () => {
-    expect(document.querySelector('#createdDate')).toBeInTheDocument();
+    expect(document.querySelector('#itemsCreatedDate')).toBeInTheDocument();
   });
 
   it('Contains a filter for update date ', () => {
-    expect(document.querySelector('#updatedDate')).toBeInTheDocument();
+    expect(document.querySelector('#itemsUpdatedDate')).toBeInTheDocument();
   });
 });

--- a/src/constants.js
+++ b/src/constants.js
@@ -174,6 +174,10 @@ export const FACETS = {
   HOLDINGS_DISCOVERY_SUPPRESS: 'holdingsDiscoverySuppress',
   CREATED_DATE: 'createdDate',
   UPDATED_DATE: 'updatedDate',
+  HOLDINGS_CREATED_DATE: 'holdingsCreatedDate',
+  HOLDINGS_UPDATED_DATE: 'holdingsUpdatedDate',
+  ITEMS_CREATED_DATE: 'itemsCreatedDate',
+  ITEMS_UPDATED_DATE: 'itemsUpdatedDate',
   SOURCE: 'source',
   INSTANCES_TAGS: 'instancesTags',
   HOLDINGS_TAGS: 'holdingsTags',
@@ -196,6 +200,10 @@ export const FACETS_CQL = {
   ITEMS_DISCOVERY_SUPPRESS: 'items.discoverySuppress',
   CREATED_DATE: 'metadata.createdDate',
   UPDATED_DATE: 'metadata.updatedDate',
+  HOLDINGS_CREATED_DATE: 'holdings.metadata.createdDate',
+  HOLDINGS_UPDATED_DATE: 'holdings.metadata.updatedDate',
+  ITEMS_CREATED_DATE: 'items.metadata.createdDate',
+  ITEMS_UPDATED_DATE: 'items.metadata.updatedDate',
   SOURCE: 'source',
   INSTANCES_TAGS: 'instanceTags',
   HOLDINGS_TAGS: 'holdingTags',
@@ -225,6 +233,10 @@ export const FACETS_TO_REQUEST = {
   [FACETS.HOLDINGS_PERMANENT_LOCATION]: FACETS_CQL.HOLDINGS_PERMANENT_LOCATION,
   [FACETS.CREATED_DATE]: FACETS_CQL.CREATED_DATE,
   [FACETS.UPDATED_DATE]: FACETS_CQL.UPDATED_DATE,
+  [FACETS.HOLDINGS_CREATED_DATE]: FACETS_CQL.HOLDINGS_CREATED_DATE,
+  [FACETS.HOLDINGS_UPDATED_DATE]: FACETS_CQL.HOLDINGS_UPDATED_DATE,
+  [FACETS.ITEMS_CREATED_DATE]: FACETS_CQL.ITEMS_CREATED_DATE,
+  [FACETS.ITEMS_UPDATED_DATE]: FACETS_CQL.ITEMS_UPDATED_DATE,
 };
 
 export const FACETS_OPTIONS = {

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -61,13 +61,13 @@ export const instanceFilterConfig = [
     name: FACETS.CREATED_DATE,
     cql: FACETS_CQL.CREATED_DATE,
     values: [],
-    parse: buildDateRangeQuery(FACETS.CREATED_DATE),
+    parse: buildDateRangeQuery(FACETS_CQL.CREATED_DATE),
   },
   {
     name: FACETS.UPDATED_DATE,
     cql: FACETS_CQL.UPDATED_DATE,
     values: [],
-    parse: buildDateRangeQuery(FACETS.UPDATED_DATE),
+    parse: buildDateRangeQuery(FACETS_CQL.UPDATED_DATE),
   },
   {
     name: FACETS.SOURCE,
@@ -140,6 +140,18 @@ export const holdingFilterConfig = [
     cql: FACETS_CQL.HOLDINGS_TAGS,
     values: [],
   },
+  {
+    name: FACETS.HOLDINGS_CREATED_DATE,
+    cql: FACETS_CQL.HOLDINGS_CREATED_DATE,
+    values: [],
+    parse: buildDateRangeQuery(FACETS_CQL.HOLDINGS_CREATED_DATE),
+  },
+  {
+    name: FACETS.HOLDINGS_UPDATED_DATE,
+    cql: FACETS_CQL.HOLDINGS_UPDATED_DATE,
+    values: [],
+    parse: buildDateRangeQuery(FACETS_CQL.HOLDINGS_UPDATED_DATE),
+  },
 ];
 
 export const itemIndexes = [
@@ -181,6 +193,18 @@ export const itemFilterConfig = [
     name: FACETS.ITEMS_DISCOVERY_SUPPRESS,
     cql: FACETS_CQL.ITEMS_DISCOVERY_SUPPRESS,
     values: [],
+  },
+  {
+    name: FACETS.ITEMS_CREATED_DATE,
+    cql: FACETS_CQL.ITEMS_CREATED_DATE,
+    values: [],
+    parse: buildDateRangeQuery(FACETS_CQL.ITEMS_CREATED_DATE),
+  },
+  {
+    name: FACETS.ITEMS_UPDATED_DATE,
+    cql: FACETS_CQL.ITEMS_UPDATED_DATE,
+    values: [],
+    parse: buildDateRangeQuery(FACETS_CQL.ITEMS_UPDATED_DATE),
   },
   {
     name: FACETS.ITEMS_TAGS,

--- a/src/utils.js
+++ b/src/utils.js
@@ -195,7 +195,7 @@ export const buildDateRangeQuery = name => values => {
 
   if (!startDateString || !endDateString) return '';
 
-  return `metadata.${name}>="${startDateString}" and metadata.${name}<="${endDateString}"`;
+  return `${name}>="${startDateString}" and ${name}<="${endDateString}"`;
 };
 
 // Function which takes a filter name and returns

--- a/src/withFacets.js
+++ b/src/withFacets.js
@@ -68,11 +68,12 @@ function withFacets(WrappedComponent) {
 
     getFacets = (accordions, accordionsData) => {
       let index = 0;
+
       return reduce(accordions, (accum, isFacetOpened, facetName) => {
         if (
           isFacetOpened &&
-          facetName !== FACETS.UPDATED_DATE &&
-          facetName !== FACETS.CREATED_DATE
+          !facetName.match(/createdDate/i) &&
+          !facetName.match(/updatedDate/i)
         ) {
           const facetNameToRequest = FACETS_TO_REQUEST[facetName];
           const defaultFiltersNumber = `:${DEFAULT_FILTERS_NUMBER}`;
@@ -128,6 +129,8 @@ function withFacets(WrappedComponent) {
         params.facet = facetNameToRequest;
       } else {
         const facets = this.getFacets(accordions, accordionsData);
+
+        console.log('return facets', facets);
         if (facets) {
           params.facet = facets;
         } else {


### PR DESCRIPTION
Add ability to filter items and holding records by create and update dates. 

https://issues.folio.org/browse/UIIN-785
https://issues.folio.org/browse/UIIN-786
https://issues.folio.org/browse/UIIN-789
https://issues.folio.org/browse/UIIN-791

This is mostly based on the work @Baroquem did in: https://github.com/folio-org/ui-inventory/pull/1494