### PR TITLE
UIIN-1927: Fix confusing checkboxes in item move UI

### DIFF
--- a/src/Instance/HoldingsList/Holding/Holding.js
+++ b/src/Instance/HoldingsList/Holding/Holding.js
@@ -23,20 +23,17 @@ const Holding = ({
   return (
     <div>
       {isDraggable &&
-        <FormattedMessage id="ui-inventory.moveItems.selectItem">
-          {
-            ([ariaLabel]) => (
-              <span data-test-select-holding>
-                <Checkbox
-                  id={`select-holding-${holding.id}`}
-                  aria-label={ariaLabel}
-                  checked={isHoldingDragSelected(holding)}
-                  onChange={() => selectHoldingsForDrag(holding)}
-                />
-              </span>
-            )
-          }
-        </FormattedMessage>
+        <>
+          <FormattedMessage id="ui-inventory.moveItems.selectHolding" />
+          {' '}
+          <span data-test-select-holding>
+            <Checkbox
+              id={`select-holding-${holding.id}`}
+              checked={isHoldingDragSelected(holding)}
+              onChange={() => selectHoldingsForDrag(holding)}
+            />
+          </span>
+        </>
       }
       <DropZone
         isItemsDroppable={isItemsDroppable}

--- a/src/Instance/HoldingsList/Holding/Holding.js
+++ b/src/Instance/HoldingsList/Holding/Holding.js
@@ -24,8 +24,6 @@ const Holding = ({
     <div>
       {isDraggable &&
         <>
-          <FormattedMessage id="ui-inventory.moveItems.selectHolding" />
-          {' '}
           <span data-test-select-holding>
             <Checkbox
               id={`select-holding-${holding.id}`}
@@ -33,6 +31,8 @@ const Holding = ({
               onChange={() => selectHoldingsForDrag(holding)}
             />
           </span>
+          {' '}
+          <FormattedMessage id="ui-inventory.moveItems.selectHolding" />
         </>
       }
       <DropZone

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -648,6 +648,7 @@
   "moveItems.moveButton": "Move to",
   "moveItems.selectAll": "Select/unselect all items for movement",
   "moveItems.selectItem": "Select/unselect item for movement",
+  "moveItems.selectHolding": "Select/unselect holding for movement",
   "moveItems.move.items.count": "Move: {count, number} {count, plural, one {item} other {items}}",
   "moveItems.move.holdings.count": "Move: {count, number} {count, plural, one {holding} other {holdings}}",
   "moveItems.instance.actionMenu.enable": "Move items within an instance",


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1927

This is not a good-looking UI, regardless of the approach used to fix the issue. These checkboxes are used to select which holdings records to move, so logically and aesthetically they would be better placed within the holdings accordion they indicate, rather than above it. However, placing them there triggers errors in `react-beautiful-dnd` and prevents drag and drop from working correctly. 

I found that the existing label for these checkboxes was (a) not being displayed, and (b) incorrectly describing selection of items rather than holdings. So I went for the most expedient solution of correcting the label and making sure that they appeared in the views. Still not a particularly good UI, but I hope it will be less confusing for the users.

<img width="1940" alt="Screen Shot 2022-03-24 at 5 44 29 PM" src="https://user-images.githubusercontent.com/1322242/160016490-b019f0fc-845d-41c5-bfc5-42aa2e6eebdf.png">

