### PR TITLE
UIIN-1973 New Permission: View MARC holdings record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * updated "Date ordered" label to "Date opened". Refs UIIN-1946.
 * search.holdings.ids.collection.get permission missing from package.json. Refs UIIN-1972.
+* New Permission: View MARC holdings record . Refs UIIN-1973.
 
 ## [9.0.0](https://github.com/folio-org/ui-inventory/tree/v9.0.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v8.0.0...v9.0.0)

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -345,6 +345,8 @@ class ViewHoldingsRecord extends React.Component {
     const canCreate = stripes.hasPerm('ui-inventory.holdings.create');
     const canEdit = stripes.hasPerm('ui-inventory.holdings.edit');
     const canDelete = stripes.hasPerm('ui-inventory.holdings.delete');
+    const canViewMARC = stripes.hasPerm('ui-quick-marc.quick-marc-holdings-editor.view');
+    const canEditMARC = stripes.hasPerm('ui-quick-marc.quick-marc-holdings-editor.all');
 
     const instance = instances1.records[0];
     const isSourceMARC = this.isMARCSource();
@@ -385,32 +387,36 @@ class ViewHoldingsRecord extends React.Component {
         }
         {isSourceMARC && (
           <>
-            <Button
-              id="clickable-view-source"
-              buttonStyle="dropdownItem"
-              disabled={!marcRecord}
-              onClick={(e) => {
-                onToggle();
-                this.handleViewSource(e, instance);
-              }}
-            >
-              <Icon icon="document">
-                <FormattedMessage id="ui-inventory.viewSource" />
-              </Icon>
-            </Button>
-            <Button
-              id="clickable-edit-marc-holdings"
-              buttonStyle="dropdownItem"
-              disabled={!marcRecord}
-              onClick={(e) => {
-                onToggle();
-                this.handleEditInQuickMarc(e);
-              }}
-            >
-              <Icon icon="edit">
-                <FormattedMessage id="ui-inventory.editMARCHoldings" />
-              </Icon>
-            </Button>
+            {canViewMARC && (
+              <Button
+                id="clickable-view-source"
+                buttonStyle="dropdownItem"
+                disabled={!marcRecord}
+                onClick={(e) => {
+                  onToggle();
+                  this.handleViewSource(e, instance);
+                }}
+              >
+                <Icon icon="document">
+                  <FormattedMessage id="ui-inventory.viewSource" />
+                </Icon>
+              </Button>
+            )}
+            {canEditMARC && (
+              <Button
+                id="clickable-edit-marc-holdings"
+                buttonStyle="dropdownItem"
+                disabled={!marcRecord}
+                onClick={(e) => {
+                  onToggle();
+                  this.handleEditInQuickMarc(e);
+                }}
+              >
+                <Icon icon="edit">
+                  <FormattedMessage id="ui-inventory.editMARCHoldings" />
+                </Icon>
+              </Button>
+            )}
           </>
         )}
         {


### PR DESCRIPTION
## Description
Used new permission: "View MARC holdings record" and "View, edit MARC holdings record"

## Issues
[UIIN-1973](https://issues.folio.org/browse/UIIN-1973)

## Related PRs
https://github.com/folio-org/ui-quick-marc/pull/289