### PR TITLE
UIIN-2170: Support inventory 12.0 in okapiInterfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@
 * Do not load child/parent relations when navigating between two instances. Fixes UIIN-2129.
 * Remove shelving order in search option. Fixes UIIN-2151.
 * Clearing filters after clicking "Previous"/"Next" buttons in Inventory tab on Browse form. UIIN-2131.
-* Also support `instance-storage` `9.0`, `holdings-storage` `6.0`, `item-storage 10.0`. Refs UIIN-2162.
+* Also support `instance-storage` `9.0`. Refs UIIN-2162.
+* Also support `holdings-storage` `6.0`. Refs UIIN-2162.
+* Also support `item-storage` `10.0`. Refs UIIN-2162.
+* Also support `inventory` `12.0`. Refs UIIN-2170.
 * Request with operator "==/string" doesn't return the exact match results when search for contributor name. UIIN-2157.
 
 ## [9.1.0](https://github.com/folio-org/ui-inventory/tree/v9.1.0) (2022-06-28)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
       }
     ],
     "okapiInterfaces": {
-      "inventory": "10.10 11.0",
+      "inventory": "10.10 11.0 12.0",
       "search": "0.7",
       "source-storage-records": "3.0",
       "instance-storage": "7.0 8.0 9.0",


### PR DESCRIPTION
Add version `12.0` to the list of supported `inventory` interface versions.

`DELETE /inventory/instances` and `DELETE /inventory/items` have been deleting all records.

MODINV-731 changed them to delete records by CQL, this requires a major interface version bump.

ui-inventory doesn't use these two `DELETE` APIs therefore no code change is needed.