### PR TITLE
UIIN-2052: Add id attribute to Instance movement sections to use in e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Inventory causes an error. Refs UIIN-2012.
 * Add OCLC search option. Refs UIIN-1208.
 * Provide `CalloutContext.Provider` in the test harness to avoid `callout.sendCallout` NPEs.
 * Select existing order when creating an order from instance record. Refs UIIN-2041.
+* Add id attribute to Instance movement sections to use in e2e tests. Refs UIIN-2052.
 
 ## [9.0.0](https://github.com/folio-org/ui-inventory/tree/v9.0.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v8.0.0...v9.0.0)

--- a/src/Instance/InstanceMovement/InstanceMovement.js
+++ b/src/Instance/InstanceMovement/InstanceMovement.js
@@ -27,12 +27,14 @@ const InstanceMovement = ({
           instance={instanceFrom}
           onClose={onClose}
           data-test-movement-from-instance-details
+          id="movement-from-instance-details"
         />
 
         <InstanceMovementDetailsContainer
           instance={instanceTo}
           onClose={onClose}
           data-test-movement-to-instance-details
+          id="movement-to-instance-details"
         />
       </MoveHoldingContext>
     </Paneset>

--- a/src/Instance/InstanceMovement/InstanceMovementDetails/InstanceMovementDetails.js
+++ b/src/Instance/InstanceMovement/InstanceMovementDetails/InstanceMovementDetails.js
@@ -23,6 +23,7 @@ const InstanceMovementDetails = ({
   instance,
   onClose,
   hasMarc,
+  id,
 }) => {
   const stripes = useStripes();
 
@@ -61,6 +62,7 @@ const InstanceMovementDetails = ({
       onClose={closeInstance}
       actionMenu={getActionMenu}
       data-test-instance-movement-details={instance.id}
+      id={id}
     >
       <Droppable
         droppableId={`${instance.id}`}
@@ -91,10 +93,12 @@ InstanceMovementDetails.propTypes = {
   instance: PropTypes.object,
   hasMarc: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
+  id: PropTypes.string,
 };
 
 InstanceMovementDetails.defaultProps = {
   instance: {},
+  id: 'movement-instance-details',
 };
 
 export default InstanceMovementDetails;

--- a/src/Instance/InstanceMovement/InstanceMovementDetails/InstanceMovementDetailsContainer.js
+++ b/src/Instance/InstanceMovement/InstanceMovementDetails/InstanceMovementDetailsContainer.js
@@ -12,6 +12,7 @@ const InstanceMovementDetailsContainer = ({
   instance,
   onClose,
   mutator,
+  id,
 }) => {
   const [marc, setMarc] = useState();
 
@@ -26,6 +27,7 @@ const InstanceMovementDetailsContainer = ({
       instance={instance}
       onClose={onClose}
       hasMarc={Boolean(marc)}
+      id={id}
     />
   );
 };
@@ -34,10 +36,12 @@ InstanceMovementDetailsContainer.propTypes = {
   instance: PropTypes.object,
   onClose: PropTypes.func.isRequired,
   mutator: PropTypes.object.isRequired,
+  id: PropTypes.string,
 };
 
 InstanceMovementDetailsContainer.defaultProps = {
   instance: {},
+  id: 'movement-instance-details',
 };
 
 InstanceMovementDetailsContainer.manifest = Object.freeze({


### PR DESCRIPTION
## Purpose
Add `id` to Instance movement sections to make it's easier to query them in e2e tests.

## Issues
[UIIN-2052](https://issues.folio.org/browse/UIIN-2052)