### PR TITLE
Transition on browse row click

### DIFF
--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -157,7 +157,7 @@ class InstancesList extends React.Component {
   }
 
   componentDidMount() {
-    if (this.isBrowseOptionSelected()) {
+    if (this.getSelectedBrowseOption()) {
       this.setState({
         optionSelected: this.getQIndexFromParams(),
       });
@@ -173,9 +173,9 @@ class InstancesList extends React.Component {
     return params.get('qindex');
   }
 
-  isBrowseOptionSelected = () => {
+  getSelectedBrowseOption = () => {
     const isBrowseSelectedBasedOnUrl = Object.keys(browseModeOptions).filter(k => browseModeOptions[k] === this.getQIndexFromParams())[0];
-    const isBrowseSelectedBasedOnState = Object.values(browseModeOptions).includes(this.state.optionSelected);
+    const isBrowseSelectedBasedOnState = Object.keys(browseModeOptions).filter(k => browseModeOptions[k] === this.state.optionSelected)[0];
 
     return isBrowseSelectedBasedOnUrl || isBrowseSelectedBasedOnState;
   }
@@ -185,7 +185,7 @@ class InstancesList extends React.Component {
   }
 
   getVisibleColumns = () => {
-    let columns = columnSets[this.isBrowseOptionSelected()];
+    let columns = columnSets[this.getSelectedBrowseOption()];
     if (!columns) {
       columns = this.state.visibleColumns;
     }
@@ -931,7 +931,7 @@ class InstancesList extends React.Component {
       >
         <div data-test-inventory-instances>
           <SearchAndSort
-            actionMenu={this.isBrowseOptionSelected() ? noop : this.getActionMenu}
+            actionMenu={this.getSelectedBrowseOption() ? noop : this.getActionMenu}
             packageInfo={packageInfo}
             objectName="inventory"
             title={titleBrowse}
@@ -985,8 +985,8 @@ class InstancesList extends React.Component {
             onFilterChange={this.onFilterChangeHandler}
             pageAmount={100}
             pagingType={pagingTypes.PREV_NEXT}
-            hidePageIndices={this.isBrowseOptionSelected()}
-            paginationBoundaries={!this.isBrowseOptionSelected()}
+            hidePageIndices={this.getSelectedBrowseOption()}
+            paginationBoundaries={!this.getSelectedBrowseOption()}
             hasNewButton={false}
             onResetAll={this.handleResetAll}
             sortableColumns={['title', 'contributors', 'publishers']}

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -739,7 +739,7 @@ class InstancesList extends React.Component {
       default:
     }
 
-    // the searchAndSortKey state field can be updated to reset SearchAndSortQuery
+    // the searchAndSortKey state field can be updated to reset SearchAndSort
     // to use the app-level selectedIndex
     this.setState((curState) => ({
       optionSelected: '',

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -769,7 +769,8 @@ class InstancesList extends React.Component {
       isSelectedRecordsModalOpened,
       isImportRecordModalOpened,
       selectedRows,
-      optionSelected
+      optionSelected,
+      searchAndSortKey
     } = this.state;
 
     const itemToView = getItem(`${namespace}.position`);
@@ -958,6 +959,7 @@ class InstancesList extends React.Component {
       >
         <div data-test-inventory-instances>
           <SearchAndSort
+            key={searchAndSortKey}
             actionMenu={this.getSelectedBrowseOption() ? noop : this.getActionMenu}
             packageInfo={packageInfo}
             objectName="inventory"

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -153,6 +153,7 @@ class InstancesList extends React.Component {
       visibleColumns: this.getInitialToggableColumns(),
       isImportRecordModalOpened: false,
       optionSelected: '',
+      searchAndSortKey: 0,
     };
   }
 
@@ -706,20 +707,44 @@ class InstancesList extends React.Component {
     return `${defaultCellStyle} ${css.cellAlign}`;
   }
 
+  // handler used for clicking a row in browse mode
   onSelectRow = (_, row) => {
-    if (!row.instance && !row.totalRecords) return;
+    const {
+      parentMutator,
+      parentResources,
+      updateLocation,
+    } = this.props;
 
-    this.setState({ optionSelected: '' });
-    if (row.instance) {
-      this.props.updateLocation({
-        qindex: 'callNumber',
-        query: row.shelfKey
-      });
+    switch (get(parentResources.query, 'qindex')) {
+      case browseModeOptions.CALL_NUMBERS:
+        parentMutator.query.update({
+          qindex: 'callNumber',
+          query: row.shelfKey
+        });
+        updateLocation({
+          qindex: 'callNumber',
+          query: row.shelfKey
+        });
+        break;
+      case browseModeOptions.SUBJECTS:
+        parentMutator.query.update({
+          qindex: 'subject',
+          query: row.subject
+        });
+        updateLocation({
+          qindex: 'subject',
+          query: row.subject
+        });
+        break;
+      default:
     }
-    this.props.updateLocation({
-      qindex: 'subject',
-      query: row.subject
-    });
+
+    // the searchAndSortKey state field can be updated to reset SearchAndSortQuery
+    // to use the app-level selectedIndex
+    this.setState((curState) => ({
+      optionSelected: '',
+      searchAndSortKey: curState.searchAndSortKey + 1
+    }));
   }
 
   render() {
@@ -982,7 +1007,7 @@ class InstancesList extends React.Component {
             path={`${path}/(view|viewsource)/:id/:holdingsrecordid?/:itemid?`}
             showSingleResult={showSingleResult}
             browseOnly={browseOnly}
-            onSelectRow={browseSelectedString && this.onSelectRow}
+            onSelectRow={browseQueryExecuted ? this.onSelectRow : undefined}
             renderFilters={browseFilter()}
             onFilterChange={this.onFilterChangeHandler}
             pageAmount={100}

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -789,6 +789,7 @@ class InstancesList extends React.Component {
           <span className={css.missingMatchError}>
             &nbsp;
             {query}
+            &nbsp;
           </span>
           <strong>
             <FormattedMessage id="ui-inventory.browseCallNumbers.missedMatch" />

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -787,6 +787,7 @@ class InstancesList extends React.Component {
             />
           </span>
           <span className={css.missingMatchError}>
+            &nbsp;
             {query}
           </span>
           <strong>

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { Router } from 'react-router-dom';
 import { noop } from 'lodash';
 import userEvent from '@testing-library/user-event';
-
+import { createMemoryHistory } from 'history';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 
 import '../../../test/jest/__mock__';
@@ -40,6 +40,18 @@ const query = {
   sort: 'title',
 };
 
+const browseCNlocation = {
+  search: {
+    qindex: 'callNumbers'
+  }
+};
+
+const browseSubjectlocation = {
+  search: {
+    qindex: 'browseSubjects'
+  }
+};
+
 const resources = {
   query,
   records: {
@@ -66,6 +78,8 @@ const resources = {
   resultOffset: 0,
 };
 
+const history = createMemoryHistory();
+
 const renderInstancesList = ({ segment }) => {
   const {
     indexes,
@@ -74,7 +88,7 @@ const renderInstancesList = ({ segment }) => {
   } = getFilterConfig(segment);
 
   return renderWithIntl(
-    <Router>
+    <Router history={history}>
       <StripesContext.Provider value={stripesStub}>
         <ModuleHierarchyProvider module="@folio/inventory">
           <InstancesList
@@ -160,6 +174,17 @@ describe('InstancesList', () => {
       userEvent.click(screen.getByRole('button', { name: 'Actions' }));
 
       expect(screen.getByRole('button', { name: 'Save holdings UUIDs' })).toBeVisible();
+    });
+  });
+
+  describe('rendering browse results', () => {
+    beforeEach(() => {
+      history.push('/inventory/browse/instances?qindex=callNumbers');
+      renderInstancesList({ segment: 'instances' });
+    });
+
+    it('should display Browse header', () => {
+      expect(screen.getByText('Browse inventory')).toBeVisible();
     });
   });
 });

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -122,8 +122,6 @@ describe('InstancesList', () => {
       });
 
       expect((screen.getByRole('option', { name: 'Browse call numbers' })).selected).toBeTruthy();
-
-      expect(screen.getByText('Browse inventory')).toBeVisible();
     });
 
     it('should have selected subject browse option', () => {
@@ -132,8 +130,6 @@ describe('InstancesList', () => {
       });
 
       expect((screen.getByRole('option', { name: 'Browse subjects' })).selected).toBeTruthy();
-
-      expect(screen.getByText('Browse inventory')).toBeVisible();
     });
 
     describe('opening action menu', () => {


### PR DESCRIPTION
Currently, The query index select will not stay as it should after a browse row is clicked.

This PR resolves that by setting a key prop on search and sort that will change, causing the component to reset so that it will accept the supplied `selectedIndex` prop.

