### PR TITLE
UIIN-2006 avoid timeouts when retrieving item-counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Optimistic locking: display error message to inform user about OL. Refs UIIN-1987.
 * Instances linked to package order lines are not displaying Order information. Fixes UIIN-1995.
 * Remove expandAll parameter from browse requests. Refs UIIN-1990.
+* Eliminate timeout for counting holdings-records' items. Refs UIIN-2006.
 
 ## [9.0.0](https://github.com/folio-org/ui-inventory/tree/v9.0.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v8.0.0...v9.0.0)

--- a/src/hooks/useHoldingItemsQuery.js
+++ b/src/hooks/useHoldingItemsQuery.js
@@ -9,7 +9,7 @@ const useHoldingItemsQuery = (
   holdingsRecordId,
   options = { searchParams: {}, key: 'items' },
 ) => {
-  const ky = useOkapiKy();
+  const ky = useOkapiKy().extend({ timeout: false });
   const [namespace] = useNamespace();
   const queryKey = [namespace, options.key, holdingsRecordId];
   const defaultSearchParams = {

--- a/src/hooks/useHoldingItemsQuery.test.js
+++ b/src/hooks/useHoldingItemsQuery.test.js
@@ -30,6 +30,7 @@ describe('useHoldingItemsQuery', () => {
   beforeEach(() => {
     useOkapiKy.mockClear().mockReturnValue({
       get: mockGet,
+      extend: jest.fn().mockReturnValue({ get: mockGet }),
     });
   });
 


### PR DESCRIPTION
Instance records with N holdings-records will have to issue N queries to
count their items and this can take a looooong time, longer than the
default timeout as configured in stripes-core. Rather than putting a
longer cap on the timeout, I think the best option is to just act like
fetch and wait indefinitely until the requests return.

https://github.com/folio-org/stripes-core/blob/6afa0d761aac4f4d00073a781072ae3ec0c8f6dd/doc/okapiKy.md#timeouts
describes this precisely.

Refs [UIIN-2006](https://issues.folio.org/browse/UIIN-2006)

