### PR TITLE
UIIN-2130: valid prop type for regExpForQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * The table columns size changes when user return to the "Browse inventory" pane. Fixes UIIN-2106.
 * Non-exact match placeholder message displayed when user switching between browse contributors result list pages. Fixes UIIN-2087.
 * Browse contributors with special characters shows incomplete error message. Refs UIIN-2092.
+* Failed prop type: Invalid prop `regExpForQuery` of type `regexp` supplied to `SearchAndSort`, expected `string`. Fixes UIIN-2130
 
 ## [9.1.0](https://github.com/folio-org/ui-inventory/tree/v9.1.0) (2022-06-28)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.0.0...v9.1.0)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -1070,7 +1070,7 @@ class InstancesList extends React.Component {
             viewRecordComponent={ViewInstanceWrapper}
             editRecordComponent={InstanceForm}
             onChangeIndex={onChangeIndex}
-            regExpForQuery={regExp}
+            regExpForQuery={regExp.toString()}
             newRecordInitialValues={(this.state && this.state.copiedInstance) ? this.state.copiedInstance : {
               discoverySuppress: false,
               staffSuppress: false,


### PR DESCRIPTION
## Purpose
Failed prop type: Invalid prop `regExpForQuery` of type `regexp` supplied to `SearchAndSort`, expected `string`.