### PR TITLE
UIIN-1934: Fix issues with re-entering ui-inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * updated "Date ordered" label to "Date opened". Refs UIIN-1946.
 * search.holdings.ids.collection.get permission missing from package.json. Refs UIIN-1972.
 * New Permission: View MARC holdings record . Refs UIIN-1973.
+* Fix issues with re-entering ui-inventory when the instance details pane is opened. Fixes UIIN-1934.
 
 ## [9.0.0](https://github.com/folio-org/ui-inventory/tree/v9.0.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v8.0.0...v9.0.0)

--- a/src/Instance/HoldingsList/Holding/HoldingAccordion.js
+++ b/src/Instance/HoldingsList/Holding/HoldingAccordion.js
@@ -101,7 +101,7 @@ HoldingAccordion.propTypes = {
   onAddItem: PropTypes.func.isRequired,
   holdings: PropTypes.arrayOf(PropTypes.object),
   withMoveDropdown: PropTypes.bool,
-  children: PropTypes.func,
+  children: PropTypes.object,
 };
 
 export default HoldingAccordion;

--- a/src/Instance/InstanceDetails/InstanceDetails.js
+++ b/src/Instance/InstanceDetails/InstanceDetails.js
@@ -213,10 +213,7 @@ InstanceDetails.propTypes = {
   onClose: PropTypes.func.isRequired,
   instance: PropTypes.object,
   paneTitle: PropTypes.object,
-  paneSubtitle: PropTypes.arrayOf(PropTypes.oneOfType([
-    PropTypes.object,
-    PropTypes.string,
-  ])),
+  paneSubtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   tagsToggle: PropTypes.func,
   tagsEnabled: PropTypes.bool,
 };

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -636,16 +636,6 @@ class ViewInstance extends React.Component {
     );
   };
 
-  // Pane subtitle (second line) for instance details pane
-  createSubtitle = (record) => {
-    return this.props.intl.formatMessage({
-      id: 'ui-inventory.instanceRecordSubtitle',
-    }, {
-      hrid: record?.hrid,
-      updatedDate: getDate(record?.metadata?.updatedDate),
-    });
-  }
-
   render() {
     const {
       match: { params: { id, holdingsrecordid, itemid } },
@@ -655,6 +645,7 @@ class ViewInstance extends React.Component {
       paneWidth,
       tagsEnabled,
       updateLocation,
+      intl,
     } = this.props;
     const ci = makeConnectedInstance(this.props, stripes.logger);
     const instance = ci.instance();
@@ -690,12 +681,13 @@ class ViewInstance extends React.Component {
       },
     ];
 
+
     if (!instance) {
       return (
         <Pane
           id="pane-instancedetails"
           defaultWidth={paneWidth}
-          paneTitle={<FormattedMessage id="ui-inventory.edit" />}
+          paneTitle={intl.formatMessage({ id: 'ui-inventory.edit' })}
           appIcon={<AppIcon app="inventory" iconKey="instance" />}
           dismissible
           onClose={onClose}
@@ -728,7 +720,15 @@ class ViewInstance extends React.Component {
                 }}
               />
             }
-            paneSubtitle={this.createSubtitle(instance)}
+            paneSubtitle={
+              <FormattedMessage
+                id="ui-inventory.instanceRecordSubtitle"
+                values={{
+                  hrid: instance?.hrid,
+                  updatedDate: getDate(instance?.metadata?.updatedDate),
+                }}
+              />
+            }
             onClose={onClose}
             actionMenu={this.createActionMenuGetter(instance)}
             instance={instance}
@@ -807,7 +807,6 @@ ViewInstance.propTypes = {
   }),
   mutator: PropTypes.shape({
     allInstanceItems: PropTypes.object.isRequired,
-    allInstanceRequests: PropTypes.object.isRequired,
     holdings: PropTypes.shape({
       POST: PropTypes.func.isRequired,
     }),

--- a/src/components/ViewInstance/MenuSection/RequestsReorderButton.js
+++ b/src/components/ViewInstance/MenuSection/RequestsReorderButton.js
@@ -43,9 +43,9 @@ const RequestsReorderButton = ({
 
 RequestsReorderButton.propTypes = {
   hasReorderPermissions: PropTypes.bool.isRequired,
-  requestId: PropTypes.string.isRequired,
+  requestId: PropTypes.string,
   instanceId: PropTypes.string.isRequired,
-  numberOfRequests: PropTypes.number.isRequired,
+  numberOfRequests: PropTypes.number,
 };
 
 export default RequestsReorderButton;

--- a/src/facetUtils.js
+++ b/src/facetUtils.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 const getFacetDataMap = (facetData, key = 'id') => {
   const facetDataMap = new Map();
 
-  facetData.forEach(data => {
+  facetData?.forEach(data => {
     const id = data[key];
     facetDataMap.set(id, data);
   });


### PR DESCRIPTION
When users re-entered previously opened ui-inventory the facet data:

https://github.com/folio-org/ui-inventory/compare/UIIN-1934?expand=1#diff-0cd75b0df340c7bdfae9e993dda70e6e6703595f563fc46e055bb7f35ef738e4R7

was sometimes not loaded completely causing exception in the bug fest env.

This PR fixes this issue.

It also includes various other small fixes reported by react and lint when the instance details pane was opened.