### PR TITLE
UIIN-2068: Applied filters don't reset when user select 'Browse contr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Inventory causes an error. Refs UIIN-2012.
 * Fix when click view Holdings the Something went wrong error page appears. Refs UIIN-2063.
 * Add filter/facet for instance status. Refs UIIN-1207.
 * Fix Name Type facet sends requests to incorrect endpoint. Refs UIIN-2062.
+* Applied filters don't reset when user select "Browse contributors" search option. Refs UIIN-2068
 
 ## [9.0.0](https://github.com/folio-org/ui-inventory/tree/v9.0.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v8.0.0...v9.0.0)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -961,7 +961,7 @@ class InstancesList extends React.Component {
 
       const isBrowseOption = Object.values(browseModeOptions).includes(e.target.value);
 
-      parentMutator.query.update({ qindex: e.target.value });
+      parentMutator.query.update({ qindex: e.target.value, filters: '' });
 
       if (isBrowseOption) {
         this.setState({ isSingleResult: false });

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -174,7 +174,7 @@ describe('InstancesList', () => {
             target: { value: 'contributors' },
           });
 
-          expect(updateMock).toHaveBeenCalledWith({ qindex: 'contributors' });
+          expect(updateMock).toHaveBeenCalledWith({ qindex: 'contributors', filters: '' });
         });
 
         it('should display Instances segment navigation button as primary', () => {


### PR DESCRIPTION
## Purpose
Applied filters don't reset when user select "Browse contributors" search option 

## Approach
Reset filters value when query index changes in `onChangeIndex` method