### PR TITLE
UIIN-1931: Do not change identifiers array for the preceding/succeeding titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Do not cross-check tag facets with tag list. Refs UIIN-1974.
 * Fix issues with re-entering ui-inventory when the instance details pane is opened. Fixes UIIN-1934.
 * New Permission: View source (instance). Refs UIIN-1975.
+* Do not change identifiers array for the preceding/succeeding titles. Fixes UIIN-1931.
 
 ## [9.0.0](https://github.com/folio-org/ui-inventory/tree/v9.0.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v8.0.0...v9.0.0)

--- a/src/utils.js
+++ b/src/utils.js
@@ -458,6 +458,17 @@ export const getIdentifiers = (identifiers = [], type, identifierTypesById) => {
     </div>);
 };
 
+export const updateOrAddIdentifier = (identifiers, identifierTypeId, value) => {
+  const index = identifiers.findIndex(identifier => identifier.identifierTypeId === identifierTypeId);
+  const indentifier = { identifierTypeId, value };
+
+  if (index > -1) {
+    identifiers[index] = indentifier;
+  } else {
+    identifiers.push(indentifier);
+  }
+};
+
 /**
  * Marshal ISBN and ISSN attatched to the given title into
  * identifiers required by the backend.
@@ -467,24 +478,18 @@ export const getIdentifiers = (identifiers = [], type, identifierTypesById) => {
  *
  */
 export const marshalIdentifiers = (title, identifierTypesByName) => {
-  const identifiers = [];
+  const identifiers = [...(title?.identifiers ?? [])];
   const {
     isbn,
     issn,
   } = title;
 
   if (isbn) {
-    identifiers.push({
-      identifierTypeId: identifierTypesByName.ISBN.id,
-      value: isbn,
-    });
+    updateOrAddIdentifier(identifiers, identifierTypesByName.ISBN.id, isbn);
   }
 
   if (issn) {
-    identifiers.push({
-      identifierTypeId: identifierTypesByName.ISSN.id,
-      value: issn,
-    });
+    updateOrAddIdentifier(identifiers, identifierTypesByName.ISSN.id, issn);
   }
 
   return identifiers;


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-1931

The previous implementation would always override identifiers array for the preceding/succeeding titles and only ISSN and ISBN would be kept around and updated.

This PR is trying to address an issue described in details by @wafschneider under UIIN-1931.

The new approach will keep all identifiers unchanged and it will only update ISSN and ISBN (if they are present and changed).