### PR TITLE
UIIN-2096 Browse contributors | Instance search query does not include contributor Name type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 9.2.0 IN PROGRESS
 
+* Create Jest/RTL test for HoldingButtonsGroup.js. Refs UIEH-1746.
+* Browse contributors | Instance search query does not include contributor Name type. Fixes UIIN-2096.
+
 ## [9.1.0](https://github.com/folio-org/ui-inventory/tree/v9.1.0) (2022-06-28)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.0.0...v9.1.0)
 
@@ -71,7 +74,6 @@ Inventory causes an error. Refs UIIN-2012.
 * Improve query when search by call number. Refs UIIN-2078.
 * Rename and reorder search options for clarity, consistency. Fixes UIIN-2060, UIIN-2061.
 * Browse contributors. Placeholder match does not look right in the contributor column. Refs UIIN-2079.
-* Create Jest/RTL test for HoldingButtonsGroup.js. Refs UIEH-1746.
 
 ## [9.0.0](https://github.com/folio-org/ui-inventory/tree/v9.0.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v8.0.0...v9.0.0)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -56,6 +56,7 @@ import {
   QUICK_EXPORT_LIMIT,
   segments,
   browseModeOptions,
+  FACETS,
 } from '../../constants';
 import {
   IdReportGenerator,
@@ -754,7 +755,7 @@ class InstancesList extends React.Component {
         parentMutator.query.update({
           qindex: 'contributor',
           query: row.name,
-          filters: '',
+          filters: `${FACETS.SEARCH_CONTRIBUTORS}.${row.contributorNameTypeId}`,
         });
         break;
       default:

--- a/src/constants.js
+++ b/src/constants.js
@@ -211,6 +211,7 @@ export const FACETS = {
   HOLDINGS_PERMANENT_LOCATION: 'holdingsPermanentLocation',
   HOLDINGS_SOURCE: 'holdingsSource',
   NAME_TYPE: 'nameType',
+  SEARCH_CONTRIBUTORS: 'searchContributors',
   HOLDINGS_TYPE: 'holdingsType',
 };
 
@@ -244,6 +245,7 @@ export const FACETS_CQL = {
   HOLDINGS_PERMANENT_LOCATION: 'holdings.permanentLocationId',
   HOLDINGS_SOURCE: 'holdings.sourceId',
   NAME_TYPE: 'contributorNameTypeId',
+  SEARCH_CONTRIBUTORS: 'contributors.contributorNameTypeId',
   HOLDINGS_TYPE: 'holdings.holdingsTypeId',
 };
 

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -102,6 +102,11 @@ export const instanceFilterConfig = [
     cql: FACETS_CQL.NAME_TYPE,
     values: [],
   },
+  {
+    name: FACETS.SEARCH_CONTRIBUTORS,
+    cql: FACETS_CQL.SEARCH_CONTRIBUTORS,
+    values: [],
+  },
 ];
 
 export const instanceIndexes = [


### PR DESCRIPTION
## Description
Added contributor type filter to query when going from browse contributors to searching instances by contributor

## Screenshots

https://user-images.githubusercontent.com/19309423/177537262-4bcd1516-1fdd-47b0-89d1-77daff8fd006.mp4


## Issues
[UIIN-2096](https://issues.folio.org/browse/UIIN-2096)