### PR TITLE
Revert "UIIN-2045 Fix browse form refresh issue (#1700)"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ import { DataProvider, HoldingsProvider } from './providers';
 const InventoryRouting = (props) => {
   const [isShortcutsModalOpen, setIsShortcutsModalOpen] = useState(false);
   const { showSettings, match: { path } } = props;
+
   const focusSearchField = () => {
     const el = document.getElementById('input-inventory-search');
 
@@ -70,118 +71,115 @@ const InventoryRouting = (props) => {
 
   return (
     <DataProvider>
-      <div key={props.location.key}>
-        <HoldingsProvider>
-          <CommandList commands={defaultKeyboardShortcuts}>
-            <HasCommand
-              commands={shortcuts}
-              isWithinScope={checkScope}
-              scope={document.body}
-            >
-              <AppContextMenu>
-                {(handleToggle) => (
-                  <NavList>
-                    <NavListSection>
-                      <NavListItem
-                        id="keyboard-shortcuts-item"
-                        onClick={() => {
-                          handleToggle();
-                          toggleModal();
-                        }}
-                      >
-                        <FormattedMessage id="ui-inventory.appMenu.keyboardShortcuts" />
-                      </NavListItem>
-                    </NavListSection>
-                  </NavList>
-                )}
-              </AppContextMenu>
-              <Switch>
-                <Route
-                  path={`${path}/create/:id/holding`}
-                  component={CreateHoldingRoute}
-                />
-                <Route
-                  path={`${path}/edit/:id/:holdingId/:itemId`}
-                  component={EditItemRoute}
-                />
-                <Route
-                  path={`${path}/create/:id/:holdingId/item`}
-                  component={CreateItemRoute}
-                />
-                <Route
-                  path={`${path}/move/:idFrom/:idTo/instance`}
-                  component={InstanceMovementRoute}
-                />
-                <Route
-                  path={`${path}/view/:id/:holdingsrecordid/:itemid`}
-                  component={ItemRoute}
-                />
-                <Route
-                  path={`${path}/copy/:id/:holdingsrecordid/:itemid`}
-                  component={DuplicateItemRoute}
-                />
-                <Route
-                  path={`${path}/quick-marc`}
-                  component={QuickMarcRoute}
-                />
-                <Route
-                  path={`${path}/viewsource/:id/:holdingsrecordid`}
-                  component={HoldingsMarcRoute}
-                />
-                <Route
-                  path={`${path}/viewsource/:id`}
-                  component={InstanceMarcRoute}
-                />
-                <Route
-                  path={`${path}/edit/:id/instance`}
-                  component={InstanceEditRoute}
-                />
-                <Route
-                  path={`${path}/view/:id/:holdingsrecordid`}
-                  component={ViewHoldingRoute}
-                />
-                <Route
-                  path={`${path}/edit/:id/:holdingsrecordid`}
-                  component={EditHoldingRoute}
-                />
-                <Route
-                  path={`${path}/copy/:id/:holdingsrecordid`}
-                  component={DuplicateHoldingRoute}
-                />
-                <Route
-                  path={`${path}/view-requests/:id`}
-                  component={ViewRequestsRoute}
-                />
-                <Route
-                  path={`${path}/import/:id`}
-                  component={ImportRoute}
-                />
-                <Route
-                  path={`${path}/import`}
-                  component={ImportRoute}
-                />
-                <Route
-                  path={path}
-                  component={InstancesRoute}
-                />
-              </Switch>
-            </HasCommand>
-          </CommandList>
-          {isShortcutsModalOpen && (
-            <KeyboardShortcutsModal
-              allCommands={defaultKeyboardShortcuts}
-              onClose={toggleModal}
-            />
-          )}
-        </HoldingsProvider>
-      </div>
+      <HoldingsProvider>
+        <CommandList commands={defaultKeyboardShortcuts}>
+          <HasCommand
+            commands={shortcuts}
+            isWithinScope={checkScope}
+            scope={document.body}
+          >
+            <AppContextMenu>
+              {(handleToggle) => (
+                <NavList>
+                  <NavListSection>
+                    <NavListItem
+                      id="keyboard-shortcuts-item"
+                      onClick={() => {
+                        handleToggle();
+                        toggleModal();
+                      }}
+                    >
+                      <FormattedMessage id="ui-inventory.appMenu.keyboardShortcuts" />
+                    </NavListItem>
+                  </NavListSection>
+                </NavList>
+              )}
+            </AppContextMenu>
+            <Switch>
+              <Route
+                path={`${path}/create/:id/holding`}
+                component={CreateHoldingRoute}
+              />
+              <Route
+                path={`${path}/edit/:id/:holdingId/:itemId`}
+                component={EditItemRoute}
+              />
+              <Route
+                path={`${path}/create/:id/:holdingId/item`}
+                component={CreateItemRoute}
+              />
+              <Route
+                path={`${path}/move/:idFrom/:idTo/instance`}
+                component={InstanceMovementRoute}
+              />
+              <Route
+                path={`${path}/view/:id/:holdingsrecordid/:itemid`}
+                component={ItemRoute}
+              />
+              <Route
+                path={`${path}/copy/:id/:holdingsrecordid/:itemid`}
+                component={DuplicateItemRoute}
+              />
+              <Route
+                path={`${path}/quick-marc`}
+                component={QuickMarcRoute}
+              />
+              <Route
+                path={`${path}/viewsource/:id/:holdingsrecordid`}
+                component={HoldingsMarcRoute}
+              />
+              <Route
+                path={`${path}/viewsource/:id`}
+                component={InstanceMarcRoute}
+              />
+              <Route
+                path={`${path}/edit/:id/instance`}
+                component={InstanceEditRoute}
+              />
+              <Route
+                path={`${path}/view/:id/:holdingsrecordid`}
+                component={ViewHoldingRoute}
+              />
+              <Route
+                path={`${path}/edit/:id/:holdingsrecordid`}
+                component={EditHoldingRoute}
+              />
+              <Route
+                path={`${path}/copy/:id/:holdingsrecordid`}
+                component={DuplicateHoldingRoute}
+              />
+              <Route
+                path={`${path}/view-requests/:id`}
+                component={ViewRequestsRoute}
+              />
+              <Route
+                path={`${path}/import/:id`}
+                component={ImportRoute}
+              />
+              <Route
+                path={`${path}/import`}
+                component={ImportRoute}
+              />
+              <Route
+                path={path}
+                component={InstancesRoute}
+              />
+            </Switch>
+          </HasCommand>
+        </CommandList>
+        {isShortcutsModalOpen && (
+          <KeyboardShortcutsModal
+            allCommands={defaultKeyboardShortcuts}
+            onClose={toggleModal}
+          />
+        )}
+      </HoldingsProvider>
     </DataProvider>
   );
 };
 
 InventoryRouting.propTypes = {
   match: ReactRouterPropTypes.match,
-  location: ReactRouterPropTypes.location,
   showSettings: PropTypes.bool,
 };
 

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -102,7 +102,6 @@ export function buildManifestObject() {
       throwErrors: false,
       path: 'inventory/instances',
       resultDensity: 'sparse',
-      resourceShouldRefresh: true,
       GET: {
         path: (queryParams) => {
           if (queryParams.qindex === browseModeOptions.SUBJECTS) {


### PR DESCRIPTION
This reverts commit da5f59eae201ff15a7af899cab4681489d567613.

Unfortunately, #1700 caused as many problems as it solved. With those
changes in place, regular searches (not browses) that resulted in a
single record would cause the results list and details pane to be stuck
in an infinite refresh loop.

Refs [UIIN-2045](https://issues.folio.org/browse/UIIN-2045)