### PR TITLE
UIIN-2016 retrieve up to 5000 locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Correctly place (or omit) seprators between filters. Refs UIIN-1933.
 * Eliminate timeout for counting holdings-records' items. Refs UIIN-2006.
 * Update locations in `<ViewHoldingsRecord>` after edit. Fixes UIIN-1980.
+* Retrieve up to 5000 locations when viewing Instances. Refs UIIN-2016.
 
 ## [9.0.0](https://github.com/folio-org/ui-inventory/tree/v9.0.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v8.0.0...v9.0.0)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -129,7 +129,7 @@ class ViewInstance extends React.Component {
     locations: {
       type: 'okapi',
       records: 'locations',
-      path: 'locations?limit=1000',
+      path: 'locations?limit=5000',
     },
     configs: {
       type: 'okapi',


### PR DESCRIPTION
Tenants may have more than 1000 locations; [5000 is the standard for
location-related values in stripes-smart-components](https://github.com/folio-org/stripes-smart-components/blob/cd38c4bbbef53e49e93f62f9bda3d134a9909fd1/lib/LocationLookup/LocationModal.js#L120) so we will use that
value here, too.

Refs [UIIN-2016](https://issues.folio.org/browse/UIIN-2016)