### PR TITLE
UIIN-792 Adds statistical code types to statistical code filters

### DIFF
--- a/src/components/HoldingsRecordFilters/HoldingsRecordFilters.js
+++ b/src/components/HoldingsRecordFilters/HoldingsRecordFilters.js
@@ -16,6 +16,7 @@ import { useFacets } from '../../common/hooks';
 import {
   getSuppressedOptions,
   processFacetOptions,
+  processStatisticalCodes,
 } from '../../facetUtils';
 import {
   DATE_FORMAT,
@@ -84,7 +85,7 @@ const HoldingsRecordFilters = (props) => {
             accum[name] = getSuppressedOptions(activeFilters[FACETS.HOLDINGS_DISCOVERY_SUPPRESS], recordValues);
             break;
           case FACETS_CQL.STATISTICAL_CODES:
-            processFacetOptions(activeFilters[FACETS.STATISTICAL_CODES], statisticalCodes, ...commonProps);
+            processStatisticalCodes(activeFilters[FACETS.STATISTICAL_CODES], statisticalCodes, ...commonProps);
             break;
           case FACETS_CQL.HOLDINGS_TAGS:
             processFacetOptions(activeFilters[FACETS.HOLDINGS_TAGS], tagsRecords, ...commonProps, 'label');

--- a/src/components/InstanceFilters/InstanceFilters.js
+++ b/src/components/InstanceFilters/InstanceFilters.js
@@ -15,7 +15,8 @@ import CheckboxFacet from '../CheckboxFacet';
 import {
   getSourceOptions,
   getSuppressedOptions,
-  processFacetOptions
+  processFacetOptions,
+  processStatisticalCodes,
 } from '../../facetUtils';
 import {
   DATE_FORMAT,
@@ -130,7 +131,7 @@ const InstanceFilters = props => {
             accum[name] = getSourceOptions(activeFilters[FACETS.SOURCE], recordValues);
             break;
           case FACETS_CQL.STATISTICAL_CODES:
-            processFacetOptions(activeFilters[FACETS.STATISTICAL_CODES], statisticalCodes, ...commonProps);
+            processStatisticalCodes(activeFilters[FACETS.STATISTICAL_CODES], statisticalCodes, ...commonProps);
             break;
           case FACETS_CQL.INSTANCES_TAGS:
             processFacetOptions(activeFilters[FACETS.INSTANCES_TAGS], tagsRecords, ...commonProps, 'label');
@@ -316,7 +317,7 @@ const InstanceFilters = props => {
         />
       </Accordion>
       <Accordion
-        label={<FormattedMessage id="ui-inventory.statisticalCodes" />}
+        label={<FormattedMessage id="ui-inventory.statisticalCode" />}
         id={FACETS.STATISTICAL_CODES}
         name={FACETS.STATISTICAL_CODES}
         separator={false}

--- a/src/components/ItemFilters/ItemFilters.js
+++ b/src/components/ItemFilters/ItemFilters.js
@@ -15,7 +15,8 @@ import { useFacets } from '../../common/hooks';
 import {
   getSuppressedOptions,
   processFacetOptions,
-  processItemsStatuses
+  processItemsStatuses,
+  processStatisticalCodes,
 } from '../../facetUtils';
 import {
   DATE_FORMAT,
@@ -95,7 +96,7 @@ const ItemFilters = (props) => {
             processFacetOptions(activeFilters[FACETS.MATERIAL_TYPE], materialTypes, ...commonProps);
             break;
           case FACETS_CQL.STATISTICAL_CODES:
-            processFacetOptions(activeFilters[FACETS.STATISTICAL_CODES], statisticalCodes, ...commonProps);
+            processStatisticalCodes(activeFilters[FACETS.STATISTICAL_CODES], statisticalCodes, ...commonProps);
             break;
           case FACETS_CQL.ITEMS_DISCOVERY_SUPPRESS:
             accum[name] = getSuppressedOptions(activeFilters[FACETS.ITEMS_DISCOVERY_SUPPRESS], recordValues);

--- a/src/providers/DataProvider.js
+++ b/src/providers/DataProvider.js
@@ -23,7 +23,7 @@ const DataProvider = ({
     }
 
     return false;
-  }, [manifest, resources]);
+  }, [resources, manifest]);
 
   useEffect(() => {
     if (isLoading || dataRef.current) {


### PR DESCRIPTION
This PR adds statistical code types to statistical code filters based on feedback from @CharlotteWhitt.
 
I noticed that the data provider which holds all dictionaries was processing data multiple times at each re-render. I cleaned it up a bit to improve it.

https://issues.folio.org/browse/UIIN-792
https://issues.folio.org/browse/UIIN-793
https://issues.folio.org/browse/UIIN-794