### PR TITLE
provide CalloutContext.Provider in the test harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Inventory causes an error. Refs UIIN-2012.
 * Creating an order from instance record. Add action to the Main Pane Header. Refs UIIN-547.
 * Cannot read properties of undefined (reading 'shelfKey'). Refs UIIN-2038.
 * Add OCLC search option. Refs UIIN-1208.
+* Provide `CalloutContext.Provider` in the test harness to avoid `callout.sendCallout` NPEs.
 
 ## [9.0.0](https://github.com/folio-org/ui-inventory/tree/v9.0.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v8.0.0...v9.0.0)

--- a/test/jest/helpers/Harness.js
+++ b/test/jest/helpers/Harness.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { IntlProvider } from 'react-intl';
+import { CalloutContext } from '@folio/stripes/core';
 
 import translations from '../../../translations/ui-inventory/en';
 import prefixKeys from './prefixKeys';
@@ -24,14 +25,16 @@ const Harness = ({
   }
 
   return (
-    <IntlProvider
-      locale="en"
-      key="en"
-      timeZone="UTC"
-      messages={allTranslations}
-    >
-      {children}
-    </IntlProvider>
+    <CalloutContext.Provider value={{ sendCallout: () => { } }}>
+      <IntlProvider
+        locale="en"
+        key="en"
+        timeZone="UTC"
+        messages={allTranslations}
+      >
+        {children}
+      </IntlProvider>
+    </CalloutContext.Provider>
   );
 };
 


### PR DESCRIPTION
Wrap the component in `<CalloutContext.Provider>` with a dummy
`sendCallout` prop so that tests that render components that leverage
context don't blow up with NPEs. Locally, we'd see warnings in the test
output like
```
[UnhandledPromiseRejection: This error originated either by throwing
inside of an async function without a catch block, or by rejecting a
promise which was not handled with .catch(). The promise rejected
with the reason “TypeError: Cannot read properties of undefined
(reading ‘sendCallout’)“.] {
  code: ‘ERR_UNHANDLED_REJECTION’
}
```
but tests would pass; in CI, however, such errors would cause the test
suite to abort.

This was discovered while working on UIIN-2049 to bump the CI Node
version to v16.
