### PR TITLE
coerce undefined to boolean

### DIFF
--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -585,7 +585,7 @@ class ViewInstance extends React.Component {
           }
 
           <NewInstanceRequestButton
-            isTlrEnabled={titleLevelRequestsFeatureEnabled}
+            isTlrEnabled={!!titleLevelRequestsFeatureEnabled}
             instanceId={instance.id}
           />
         </MenuSection>


### PR DESCRIPTION
Coerce a potentially undefined state value to boolean in order to avoid
a prop-types warning. Values in conditionals are automatically coerced,
hence this isn't necessary in the many other places where it's
evaluated. Here, however, where it's just passed as a (required) prop,
we need to coerce it to a boolean value.

(stumbled on this in the JS console while hunting for sth else)