### PR TITLE
UIIN-2063: When click view Holdings the Something went wrong error page appears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Inventory causes an error. Refs UIIN-2012.
 * Browse contributors list. Refs UIIN-2024.
 * Browse form - first and last record navigation. Refs UIIN-1912.
 * Inventory >  Contributors Browse - Create a Name Type facet. Refs UIIN-2021.
+* Fix when click view Holdings the Something went wrong error page appears. Refs UIIN-2063.
 
 ## [9.0.0](https://github.com/folio-org/ui-inventory/tree/v9.0.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v8.0.0...v9.0.0)

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -427,6 +427,7 @@ class ViewHoldingsRecord extends React.Component {
       holdingsRecords,
       instances1,
     } = this.props.resources;
+    const { instance } = this.state;
 
     if (this.state.isLoadingUpdatedHoldingsRecord) {
       return false;
@@ -437,6 +438,10 @@ class ViewHoldingsRecord extends React.Component {
     }
 
     if (!instances1 || !instances1.hasLoaded) {
+      return true;
+    }
+
+    if (!instance) {
       return true;
     }
 

--- a/src/ViewHoldingsRecord.test.js
+++ b/src/ViewHoldingsRecord.test.js
@@ -3,7 +3,7 @@ import '../test/jest/__mock__';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { MemoryRouter } from 'react-router-dom';
 import user from '@testing-library/user-event';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 
 import { renderWithIntl, translationsProperties } from '../test/jest/helpers';
 import ViewHoldingsRecord from './ViewHoldingsRecord';
@@ -27,7 +27,7 @@ const defaultProps = {
   },
   mutator: {
     instances1: {
-      GET: jest.fn(() => Promise.resolve()),
+      GET: jest.fn(() => Promise.resolve({ id: 'instanceId' })),
     },
     holdingsRecords: {
       GET: jest.fn(() => Promise.resolve({ hrid: 'hrid' })),
@@ -83,11 +83,13 @@ describe('ViewHoldingsRecord actions', () => {
   it('should close view holding page', async () => {
     renderViewHoldingsRecord();
 
-    const closeBtn = screen.getAllByRole('button')[0];
+    await waitFor(() => {
+      const closeBtn = screen.getAllByRole('button')[0];
 
-    user.click(closeBtn);
+      user.click(closeBtn);
 
-    expect(defaultProps.history.push).toHaveBeenCalled();
+      expect(defaultProps.history.push).toHaveBeenCalled();
+    });
   });
 
   it('should translate to edit holding form page', async () => {


### PR DESCRIPTION
## Purpose
Fix when click view Holdings the Something went wrong error page appears.

The issue was caused by changes in [this PR](https://github.com/folio-org/ui-inventory/pull/1699)

The problem was that the component started to render before promises in `componentDidMount` are resolved, thus resulting in an empty `instance`.
The fix is to wait until `instance` is defined and only then render the component.

## Screenshots
![chrome_eu0D4NBo6Q](https://user-images.githubusercontent.com/84023879/171632129-0422361d-9f43-46cb-b1cc-57376c7e4df8.gif)

## Issues
[UIIN-2063](https://issues.folio.org/browse/UIIN-2063)