### PR TITLE
UIIN-2129: Do not load child/parent relations when navigating between two instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Incorrect format of the missing match in the call number browse. Refs UIIN-2141.
 * Increase limit for fetching child/parents relations. Fixes UIIN-2150.
 * The browse query changed when user returns from search to browse contributors pane. UIIN-2125.
+* Do not load child/parent relations when navigating between two instances. Fixes UIIN-2129.
 
 ## [9.1.0](https://github.com/folio-org/ui-inventory/tree/v9.1.0) (2022-06-28)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.0.0...v9.1.0)

--- a/src/ViewInstanceWrapper.js
+++ b/src/ViewInstanceWrapper.js
@@ -20,11 +20,11 @@ const ViewInstanceWrapper = (props) => {
   const childInstances = useLoadSubInstances(selectedInstance?.childInstances, 'subInstanceId');
 
   if (selectedInstance) {
-    if (parentInstances?.length) {
+    if (selectedInstance?.parentInstances?.length && parentInstances?.length) {
       selectedInstance = { ...selectedInstance, parentInstances };
     }
 
-    if (childInstances?.length) {
+    if (selectedInstance?.childInstances?.length && childInstances?.length) {
       selectedInstance = { ...selectedInstance, childInstances };
     }
   }


### PR DESCRIPTION
When navigating from one instance with a parent/child relation to another without the parent or child relation the relation from the previous instance would still be present in the local state.

This PR is trying to address it by checking if the newly opened instance has the parent and child relations present.

https://issues.folio.org/browse/UIIN-2129

