### PR TITLE
lock @vue/compiler-sfc

### DIFF
--- a/package.json
+++ b/package.json
@@ -909,6 +909,7 @@
     "@folio/plugin-find-instance": "^6.0.0"
   },
   "resolutions": {
-    "moment": "~2.24.0"
+    "moment": "~2.24.0",
+    "@vue/compiler-sfc": "3.2.33"
   }
 }


### PR DESCRIPTION
Spike: lock `@vue/compiler-sfc` to `3.2.33` to avoid the buggy 3.2.34 release to see if vuejs/core/issues/5957 is the source of our build failures on our CI machines that are still running NodeJS v12. 