### PR TITLE
UIIN-1962: Improve RepeatableField layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Reset reference data resources on unmount. Fixes UIIN-1966.
 * Do not cross-check tag facets with tag list. Refs UIIN-1974.
 * Fix issues with re-entering ui-inventory when the instance details pane is opened. Fixes UIIN-1934.
+* Improve `<RepeatableField>` layout. Fixes UIIN-1962.
 
 ## [9.0.0](https://github.com/folio-org/ui-inventory/tree/v9.0.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v8.0.0...v9.0.0)

--- a/src/components/RepeatableField/FieldRow.js
+++ b/src/components/RepeatableField/FieldRow.js
@@ -6,7 +6,6 @@ import { FormattedMessage } from 'react-intl';
 
 import {
   Button,
-  Layout,
   Icon,
   Row,
   Col,
@@ -101,10 +100,9 @@ class FieldRow extends React.Component {
     const labelProps = {};
     if (fieldIndex === 0) {
       labelProps.label = label;
+    } else {
+      labelProps['aria-label'] = `${label} ${fieldIndex}`;
     }
-
-    labelProps['aria-label'] = `${label} ${fieldIndex}`;
-
     return (
       <Field
         name={name ? `${fields.name}[${fieldIndex}].${name}` : `${fields.name}[${fieldIndex}]`}
@@ -182,7 +180,7 @@ class FieldRow extends React.Component {
               style={{ width: '100%' }}
               ref={(ref) => { this.refIfLastRow(ref, fieldIndex); }}
             >
-              <Row>
+              <Row bottom="xs">
                 <Col xs={10}>
                   <Row>
                     {template.map((t, i) => {
@@ -197,24 +195,21 @@ class FieldRow extends React.Component {
                   </Row>
                 </Col>
                 <Col xs={2}>
-                  <Layout className={fieldIndex === 0 ? 'marginTopLabelSpacer' : ''}>
-                    <FormattedMessage
-                      id="stripes-components.removeFields"
-                      values={{ item: label, num: fieldIndex + 1 }}
-                    >
-                      {([ariaLabel]) => (
-                        <Button
-                          buttonStyle="link"
-                          style={{ padding: 0, marginBottom: '12px' }}
-                          onClick={() => { this.handleRemove(fieldIndex, f); }}
-                          aria-label={ariaLabel}
-                          disabled={!canDelete}
-                        >
-                          <Icon icon="trash" />
-                        </Button>
-                      )}
-                    </FormattedMessage>
-                  </Layout>
+                  <FormattedMessage
+                    id="stripes-components.removeFields"
+                    values={{ item: label, num: fieldIndex + 1 }}
+                  >
+                    {([ariaLabel]) => (
+                      <Button
+                        buttonStyle="link"
+                        onClick={() => { this.handleRemove(fieldIndex, f); }}
+                        aria-label={ariaLabel}
+                        disabled={!canDelete}
+                      >
+                        <Icon icon="trash" />
+                      </Button>
+                    )}
+                  </FormattedMessage>
                 </Col>
               </Row>
               {fieldIndex === fields.length - 1 &&

--- a/src/edit/alternativeTitles.js
+++ b/src/edit/alternativeTitles.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import {
   TextArea,
@@ -20,6 +20,7 @@ const AlternativeTitles = props => {
     label: it.name,
     value: it.id,
   }));
+  const intl = useIntl();
 
   return (
     <FormattedMessage id="ui-inventory.selectAlternativeTitleType">
@@ -32,7 +33,7 @@ const AlternativeTitles = props => {
           template={[
             {
               name: 'alternativeTitleTypeId',
-              label: <FormattedMessage id="ui-inventory.type" />,
+              label: intl.formatMessage({ id: 'ui-inventory.type' }),
               component: Select,
               placeholder,
               dataOptions: alternativeTitleTypeOptions,
@@ -41,7 +42,7 @@ const AlternativeTitles = props => {
             },
             {
               name: 'alternativeTitle',
-              label: <FormattedMessage id="ui-inventory.alternativeTitle" />,
+              label: intl.formatMessage({ id: 'ui-inventory.alternativeTitle' }),
               component: TextArea,
               required: true,
               rows: 1,


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1962

Improve `<RepeatableField>` layout.

Before:
![before](https://user-images.githubusercontent.com/63545/160044142-565c8802-1898-42be-bbe9-251461de0865.png)

After:
![after](https://user-images.githubusercontent.com/63545/160044179-30e84706-dfdd-44b1-89ad-157af59b09ed.png)

