### PR TITLE
UIIN-2044: Option View Source is not available in holdings record view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Inventory causes an error. Refs UIIN-2012.
 * Select existing order when creating an order from instance record. Refs UIIN-2041.
 * Add id attribute to Instance movement sections to use in e2e tests. Refs UIIN-2052.
 * Inventory > Update Instance search options dropdown with Browse contributors. Refs UIIN-2023.
+* Fix option View Source is not available in holdings record view. Refs UIIN-2044.
 
 ## [9.0.0](https://github.com/folio-org/ui-inventory/tree/v9.0.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v8.0.0...v9.0.0)

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -92,6 +92,7 @@ class ViewHoldingsRecord extends React.Component {
     instances1: {
       type: 'okapi',
       path: 'inventory/instances/:{id}',
+      accumulate: true,
     },
     tagSettings: {
       type: 'okapi',
@@ -122,13 +123,17 @@ class ViewHoldingsRecord extends React.Component {
   }
 
   componentDidMount() {
-    this.props.mutator.holdingsRecords.GET();
+    const holdingsRecordPromise = this.props.mutator.holdingsRecords.GET();
+    const instances1Promise = this.props.mutator.instances1.GET();
 
-    if (this.props.resources.instances1?.records[0]?.source) {
-      if (this.isMARCSource() && !this.state.markRecord) {
-        this.getMARCRecord();
-      }
-    }
+    Promise.all([holdingsRecordPromise, instances1Promise])
+      .then(() => {
+        if (this.props.resources.instances1?.records[0]?.source) {
+          if (this.isMARCSource() && !this.state.marcRecord) {
+            this.getMARCRecord();
+          }
+        }
+      });
   }
 
   componentDidUpdate(prevProps) {
@@ -137,7 +142,7 @@ class ViewHoldingsRecord extends React.Component {
     const hasHoldingsRecordsLoaded = this.props.resources.holdingsRecords?.hasLoaded;
 
     if (wasHoldingsRecordsPending !== isHoldingsRecordsPending && hasHoldingsRecordsLoaded) {
-      if (this.isMARCSource() && !this.state.markRecord) {
+      if (this.isMARCSource() && !this.state.marcRecord) {
         this.getMARCRecord();
       }
     }
@@ -1022,6 +1027,9 @@ ViewHoldingsRecord.propTypes = {
   paneWidth: PropTypes.string,
   referenceTables: PropTypes.object.isRequired,
   mutator: PropTypes.shape({
+    instances1: PropTypes.shape({
+      GET: PropTypes.func.isRequired,
+    }),
     holdingsRecords: PropTypes.shape({
       GET: PropTypes.func.isRequired,
       PUT: PropTypes.func.isRequired,

--- a/src/ViewHoldingsRecord.test.js
+++ b/src/ViewHoldingsRecord.test.js
@@ -26,6 +26,9 @@ const defaultProps = {
     temporaryLocation: { hasLoaded: true },
   },
   mutator: {
+    instances1: {
+      GET: jest.fn(() => Promise.resolve()),
+    },
     holdingsRecords: {
       GET: jest.fn(() => Promise.resolve({ hrid: 'hrid' })),
       POST: jest.fn(() => Promise.resolve()),


### PR DESCRIPTION
## Purpose
Fix options "View Source" and "Edit in quickMARC" are not available in holdings record view.

This issue was mostly reproduced in e2e tests, when the required resources didn't update in time.
The not loaded `instances1` resource resulted in `undefined` source which prevented from getting `marcRecord` data in `componentDidMount`.
The not loaded `holdingsRecords` resource resulted in having `isPending` always false and thus prevented from getting `marcRecord` data in `componentDidUpdate`.
And empty `marcRecord` led to disabled "View Source" and "Edit in quickMARC" options.

## Approach
The fix was to wait for promises for `instances1` and `holdingsRecords` resources to resolve in `componentDidMount` before continuing.

## Screenshots
With this fix, affected tests are passing successfully.

**C345404** in `cypress/integration/inventory/moving-items.spec.js`:

![image](https://user-images.githubusercontent.com/84023879/170293109-8b5bc371-96f0-4537-8c82-50bfa3a32edc.png)

**C345390, C345398, and C345400** in `cypress/integration/quickmark/holding-quickmark.spec.js`:

![image](https://user-images.githubusercontent.com/84023879/170293667-2e3078ec-ce0d-4f21-be02-2bf9d9064945.png)

## Issues
[UIIN-2044](https://issues.folio.org/browse/UIIN-2044)