### PR TITLE
UIIN-2030: Adjust isPending check for reference data resources

### DIFF
--- a/src/providers/DataProvider.js
+++ b/src/providers/DataProvider.js
@@ -18,11 +18,13 @@ const DataProvider = ({
   const isLoading = useMemo(() => {
     // eslint-disable-next-line guard-for-in
     for (const key in manifest) {
-      const isRecourceLoading = !(resources?.[key]?.hasLoaded)
-        && resources?.[key]?.isPending
-        && !(resources?.[key]?.failed);
+      const resource = resources?.[key] ?? {};
+      // if the resource is in pending mode (which means it is currently trying to finalize the request)
+      // or if the resource hasn't started at all yet (all flags are still set to false)
+      // then return true indicating that the resource is still pending
+      const isResourceLoading = resource.isPending || (!resource.hasLoaded && !resource.failed && !resource.isPending);
 
-      if (manifest[key].type === 'okapi' && isRecourceLoading) {
+      if (manifest[key].type === 'okapi' && isResourceLoading) {
         return true;
       }
     }


### PR DESCRIPTION
The issue with the previous attempt was that during the first render the resources are still in the initial state:

````js
hasLoaded: false
failed: false
isPending: false
````

causing the `isLoading` to return `false`.

This PR changes it a bit and it will return `isPending === true` if the resource is marked as `isPending` or if it did not start the fetching yet (it is still in the initial state). 

[UIIN-2030](https://issues.folio.org/browse/UIIN-2030)

