### PR TITLE
UIIN-1831: Add pagination to holding items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 * New/Edit Item Page - Accessibility Error: Some elements has insufficient color contrast of 3.3 and several elements with same id. Refs UIIN-1161.
 * Accessibility Error: Form elements must have labels. Inventory landing page. Refs UIIN-1144.
 * Matching call number should be in bold. Refs UIIN-1922.
+* Add pagination so holding items. Fixes UIIN-1831.
 
 ## [8.0.0](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.4...v8.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@
 * New/Edit Item Page - Accessibility Error: Some elements has insufficient color contrast of 3.3 and several elements with same id. Refs UIIN-1161.
 * Accessibility Error: Form elements must have labels. Inventory landing page. Refs UIIN-1144.
 * Matching call number should be in bold. Refs UIIN-1922.
-* Add pagination so holding items. Fixes UIIN-1831.
+* Add pagination to holding items. Fixes UIIN-1831.
 
 ## [8.0.0](https://github.com/folio-org/ui-inventory/tree/v8.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.4...v8.0.0)

--- a/src/Instance/HoldingsList/Holding/HoldingAccordion.js
+++ b/src/Instance/HoldingsList/Holding/HoldingAccordion.js
@@ -25,10 +25,16 @@ const HoldingAccordion = ({
   onAddItem,
   withMoveDropdown,
 }) => {
+  const searchParams = {
+    limit: 0,
+  };
+
   const { locationsById } = useContext(DataContext);
   const labelLocation = holding.permanentLocationId ? locationsById[holding.permanentLocationId].name : '';
   const [open, setOpen] = useState(false);
   const [openFirstTime, setOpenFirstTime] = useState(false);
+  const { totalRecords, isFetching } = useHoldingItemsQuery(holding.id, { searchParams, key: 'itemCount' });
+
   const handleAccordionToggle = () => {
     if (!open && !openFirstTime) {
       setOpenFirstTime(true);
@@ -36,11 +42,6 @@ const HoldingAccordion = ({
 
     setOpen(!open);
   };
-
-  const searchParams = {
-    limit: 1,
-  };
-  const { totalRecords, isFetching } = useHoldingItemsQuery(holding.id, { searchParams });
 
   const holdingButtonsGroup = <HoldingButtonsGroup
     holding={holding}

--- a/src/Instance/ItemsList/ItemsList.js
+++ b/src/Instance/ItemsList/ItemsList.js
@@ -139,6 +139,7 @@ const ItemsList = ({
     column: 'barcode',
   });
   const [records, setRecords] = useState([]);
+  const [paginatedItems, setPaginatedItems] = useState([]);
 
   const ariaLabel = useMemo(() => getTableAria(intl), []);
   const columnMapping = useMemo(
@@ -155,13 +156,6 @@ const ItemsList = ({
     getDraggingItems,
   }), [draggable, isItemsDragSelected, getDraggingItems]);
 
-  const [paginatedItems, setPaginatedItems] = useState([]);
-
-  useEffect(() => {
-    setRecords(checkIfArrayIsEmpty(sortItems(items, itemsSorting)));
-  }, [items, itemsSorting]);
-
-
   const onNeedMoreData = (amount, index) => {
     const data = new Array(index);
     // slice original records array to extract 'pageAmount' of records
@@ -171,6 +165,10 @@ const ItemsList = ({
 
     setPaginatedItems(data);
   };
+
+  useEffect(() => {
+    setRecords(checkIfArrayIsEmpty(sortItems(items, itemsSorting)));
+  }, [items, itemsSorting]);
 
   useEffect(() => {
     if (records?.length) {

--- a/src/Instance/ItemsList/ItemsList.js
+++ b/src/Instance/ItemsList/ItemsList.js
@@ -122,11 +122,11 @@ const visibleColumns = [
 ];
 const dragVisibleColumns = ['dnd', 'select', ...visibleColumns];
 const rowMetadata = ['id', 'holdingsRecordId'];
+const pageAmount = 200;
 
 const ItemsList = ({
   holding,
   items,
-
   draggable,
   isItemsDragSelected,
   selectItemsForDrag,
@@ -155,9 +155,28 @@ const ItemsList = ({
     getDraggingItems,
   }), [draggable, isItemsDragSelected, getDraggingItems]);
 
+  const [paginatedItems, setPaginatedItems] = useState([]);
+
   useEffect(() => {
     setRecords(checkIfArrayIsEmpty(sortItems(items, itemsSorting)));
   }, [items, itemsSorting]);
+
+
+  const onNeedMoreData = (amount, index) => {
+    const data = new Array(index);
+    // slice original records array to extract 'pageAmount' of records
+    const recordSlice = records.slice(index, index + amount);
+    // push it at the end of the sparse array
+    data.push(...recordSlice);
+
+    setPaginatedItems(data);
+  };
+
+  useEffect(() => {
+    if (records?.length) {
+      setPaginatedItems(records.slice(0, pageAmount));
+    }
+  }, [records]);
 
   // NOTE: in order to sort on a particular column, it must be registered
   // as a sorter in '../utils'. If it's not, there won't be any errors;
@@ -181,17 +200,21 @@ const ItemsList = ({
 
     <MultiColumnList
       id={`list-items-${holding.id}`}
-      contentData={records}
+      contentData={paginatedItems}
       rowMetadata={rowMetadata}
       formatter={formatter}
       visibleColumns={draggable ? dragVisibleColumns : visibleColumns}
       columnMapping={columnMapping}
       ariaLabel={ariaLabel}
       interactive={false}
+      onNeedMoreData={onNeedMoreData}
+      pagingType="prev-next"
+      totalCount={items.length}
       onHeaderClick={onHeaderClick}
       sortDirection={itemsSorting.isDesc ? 'descending' : 'ascending'}
       sortedColumn={itemsSorting.column}
       rowFormatter={ItemsListRow}
+      pageAmount={pageAmount}
       rowProps={rowProps}
     />
   );

--- a/src/Instance/ItemsList/ItemsListContainer.js
+++ b/src/Instance/ItemsList/ItemsListContainer.js
@@ -22,9 +22,12 @@ const ItemsListContainer = ({
     activeDropZone,
     isItemsDroppable,
   } = useContext(DnDContext);
-  const { isLoading, items } = useHoldingItemsQuery(holding.id);
+  const searchParams = {
+    limit: 50000,
+  };
+  const { isFetching, items } = useHoldingItemsQuery(holding.id, { searchParams });
 
-  if (isLoading) {
+  if (isFetching) {
     return <Loading size="large" />;
   }
 

--- a/src/hooks/useHoldingItemsQuery.js
+++ b/src/hooks/useHoldingItemsQuery.js
@@ -7,11 +7,11 @@ import { LIMIT_MAX } from '../constants';
 
 const useHoldingItemsQuery = (
   holdingsRecordId,
-  options = { searchParams: {} },
+  options = { searchParams: {}, key: 'items' },
 ) => {
   const ky = useOkapiKy();
   const [namespace] = useNamespace();
-  const queryKey = [namespace, 'items', holdingsRecordId];
+  const queryKey = [namespace, options.key, holdingsRecordId];
   const defaultSearchParams = {
     limit: LIMIT_MAX,
     query: `holdingsRecordId==${holdingsRecordId}`,


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1831

This PR fetches all items attached to a given holdings record and adds in memory pagination to MCL used for these item records.

![items](https://user-images.githubusercontent.com/63545/153336458-36da8cd9-9da7-455e-97b3-f0e07287e12b.gif)

