### PR TITLE
UIIN-2069 Synchronizing search query with url

### DIFF
--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -1092,6 +1092,7 @@ class InstancesList extends React.Component {
             hasNewButton={false}
             onResetAll={this.handleResetAll}
             sortableColumns={['title', 'contributors', 'publishers']}
+            syncQueryWithUrl
             resultsVirtualize={false}
             resultsOnMarkPosition={this.onMarkPosition}
             resultsOnResetMarkedPosition={this.resetMarkedPosition}


### PR DESCRIPTION
## Description
Pass new `syncQueryWithUrl` prop to `<SearchAndSort>` to synchronize the "SAS" local query state with query parameter in the url

## Issues
[UIIN-2069](https://issues.folio.org/browse/UIIN-2069)