### PR TITLE
UIIN-1966: Reset reference data resources on unmount.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,12 @@
 
 ## [9.1.0] IN PROGRESS
 * The highlight of search results is not specific to the given search but now highlight all kinds of data in the record. Refs UIIN-1454.
-
 * Fetch parent and child sub instances in one query. Fixes UIIN-1902.
 * Missing Field - Receipt status under the Edit Holdings View. Fixes UIIN-1943.
-
 * updated "Date ordered" label to "Date opened". Refs UIIN-1946.
 * search.holdings.ids.collection.get permission missing from package.json. Refs UIIN-1972.
 * New Permission: View MARC holdings record . Refs UIIN-1973.
+* Reset reference data resources on unmount. Fixes UIIN-1966.
 
 ## [9.0.0](https://github.com/folio-org/ui-inventory/tree/v9.0.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v8.0.0...v9.0.0)

--- a/src/providers/DataProvider.js
+++ b/src/providers/DataProvider.js
@@ -82,36 +82,43 @@ DataProvider.manifest = {
     type: 'okapi',
     records: 'identifierTypes',
     path: 'identifier-types?limit=1000&query=cql.allRecords=1 sortby name',
+    resourceShouldRefresh: true,
   },
   contributorTypes: {
     type: 'okapi',
     records: 'contributorTypes',
     path: 'contributor-types?limit=400&query=cql.allRecords=1 sortby name',
+    resourceShouldRefresh: true,
   },
   contributorNameTypes: {
     type: 'okapi',
     records: 'contributorNameTypes',
     path: 'contributor-name-types?limit=1000&query=cql.allRecords=1 sortby ordering',
+    resourceShouldRefresh: true,
   },
   instanceFormats: {
     type: 'okapi',
     records: 'instanceFormats',
     path: 'instance-formats?limit=1000&query=cql.allRecords=1 sortby name',
+    resourceShouldRefresh: true,
   },
   instanceTypes: {
     type: 'okapi',
     records: 'instanceTypes',
     path: 'instance-types?limit=1000&query=cql.allRecords=1 sortby name',
+    resourceShouldRefresh: true,
   },
   classificationTypes: {
     type: 'okapi',
     records: 'classificationTypes',
     path: 'classification-types?limit=1000&query=cql.allRecords=1 sortby name',
+    resourceShouldRefresh: true,
   },
   alternativeTitleTypes: {
     type: 'okapi',
     records: 'alternativeTitleTypes',
     path: 'alternative-title-types?limit=1000&query=cql.allRecords=1 sortby name',
+    resourceShouldRefresh: true,
   },
   locations: {
     type: 'okapi',
@@ -121,21 +128,25 @@ DataProvider.manifest = {
       limit: (q, p, r, l, props) => props?.stripes?.config?.maxUnpagedResourceCount || 1000,
       query: 'cql.allRecords=1 sortby name',
     },
+    resourceShouldRefresh: true,
   },
   instanceRelationshipTypes: {
     type: 'okapi',
     records: 'instanceRelationshipTypes',
     path: 'instance-relationship-types?limit=1000&query=cql.allRecords=1 sortby name',
+    resourceShouldRefresh: true,
   },
   instanceStatuses: {
     type: 'okapi',
     records: 'instanceStatuses',
     path: 'instance-statuses?limit=1000&query=cql.allRecords=1 sortby name',
+    resourceShouldRefresh: true,
   },
   modesOfIssuance: {
     type: 'okapi',
     records: 'issuanceModes',
     path: 'modes-of-issuance?limit=1000&query=cql.allRecords=1 sortby name',
+    resourceShouldRefresh: true,
   },
   instanceNoteTypes: {
     type: 'okapi',
@@ -145,41 +156,49 @@ DataProvider.manifest = {
       limit: '1000',
     },
     records: 'instanceNoteTypes',
+    resourceShouldRefresh: true,
   },
   electronicAccessRelationships: {
     type: 'okapi',
     records: 'electronicAccessRelationships',
     path: 'electronic-access-relationships?limit=1000&query=cql.allRecords=1 sortby name',
+    resourceShouldRefresh: true,
   },
   statisticalCodeTypes: {
     type: 'okapi',
     records: 'statisticalCodeTypes',
     path: 'statistical-code-types?limit=1000&query=cql.allRecords=1 sortby name',
+    resourceShouldRefresh: true,
   },
   statisticalCodes: {
     type: 'okapi',
     records: 'statisticalCodes',
     path: 'statistical-codes?limit=2000&query=cql.allRecords=1 sortby name',
+    resourceShouldRefresh: true,
   },
   illPolicies: {
     type: 'okapi',
     path: 'ill-policies?limit=1000&query=cql.allRecords=1 sortby name',
     records: 'illPolicies',
+    resourceShouldRefresh: true,
   },
   holdingsTypes: {
     type: 'okapi',
     path: 'holdings-types?limit=1000&query=cql.allRecords=1 sortby name',
     records: 'holdingsTypes',
+    resourceShouldRefresh: true,
   },
   callNumberTypes: {
     type: 'okapi',
     path: 'call-number-types?limit=1000&query=cql.allRecords=1 sortby name',
     records: 'callNumberTypes',
+    resourceShouldRefresh: true,
   },
   holdingsNoteTypes: {
     type: 'okapi',
     path: 'holdings-note-types?limit=1000&query=cql.allRecords=1 sortby name',
     records: 'holdingsNoteTypes',
+    resourceShouldRefresh: true,
   },
   itemNoteTypes: {
     type: 'okapi',
@@ -189,16 +208,19 @@ DataProvider.manifest = {
       limit: '1000',
     },
     records: 'itemNoteTypes',
+    resourceShouldRefresh: true,
   },
   itemDamagedStatuses: {
     type: 'okapi',
     path: 'item-damaged-statuses?limit=1000&query=cql.allRecords=1 sortby name',
     records: 'itemDamageStatuses',
+    resourceShouldRefresh: true,
   },
   natureOfContentTerms: {
     type: 'okapi',
     path: 'nature-of-content-terms?limit=1000&query=cql.allRecords=1 sortby name',
     records: 'natureOfContentTerms',
+    resourceShouldRefresh: true,
   },
   materialTypes: {
     type: 'okapi',
@@ -208,6 +230,7 @@ DataProvider.manifest = {
       limit: '1000',
     },
     records: 'mtypes',
+    resourceShouldRefresh: true,
   },
   loanTypes: {
     type: 'okapi',
@@ -217,12 +240,14 @@ DataProvider.manifest = {
       limit: '1000',
     },
     records: 'loantypes',
+    resourceShouldRefresh: true,
   },
   tags: {
     path: 'tags?limit=10000',  // the same as Tags component in stripes-smart-components
     records: 'tags',
     throwErrors: false,
     type: 'okapi',
+    resourceShouldRefresh: true,
   },
   holdingsSources: {
     type: 'okapi',
@@ -232,6 +257,7 @@ DataProvider.manifest = {
       limit: '1000',
     },
     records: 'holdingsRecordsSources',
+    resourceShouldRefresh: true,
   }
 };
 


### PR DESCRIPTION
The resource data is being loaded every time the ui-inventory is opened. After leaving it and re-entering again the resources are re-fetched again but the previous data is still around (until new data arrives). This caused issues with stale data being served. 

This PR adds a `resourceShouldRefresh: true` which resets the resource data when the ui-inventory is unmounted so the fresh data is always being served.

https://issues.folio.org/browse/UIIN-1966 