### PR TITLE
UIIN-1933 correctly place/omit accordion separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
   after interface search 0.7 was bumped. Breaking change that is
   unfortunately not reflected in search interface. Fixes UIIN-1941.
 * Fix Edit a MARC holdings record generates a 500 error. Fixes UIIN-1997.
-
 * The highlight of search results is not specific to the given search but now highlight all kinds of data in the record. Refs UIIN-1454.
 * Fetch parent and child sub instances in one query. Fixes UIIN-1902.
 * Missing Field - Receipt status under the Edit Holdings View. Fixes UIIN-1943.
@@ -28,6 +27,7 @@
 * Optimistic locking: display error message to inform user about OL. Refs UIIN-1987.
 * Instances linked to package order lines are not displaying Order information. Fixes UIIN-1995.
 * Remove expandAll parameter from browse requests. Refs UIIN-1990.
+* Correctly place (or omit) seprators between filters. Refs UIIN-1933.
 
 ## [9.0.0](https://github.com/folio-org/ui-inventory/tree/v9.0.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v8.0.0...v9.0.0)

--- a/src/components/HoldingsRecordFilters/HoldingsRecordFilters.js
+++ b/src/components/HoldingsRecordFilters/HoldingsRecordFilters.js
@@ -184,7 +184,6 @@ const HoldingsRecordFilters = (props) => {
         label={<FormattedMessage id="ui-inventory.statisticalCode" />}
         id={FACETS.HOLDINGS_STATISTICAL_CODE_IDS}
         name={FACETS.HOLDINGS_STATISTICAL_CODE_IDS}
-        separator={false}
         closedByDefault
         header={FilterAccordionHeader}
         displayClearButton={activeFilters[FACETS.HOLDINGS_STATISTICAL_CODE_IDS]?.length > 0}

--- a/src/components/InstanceFilters/InstanceFilters.js
+++ b/src/components/InstanceFilters/InstanceFilters.js
@@ -183,7 +183,6 @@ const InstanceFilters = props => {
         label={<FormattedMessage id={`ui-inventory.instances.${FACETS.LANGUAGE}`} />}
         id={FACETS.LANGUAGE}
         name={FACETS.LANGUAGE}
-        separator={false}
         closedByDefault
         header={FilterAccordionHeader}
         displayClearButton={activeFilters[FACETS.LANGUAGE]?.length > 0}
@@ -319,7 +318,6 @@ const InstanceFilters = props => {
         label={<FormattedMessage id="ui-inventory.statisticalCode" />}
         id={FACETS.STATISTICAL_CODE_IDS}
         name={FACETS.STATISTICAL_CODE_IDS}
-        separator={false}
         closedByDefault
         header={FilterAccordionHeader}
         displayClearButton={activeFilters[FACETS.STATISTICAL_CODE_IDS]?.length > 0}

--- a/src/components/ItemFilters/ItemFilters.js
+++ b/src/components/ItemFilters/ItemFilters.js
@@ -135,6 +135,7 @@ const ItemFilters = (props) => {
         header={FilterAccordionHeader}
         displayClearButton={!_.isEmpty(activeFilters[FACETS.ITEM_STATUS])}
         onClearFilter={() => onClear(FACETS.ITEM_STATUS)}
+        separator={false}
       >
         <CheckboxFacet
           name={FACETS.ITEM_STATUS}
@@ -151,7 +152,6 @@ const ItemFilters = (props) => {
         label={<FormattedMessage id={`ui-inventory.filters.${FACETS.EFFECTIVE_LOCATION}`} />}
         id={FACETS.EFFECTIVE_LOCATION}
         name={FACETS.EFFECTIVE_LOCATION}
-        separator
         header={FilterAccordionHeader}
         displayClearButton={activeFilters[FACETS.EFFECTIVE_LOCATION]?.length > 0}
         onClearFilter={() => onClear(FACETS.EFFECTIVE_LOCATION)}
@@ -191,7 +191,6 @@ const ItemFilters = (props) => {
         label={<FormattedMessage id={`ui-inventory.${FACETS.MATERIAL_TYPE}`} />}
         id={FACETS.MATERIAL_TYPE}
         name={FACETS.MATERIAL_TYPE}
-        separator
         closedByDefault
         header={FilterAccordionHeader}
         displayClearButton={!_.isEmpty(activeFilters[FACETS.MATERIAL_TYPE])}
@@ -231,7 +230,6 @@ const ItemFilters = (props) => {
         label={<FormattedMessage id="ui-inventory.statisticalCode" />}
         id={FACETS.ITEMS_STATISTICAL_CODE_IDS}
         name={FACETS.ITEMS_STATISTICAL_CODE_IDS}
-        separator={false}
         closedByDefault
         header={FilterAccordionHeader}
         displayClearButton={activeFilters[FACETS.ITEMS_STATISTICAL_CODE_IDS]?.length > 0}


### PR DESCRIPTION
Several accordions' separators were incorrect, probably as a result of
copy-paste accordions as new filters were added.

Refs [UIIN-1933](https://issues.folio.org/browse/UIIN-1933)
