### PR TITLE
UIIN-1974: Do not cross-check tag facets with tag list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * updated "Date ordered" label to "Date opened". Refs UIIN-1946.
 * search.holdings.ids.collection.get permission missing from package.json. Refs UIIN-1972.
 * New Permission: View MARC holdings record . Refs UIIN-1973.
+* Do not cross-check tag facets with tag list. Refs UIIN-1974.
 
 ## [9.0.0](https://github.com/folio-org/ui-inventory/tree/v9.0.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v8.0.0...v9.0.0)

--- a/src/components/HoldingsRecordFilters/HoldingsRecordFilters.js
+++ b/src/components/HoldingsRecordFilters/HoldingsRecordFilters.js
@@ -14,6 +14,7 @@ import TagsFilter from '../TagsFilter';
 import CheckboxFacet from '../CheckboxFacet';
 import { useFacets } from '../../common/hooks';
 import {
+  getSourceOptions,
   getSuppressedOptions,
   processFacetOptions,
   processStatisticalCodes,
@@ -35,7 +36,6 @@ const HoldingsRecordFilters = (props) => {
     activeFilters,
     data: {
       locations,
-      tagsRecords,
       statisticalCodes,
       holdingsSources,
     },
@@ -95,7 +95,7 @@ const HoldingsRecordFilters = (props) => {
             processFacetOptions(activeFilters[FACETS.HOLDINGS_SOURCE], holdingsSources, ...commonProps);
             break;
           case FACETS_CQL.HOLDINGS_TAGS:
-            processFacetOptions(activeFilters[FACETS.HOLDINGS_TAGS], tagsRecords, ...commonProps, 'label');
+            accum[name] = getSourceOptions(activeFilters[FACETS.HOLDINGS_TAGS], recordValues);
             break;
           default:
         }

--- a/src/components/InstanceFilters/InstanceFilters.js
+++ b/src/components/InstanceFilters/InstanceFilters.js
@@ -42,7 +42,6 @@ const InstanceFilters = props => {
       modesOfIssuance,
       statisticalCodes,
       natureOfContentTerms,
-      tagsRecords,
     },
     onChange,
     onClear,
@@ -134,7 +133,7 @@ const InstanceFilters = props => {
             processStatisticalCodes(activeFilters[FACETS.STATISTICAL_CODE_IDS], statisticalCodes, ...commonProps);
             break;
           case FACETS_CQL.INSTANCES_TAGS:
-            processFacetOptions(activeFilters[FACETS.INSTANCES_TAGS], tagsRecords, ...commonProps, 'label');
+            accum[name] = getSourceOptions(activeFilters[FACETS.INSTANCES_TAGS], recordValues);
             break;
           default:
         }

--- a/src/components/ItemFilters/ItemFilters.js
+++ b/src/components/ItemFilters/ItemFilters.js
@@ -13,6 +13,7 @@ import TagsFilter from '../TagsFilter';
 import CheckboxFacet from '../CheckboxFacet';
 import { useFacets } from '../../common/hooks';
 import {
+  getSourceOptions,
   getSuppressedOptions,
   processFacetOptions,
   processItemsStatuses,
@@ -38,7 +39,6 @@ const ItemFilters = (props) => {
       statisticalCodes,
       locations,
       materialTypes,
-      tagsRecords,
     },
     onChange,
     onClear,
@@ -102,7 +102,7 @@ const ItemFilters = (props) => {
             accum[name] = getSuppressedOptions(activeFilters[FACETS.ITEMS_DISCOVERY_SUPPRESS], recordValues);
             break;
           case FACETS_CQL.ITEMS_TAGS:
-            processFacetOptions(activeFilters[FACETS.ITEMS_TAGS], tagsRecords, ...commonProps, 'label');
+            accum[name] = getSourceOptions(activeFilters[FACETS.ITEMS_TAGS], recordValues);
             break;
           default:
         }


### PR DESCRIPTION
The previous implementation cross-checked the values returned from the tags facet with the global tags list. This is no longer required since the values returns from the tag facet include tag names which are required by mod-search. 

This PR removes that cross-check and just serves the values returned by the tags facet.

https://issues.folio.org/browse/UIIN-1974