### PR TITLE
UIIN-2046: Inventory app crashes when locations are not loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Inventory causes an error. Refs UIIN-2012.
 * Remove `react-hot-loader`. Refs UIIN-1981.
 * Search results with a single hit should automatically open the detail view. Fixes UIIN-2019.
 * Fix inventory app white screen when no tags exist. Fixes UIIN-2030.
+* Fix inventory app crashes when viewing Holdings and locations don't exist. Fixes UIIN-2046.
 
 ## [9.0.0](https://github.com/folio-org/ui-inventory/tree/v9.0.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v8.0.0...v9.0.0)

--- a/src/Instance/HoldingsList/Holding/HoldingAccordion.js
+++ b/src/Instance/HoldingsList/Holding/HoldingAccordion.js
@@ -30,7 +30,7 @@ const HoldingAccordion = ({
   };
 
   const { locationsById } = useContext(DataContext);
-  const labelLocation = holding.permanentLocationId ? locationsById[holding.permanentLocationId].name : '';
+  const labelLocation = holding.permanentLocationId ? locationsById[holding.permanentLocationId]?.name : '';
   const [open, setOpen] = useState(false);
   const [openFirstTime, setOpenFirstTime] = useState(false);
   const { totalRecords, isFetching } = useHoldingItemsQuery(holding.id, { searchParams, key: 'itemCount' });

--- a/src/Instance/HoldingsList/Holding/MoveToDropdown/MoveToDropdown.js
+++ b/src/Instance/HoldingsList/Holding/MoveToDropdown/MoveToDropdown.js
@@ -44,7 +44,7 @@ export const MoveToDropdown = ({
   const movetoHoldings = filteredHoldings.map(item => {
     return {
       ...item,
-      labelLocation: item.permanentLocationId ? locationsById[item.permanentLocationId].name : '',
+      labelLocation: item.permanentLocationId ? locationsById[item.permanentLocationId]?.name : '',
       callNumber: callNumberLabel(item),
     };
   });

--- a/src/Instance/MoveHoldingContext/MoveHoldingContext.js
+++ b/src/Instance/MoveHoldingContext/MoveHoldingContext.js
@@ -177,7 +177,7 @@ const MoveHoldingContext = ({
     () => {
       const targetHolding = holdingsById[dragToId];
       const callNumber = callNumberLabel(targetHolding);
-      const labelLocation = targetHolding?.permanentLocationId ? locationsById[targetHolding.permanentLocationId].name : '';
+      const labelLocation = targetHolding?.permanentLocationId ? locationsById[targetHolding.permanentLocationId]?.name : '';
 
       const count = movingItems.length;
 

--- a/src/providers/DataProvider.js
+++ b/src/providers/DataProvider.js
@@ -18,11 +18,9 @@ const DataProvider = ({
   const isLoading = useMemo(() => {
     // eslint-disable-next-line guard-for-in
     for (const key in manifest) {
-      const isRecourceLoading = !(resources?.[key]?.hasLoaded)
-        && resources?.[key]?.isPending
-        && !(resources?.[key]?.failed);
+      const isResourceLoading = !resources?.[key]?.hasLoaded && !resources?.[key]?.failed;
 
-      if (manifest[key].type === 'okapi' && isRecourceLoading) {
+      if (manifest[key].type === 'okapi' && isResourceLoading) {
         return true;
       }
     }


### PR DESCRIPTION
## Description
When location request either fails for some reason, or has empty response and a Holdings record tries to find location name by it's `permanentLocationId` - the app crashes

## Issues
[UIIN-2046](https://issues.folio.org/browse/UIIN-2046)