### PR TITLE
UIIN-1908 Settings > Inventory > change focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * Filters/facets on Call number browse form. Refs UIIN-1882.
 * Selecting row from subject browse result list. UIIN-1895
 * Placeholder for the missing match. Refs UIIN-1889.
+* Settings > Inventory > change focus. Refs UIIN-1908
 
 ## [8.0.0](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.4...v8.0.0)

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -1,6 +1,4 @@
-import React, {
-  createRef,
-} from 'react';
+import React, { createRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -1,4 +1,6 @@
-import React from 'react';
+import React, {
+  createRef,
+} from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
@@ -212,6 +214,14 @@ class InventorySettings extends React.Component {
         ]
       });
     }
+
+    this.paneTitleRef = createRef();
+  }
+
+  componentDidMount() {
+    if (this.paneTitleRef.current) {
+      this.paneTitleRef.current.focus();
+    }
   }
 
   addPerm = permission => {
@@ -226,6 +236,7 @@ class InventorySettings extends React.Component {
         {...this.props}
         sections={this.sections}
         paneTitle={<FormattedMessage id="ui-inventory.inventory.label" />}
+        paneTitleRef={this.paneTitleRef}
         data-test-inventory-settings
       />
     );


### PR DESCRIPTION
## Requirements
Given I select Settings under Apps dropdown
When I select Inventory under the list of Settings
Then move focus to the Inventory pane header on the second pane (blue bar at top of column moves from Settings column to Users column)

## Approach
Added ref to the Settings page

## Refs
https://issues.folio.org/browse/UIIN-1908

