### PR TITLE
UIIN-2124: The "Instance" record still displayed at the third pane when user selects "Browse contributors" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * The table columns size changes when user return to the "Browse inventory" pane. Fixes UIIN-2106.
 * Non-exact match placeholder message displayed when user switching between browse contributors result list pages. Fixes UIIN-2087.
 * Browse contributors with special characters shows incomplete error message. Refs UIIN-2092.
+* The "Instance" record still displayed at the third pane when user selects "Browse contributors" option. Fixes UIIN-2124.
 
 ## [9.1.0](https://github.com/folio-org/ui-inventory/tree/v9.1.0) (2022-06-28)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.0.0...v9.1.0)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -781,6 +781,7 @@ class InstancesList extends React.Component {
       match: {
         path,
       },
+      goTo,
       namespace,
       stripes,
       fetchFacets,
@@ -967,6 +968,7 @@ class InstancesList extends React.Component {
       if (isBrowseOption) {
         parentMutator.browseModeRecords.reset();
         this.setState({ isSingleResult: false });
+        goTo(path);
       } else {
         this.setState({ isSingleResult: true });
       }

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -782,6 +782,7 @@ class InstancesList extends React.Component {
         path,
       },
       goTo,
+      getParams,
       namespace,
       stripes,
       fetchFacets,
@@ -960,6 +961,7 @@ class InstancesList extends React.Component {
 
     const onChangeIndex = (e) => {
       const qindex = e.target.value;
+      const params = getParams();
       const isBrowseOption = Object.values(browseModeOptions).includes(qindex);
 
       this.setState({ optionSelected: qindex });
@@ -969,7 +971,7 @@ class InstancesList extends React.Component {
       if (isBrowseOption) {
         parentMutator.browseModeRecords.reset();
         this.setState({ isSingleResult: false });
-        goTo(path, { qindex });
+        goTo(path, { ...params, qindex });
       } else {
         this.setState({ isSingleResult: true });
       }

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -959,16 +959,17 @@ class InstancesList extends React.Component {
     const isHandleOnNeedMore = Object.values(browseModeOptions).includes(optionSelected) ? handleOnNeedMore : null;
 
     const onChangeIndex = (e) => {
-      this.setState({ optionSelected: e.target.value });
+      const qindex = e.target.value;
+      const isBrowseOption = Object.values(browseModeOptions).includes(qindex);
 
-      const isBrowseOption = Object.values(browseModeOptions).includes(e.target.value);
+      this.setState({ optionSelected: qindex });
 
-      parentMutator.query.update({ qindex: e.target.value, filters: '' });
+      parentMutator.query.update({ qindex, filters: '' });
 
       if (isBrowseOption) {
         parentMutator.browseModeRecords.reset();
         this.setState({ isSingleResult: false });
-        goTo(path);
+        goTo(path, { qindex });
       } else {
         this.setState({ isSingleResult: true });
       }

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -30,6 +30,7 @@ const stripesStub = {
 };
 const data = {
   contributorTypes: [],
+  contributorNameTypes: [],
   instanceTypes: [],
   locations: [],
   instanceFormats: [],
@@ -153,10 +154,14 @@ describe('InstancesList', () => {
 
     describe('opening action menu', () => {
       beforeEach(() => {
+        fireEvent.change(screen.getByRole('combobox'), {
+          target: { value: 'all' }
+        });
+
         userEvent.click(screen.getByRole('button', { name: 'Actions' }));
       });
 
-      it('should disable toggable columns', () => {
+      it('should disable toggleable columns', () => {
         expect(screen.getByText(/show columns/i)).toBeInTheDocument();
       });
 
@@ -200,6 +205,10 @@ describe('InstancesList', () => {
   describe('rendering InstancesList with holdings segment', () => {
     it('should show Save Holdings UUIDs button', () => {
       renderInstancesList({ segment: 'holdings' });
+
+      fireEvent.change(screen.getByRole('combobox'), {
+        target: { value: 'all' }
+      });
 
       userEvent.click(screen.getByRole('button', { name: 'Actions' }));
 


### PR DESCRIPTION
## Purpose
The "Instance" record still displayed at the third pane when user selects "Browse contributors" option

## Approach
Redirect user to `inventory/` on `qindex` change to any browse options to close record view window.

## Issues
[UIIN-2124](https://issues.folio.org/browse/UIIN-2124)