### PR TITLE
UIIN-2092: browse contributors with special characters shows incomple…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Create Jest/RTL test for HoldingButtonsGroup.js. Refs UIEH-1746.
 * Browse contributors | Instance search query does not include contributor Name type. Fixes UIIN-2096.
+* Browse contributors with special characters shows incomplete error message. Refs UIIN-2092.
 
 ## [9.1.0](https://github.com/folio-org/ui-inventory/tree/v9.1.0) (2022-06-28)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.0.0...v9.1.0)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -793,6 +793,7 @@ class InstancesList extends React.Component {
       searchAndSortKey,
       isSingleResult
     } = this.state;
+    const { sendCallout } = this.context;
 
     const itemToView = getItem(`${namespace}.position`);
 
@@ -1024,6 +1025,19 @@ class InstancesList extends React.Component {
     const pagingCanGoNext = browseQueryExecuted ? !!other?.next : null;
     const pagingCanGoPrevious = browseQueryExecuted ? !!other?.prev : null;
 
+    const validateDataQuery = (query) => {
+      const endsWithAsterisk = new RegExp('\\*$');
+      const isValidSearch = !endsWithAsterisk.test(query);
+      const isContributors = optionSelected === browseModeOptions.CONTRIBUTORS;
+
+      if (isContributors && !isValidSearch) {
+        sendCallout({
+          type: 'error',
+          message: <FormattedMessage id="ui-inventory.browseContributors.results.error" />,
+        });
+      }
+    };
+
     return (
       <HasCommand
         commands={shortcuts}
@@ -1070,6 +1084,7 @@ class InstancesList extends React.Component {
             customPaneSub={this.renderPaneSub()}
             resultsFormatter={resultsFormatter}
             onCreate={this.onCreate}
+            validateSearchOnSubmit={validateDataQuery}
             viewRecordPerms="ui-inventory.instance.view"
             newRecordPerms="ui-inventory.instance.create"
             disableRecordCreation={disableRecordCreation || false}

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -414,6 +414,7 @@
   "instanceHrid": "Instance HRID",
   "browseCallNumbers": "Browse call numbers",
   "browseContributors": "Browse contributors",
+  "browseContributors.results.error": "Error returning results. Please retry or revise your search.",
   "browseSubjects": "Browse subjects",
   "browseCallNumbers.missedMatch": "would be here",
   "callNumber": "Call number",


### PR DESCRIPTION
## Purpose
Browse contributors with special characters shows incomplete error message

## Approach
Created a `validateQuery` callback that checks for an asterisk symbol in search value for 'Browse Contributors' mode and shows an error message if there is.