### PR TITLE
UIIN-2172 Update second pane header when switching from browse to search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Also support `item-storage` `10.0`. Refs UIIN-2162.
 * Also support `inventory` `12.0`. Refs UIIN-2170.
 * Request with operator "==/string" doesn't return the exact match results when search for contributor name. UIIN-2157.
+* Browse contributors | Second pane header doesn't update when user execute search by clicking contributor name. Fixes UIIN-2172.
 
 ## [9.1.0](https://github.com/folio-org/ui-inventory/tree/v9.1.0) (2022-06-28)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.0.0...v9.1.0)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -738,10 +738,13 @@ class InstancesList extends React.Component {
       parentResources,
     } = this.props;
 
+    let optionSelected = '';
+
     switch (get(parentResources.query, 'qindex')) {
       case browseModeOptions.CALL_NUMBERS:
+        optionSelected = 'callNumber';
         parentMutator.query.update({
-          qindex: 'callNumber',
+          qindex: optionSelected,
           query: row.fullCallNumber,
           browsePoint: '',
           filters: '',
@@ -749,8 +752,9 @@ class InstancesList extends React.Component {
         });
         break;
       case browseModeOptions.SUBJECTS:
+        optionSelected = 'subject';
         parentMutator.query.update({
-          qindex: 'subject',
+          qindex: optionSelected,
           query: row.subject,
           browsePoint: '',
           filters: '',
@@ -761,8 +765,10 @@ class InstancesList extends React.Component {
         if (row.isAnchor && !row.contributorNameTypeId) {
           return;
         }
+
+        optionSelected = 'contributor';
         parentMutator.query.update({
-          qindex: 'contributor',
+          qindex: optionSelected,
           query: row.name,
           browsePoint: '',
           filters: `${FACETS.SEARCH_CONTRIBUTORS}.${row.contributorNameTypeId}`,
@@ -775,6 +781,7 @@ class InstancesList extends React.Component {
     // the searchAndSortKey state field can be updated to reset SearchAndSort
     // to use the app-level selectedIndex
     this.setState((curState) => ({
+      optionSelected,
       searchAndSortKey: curState.searchAndSortKey + 1,
     }));
   }


### PR DESCRIPTION
## Description
Update second pane header when clicking on browse results. Pane header checks `state.optionSelected` to decide when to show Actions button and what title to show. Need to set this state with correct value

## Screenshots

https://user-images.githubusercontent.com/19309423/187957385-26b376af-6b19-4953-8fdf-100a34535f97.mp4



## Issues
[UIIN-2172](https://issues.folio.org/browse/UIIN-2172)