### PR TITLE
UIIN-1958: Handle message errors as plain text instead of json for optimistic locking 

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -722,7 +722,17 @@ export const accentFold = (str = '') => str.normalize('NFD').replace(/[\u0300-\u
  */
 export const parseHttpError = async httpError => {
   try {
-    const jsonError = await httpError.json();
+    let jsonError = {};
+
+    // 409 represents a conflict status
+    // which indicates an optimistic locking error.
+    // Optimistic locking error is currently returned as a plain text
+    // https://issues.folio.org/browse/UIIN-1872?focusedCommentId=125438&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-125438
+    if (httpError.status === 409) {
+      jsonError.message = await httpError.text();
+    } else {
+      jsonError = await httpError.json();
+    }
 
     if (jsonError.message.match(/optimistic locking/i)) {
       jsonError.errorType = ERROR_TYPES.OPTIMISTIC_LOCKING;


### PR DESCRIPTION
The optimistic locking error format has changed from json to text:

https://issues.folio.org/browse/UIIN-1958