### PR TITLE
UIIN-2044: Fix in view Holding displayed old Instance after moving Holding to a new Instance

### DIFF
--- a/src/Instance/InstanceMovement/InstanceMovementContainer.js
+++ b/src/Instance/InstanceMovement/InstanceMovementContainer.js
@@ -48,7 +48,6 @@ const InstanceMovementContainer = ({
 
     history.push({
       pathname: `/inventory/view/${instanceId}`,
-      search: history.location.search,
     });
   }, [history, instanceFrom, instanceTo]);
 


### PR DESCRIPTION
## Purpose
Fix in view Holding record displayed old Instance after moving Holding record to a new Instance.

Previously the instance data was taken from the first record in `this.props.resources.instances1.records`, but after moving Holding record between instances `this.props.resources.instances1.records` contains more than one record, the first of which being not the needed one.
The solution was to set a variable in the state to the value of the resolved `instances1` promise in `componentDidMount` and use this data to display Holdings Instance.

Fix for [this PR](https://github.com/folio-org/ui-inventory/pull/1695)

Also, fixed an issue when firstly search for a FROM Instance and the list has **one result**, then perform a move of a Holding record and go to a TO Instance - the TO Instance view is changing to a FROM Instance view due to the search params. Removing the `search` when going to a TO Instance view eliminates the problem.

## Issues
[UIIN-2044](https://issues.folio.org/browse/UIIN-2044)