### PR TITLE
UIIN-2189 - Reset qindex inside buildQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Escape quotes in search string. Fix UIIN-2143.
 * Introduce in-memory pagination when loading parent/child instances. Fixes UIIN-2155.
 * The placeholder for missing match is clickable on the Browse list. Fixes UIIN-2126.
+* Reset `qindex` inside `buildQuery` in order for `queryTemplate` to be used correctly. Fixes UIIN-2189.
 
 ## [9.1.0](https://github.com/folio-org/ui-inventory/tree/v9.1.0) (2022-06-28)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.0.0...v9.1.0)

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -3,7 +3,12 @@ import { Router } from 'react-router-dom';
 import { noop } from 'lodash';
 import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
-import { screen, fireEvent, cleanup } from '@testing-library/react';
+import {
+  cleanup,
+  fireEvent,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 
 import '../../../test/jest/__mock__';
 
@@ -145,17 +150,23 @@ describe('InstancesList', () => {
 
     it('should have selected browse call number option', async () => {
       await userEvent.selectOptions(screen.getByLabelText('Search field index'), 'callNumbers');
-      expect((screen.getByRole('option', { name: 'Browse call numbers' })).selected).toBeTruthy();
+      waitFor(() => {
+        expect((screen.getByRole('option', { name: 'Browse call numbers' })).selected).toBeTruthy();
+      });
     });
 
     it('should have selected subject browse option', async () => {
       await userEvent.selectOptions(screen.getByLabelText('Search field index'), 'browseSubjects');
-      expect((screen.getByRole('option', { name: 'Browse subjects' })).selected).toBeTruthy();
+      waitFor(() => {
+        expect((screen.getByRole('option', { name: 'Browse subjects' })).selected).toBeTruthy();
+      });
     });
 
     it('should have selected contributors browse option', async () => {
       await userEvent.selectOptions(screen.getByLabelText('Search field index'), 'contributors');
-      expect((screen.getByRole('option', { name: 'Browse contributors' })).selected).toBeTruthy();
+      waitFor(() => {
+        expect((screen.getByRole('option', { name: 'Browse contributors' })).selected).toBeTruthy();
+      });
     });
 
     describe('opening action menu', () => {

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -60,6 +60,7 @@ const resources = {
     resource: 'records',
     records: instancesFixture,
     other: { totalRecords: instancesFixture.length },
+    isPending: false,
   },
   recordsBrowseCallNumber : {
     hasLoaded: true,
@@ -68,6 +69,7 @@ const resources = {
     other: {
       totalRecords: callNumbers.length
     },
+    isPending: false,
   },
   facets: {
     hasLoaded: true,
@@ -141,27 +143,18 @@ describe('InstancesList', () => {
       expect(document.querySelectorAll('#pane-results-content .mclRowContainer > [role=row]').length).toEqual(3);
     });
 
-    it('should have selected browse call number option', () => {
-      fireEvent.change(screen.getByRole('combobox'), {
-        target: { value: 'callNumbers' }
-      });
-
+    it('should have selected browse call number option', async () => {
+      await userEvent.selectOptions(screen.getByLabelText('Search field index'), 'callNumbers');
       expect((screen.getByRole('option', { name: 'Browse call numbers' })).selected).toBeTruthy();
     });
 
-    it('should have selected subject browse option', () => {
-      fireEvent.change(screen.getByRole('combobox'), {
-        target: { value: 'browseSubjects' }
-      });
-
+    it('should have selected subject browse option', async () => {
+      await userEvent.selectOptions(screen.getByLabelText('Search field index'), 'browseSubjects');
       expect((screen.getByRole('option', { name: 'Browse subjects' })).selected).toBeTruthy();
     });
 
-    it('should have selected contributors browse option', () => {
-      fireEvent.change(screen.getByRole('combobox'), {
-        target: { value: 'contributors' }
-      });
-
+    it('should have selected contributors browse option', async () => {
+      await userEvent.selectOptions(screen.getByLabelText('Search field index'), 'contributors');
       expect((screen.getByRole('option', { name: 'Browse contributors' })).selected).toBeTruthy();
     });
 

--- a/src/withFacets.js
+++ b/src/withFacets.js
@@ -22,6 +22,11 @@ function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
   const queryIndex = queryParams?.qindex ?? 'all';
   const queryTemplate = getQueryTemplate(queryIndex, indexes);
 
+  // reset qindex otherwise makeQueryFunction does not use queryTemplate
+  // https://github.com/folio-org/stripes-smart-components/blob/e918a620ad2ac2c5b06ce121cd0e061a03bcfdf6/lib/SearchAndSort/makeQueryFunction.js#L46
+  // https://issues.folio.org/browse/UIIN-2189
+  resourceData.query = { ...resourceData.query, qindex: '' };
+
   const cql = makeQueryFunction(
     CQL_FIND_ALL,
     queryTemplate,


### PR DESCRIPTION
Reset `qindex` when a query is being built for a given facet. This is required otherwise `makeQueryFunction` won't use `queryTemplate` and will fall back to a provided query value.

https://github.com/folio-org/stripes-smart-components/blob/e918a620ad2ac2c5b06ce121cd0e061a03bcfdf6/lib/SearchAndSort/makeQueryFunction.js#L46

Thank you @zburke for catching this issue.

https://issues.folio.org/browse/UIIN-2189