### PR TITLE
Specify search.facets.collection.get UIIN-1941

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change history for ui-inventory
 
 ## [9.1.0] IN PROGRESS
+* Use permission search.facets.collection.get rather than
+  search.instances.facets.collection.get. This was renamed some time
+  after interface search 0.7 was bumped. Breaking change that is
+  unfortunately not reflected in search interface. Fixes UIIN-1941.
+
 * The highlight of search results is not specific to the given search but now highlight all kinds of data in the record. Refs UIIN-1454.
 
 * Fetch parent and child sub instances in one query. Fixes UIIN-1902.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     ],
     "okapiInterfaces": {
       "inventory": "10.10 11.0",
-      "search": "0.5",
+      "search": "0.7",
       "source-storage-records": "3.0",
       "instance-storage": "7.0 8.0",
       "holdings-storage": "3.0 4.4 5.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
           "search.config.languages.collection.get",
           "search.config.languages.item.delete",
           "search.index.inventory.reindex.post",
-          "search.instances.facets.collection.get"
+          "search.facets.collection.get"
         ]
       },
       {


### PR DESCRIPTION
Set module.inventory.enabled includes search.facets.collection.get
rather than search.instances.facets.collection.get.

This is part of interface search 0.7. That interface was not bumped
so it will be random whether ui-inventory will actually use the
right permission... Only can only rely on "pinned" interfaces in
platform-complete.
