### PR TITLE
UIIN-1997: Edit a MARC holdings record - generates a 500 error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   search.instances.facets.collection.get. This was renamed some time
   after interface search 0.7 was bumped. Breaking change that is
   unfortunately not reflected in search interface. Fixes UIIN-1941.
+* Fix Edit a MARC holdings record generates a 500 error. Fixes UIIN-1997.
 
 * The highlight of search results is not specific to the given search but now highlight all kinds of data in the record. Refs UIIN-1454.
 * Fetch parent and child sub instances in one query. Fixes UIIN-1902.

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -329,7 +329,10 @@ class ViewHoldingsRecord extends React.Component {
     const holdingsRecord = this.getMostRecentHolding();
 
     const searchParams = new URLSearchParams(location.search);
-    searchParams.append('relatedRecordVersion', holdingsRecord._version);
+
+    if (!searchParams.has('relatedRecordVersion')) {
+      searchParams.append('relatedRecordVersion', holdingsRecord._version);
+    }
 
     goTo(`/inventory/quick-marc/edit-holdings/${instances1.records[0].id}/${holdingsRecord.id}?${searchParams.toString()}`);
   }

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -330,9 +330,8 @@ class ViewHoldingsRecord extends React.Component {
 
     const searchParams = new URLSearchParams(location.search);
 
-    if (!searchParams.has('relatedRecordVersion')) {
-      searchParams.append('relatedRecordVersion', holdingsRecord._version);
-    }
+    searchParams.delete('relatedRecordVersion');
+    searchParams.append('relatedRecordVersion', holdingsRecord._version);
 
     goTo(`/inventory/quick-marc/edit-holdings/${instances1.records[0].id}/${holdingsRecord.id}?${searchParams.toString()}`);
   }

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -287,6 +287,8 @@ class ViewInstance extends React.Component {
 
     const searchParams = new URLSearchParams(location.search);
 
+    searchParams.delete('relatedRecordVersion');
+
     if (page !== quickMarcPages.createHoldings) {
       searchParams.append('relatedRecordVersion', instance._version);
     }

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -56,6 +56,12 @@ import ImportRecordModal from './components/ImportRecordModal';
 import NewInstanceRequestButton from './components/ViewInstance/MenuSection/NewInstanceRequestButton';
 import RequestsReorderButton from './components/ViewInstance/MenuSection/RequestsReorderButton';
 
+const quickMarcPages = {
+  editInstance: 'edit-bib',
+  duplicateInstance: 'duplicate-bib',
+  createHoldings: 'create-holdings',
+};
+
 const getTlrSettings = (settings) => {
   try {
     return JSON.parse(settings);
@@ -280,7 +286,10 @@ class ViewInstance extends React.Component {
     const instance = ci.instance();
 
     const searchParams = new URLSearchParams(location.search);
-    searchParams.append('relatedRecordVersion', instance._version);
+
+    if (page !== quickMarcPages.createHoldings) {
+      searchParams.append('relatedRecordVersion', instance._version);
+    }
 
     history.push({
       pathname: `/inventory/quick-marc/${page}/${instance.id}`,
@@ -289,15 +298,15 @@ class ViewInstance extends React.Component {
   };
 
   editInstanceMarc = () => {
-    this.redirectToQuickMarcPage('edit-bib');
+    this.redirectToQuickMarcPage(quickMarcPages.editInstance);
   };
 
   duplicateInstanceMarc = () => {
-    this.redirectToQuickMarcPage('duplicate-bib');
+    this.redirectToQuickMarcPage(quickMarcPages.duplicateInstance);
   };
 
   createHoldingsMarc = () => {
-    this.redirectToQuickMarcPage('create-holdings');
+    this.redirectToQuickMarcPage(quickMarcPages.createHoldings);
   };
 
   selectInstance = (selectedInstance) => {


### PR DESCRIPTION
## Purpose
Fix Edit a MARC holdings record generates a 500 error.

## Description
This bug occurred after editing MARC holdings record that was just created via quickmarc.
The problem was caused due to appending instance's `relatedRecordVersion` when redirecting to create holdings quickmarc page. Then when editing created MARC holdings record URL contained `relatedRecordVersion` of instance and then the `relatedRecordVersion` of the holdings record itself was appended.

## Issues
[UIIN-1997](https://issues.folio.org/browse/UIIN-1997)