### PR TITLE
UIIN-1987 Optimistic locking: display error message to inform user about OL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Do not change identifiers array for the preceding/succeeding titles. Fixes UIIN-1931.
 * Fix missing label on holdings/item move view. Fixes UIIN-1927.
 * Browse form flickers. Fixes UIIN-1961.
+* Optimistic locking: display error message to inform user about OL. Refs UIIN-1987.
 
 ## [9.0.0](https://github.com/folio-org/ui-inventory/tree/v9.0.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v8.0.0...v9.0.0)

--- a/src/routes/QuickMarcRoute.js
+++ b/src/routes/QuickMarcRoute.js
@@ -21,6 +21,7 @@ const QuickMarcRoute = ({ match, history, location }) => {
         type="quick-marc"
         basePath={match.path}
         onClose={onClose}
+        externalRecordPath="/inventory/view"
       >
         <span data-test-inventory-quick-marc-no-plugin>
           <FormattedMessage id="ui-inventory.quickMarcNotAvailable" />


### PR DESCRIPTION
## Description
Added a new prop to quickMARC to tell where optimistic locking banner should link to

## Issues
https://issues.folio.org/browse/UIIN-1987

## Related PRs
https://github.com/folio-org/ui-quick-marc/pull/292