### PR TITLE
test some nodey things

### DIFF
--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -40,12 +40,19 @@ jobs:
 
       - name: Setup kernel for react native, increase watchers
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODEJS_VERSION }}
           check-latest: true
           always-auth: true
+
+      - name: node's node version
+        run: node --version
+
+      - name: yarn's node version
+        run: yarn node --version
 
       - name: Set yarn config
         run: yarn config set @folio:registry $FOLIO_NPM_REGISTRY


### PR DESCRIPTION
Output node version in GA workflow to help evaluate build errors. 

Errors in https://github.com/folio-org/ui-inventory/runs/5495824257?check_suite_focus=true imply GA is running NodeJS v17, which is causing a yarn v1 regression: https://github.com/nodejs/node/pull/42136#issuecomment-1063930789