### PR TITLE
UIIN-2191 No results return when you conduct a Contributor search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Escape quotes in search string. Fix UIIN-2143.
 * Introduce in-memory pagination when loading parent/child instances. Fixes UIIN-2155.
 * The placeholder for missing match is clickable on the Browse list. Fixes UIIN-2126.
+* No results return when you conduct a Contributor search. Fixes UIIN-2191.
 
 ## [9.1.0](https://github.com/folio-org/ui-inventory/tree/v9.1.0) (2022-06-28)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.0.0...v9.1.0)

--- a/package.json
+++ b/package.json
@@ -886,7 +886,7 @@
     "file-saver": "^2.0.0",
     "final-form": "^4.18.2",
     "final-form-arrays": "^3.0.1",
-    "history": "^5.0.0",
+    "history": "^4.10.0",
     "ky": "^0.23.0",
     "lodash": "^4.17.4",
     "moment": "~2.24.0",

--- a/src/constants.js
+++ b/src/constants.js
@@ -140,7 +140,8 @@ export const holdingsStatementTypes = [
 export const queryIndexes = {
   SUBJECT: 'subject',
   QUERY_SEARCH: 'querySearch',
-  CALL_NUMBER: 'callNumber'
+  CALL_NUMBER: 'callNumber',
+  CONTRIBUTOR: 'contributor',
 };
 
 export const indentifierTypeNames = {

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -115,7 +115,7 @@ export const instanceIndexes = [
   // instead. It might make sense to rename the keyword option to something like `keywordAll`
   // but, without tracing the use of the value, I don't know what effects that would have in the code.
   { label: 'ui-inventory.search.all', value: 'all', queryTemplate: 'keyword all "%{query.query}" or isbn="%{query.query}"' },
-  { label: 'ui-inventory.contributor', value: 'contributor', queryTemplate: 'contributors.name=="%{query.query}"' },
+  { label: 'ui-inventory.contributor', value: 'contributor', queryTemplate: 'contributors.name="%{query.query}"' },
   { label: 'ui-inventory.title', value: 'title', queryTemplate: 'title all "%{query.query}"' },
   { label: 'ui-inventory.identifierAll', value: 'identifier', queryTemplate: 'identifiers.value="%{query.query}"  or isbn="%{query.query}"' },
   { label: 'ui-inventory.isbn', value: 'isbn', queryTemplate: 'isbn="%{query.query}"' },

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -115,7 +115,7 @@ export const instanceIndexes = [
   // instead. It might make sense to rename the keyword option to something like `keywordAll`
   // but, without tracing the use of the value, I don't know what effects that would have in the code.
   { label: 'ui-inventory.search.all', value: 'all', queryTemplate: 'keyword all "%{query.query}" or isbn="%{query.query}"' },
-  { label: 'ui-inventory.contributor', value: 'contributor', queryTemplate: 'contributors.name ==/string "%{query.query}"' },
+  { label: 'ui-inventory.contributor', value: 'contributor', queryTemplate: 'contributors.name=="%{query.query}"' },
   { label: 'ui-inventory.title', value: 'title', queryTemplate: 'title all "%{query.query}"' },
   { label: 'ui-inventory.identifierAll', value: 'identifier', queryTemplate: 'identifiers.value="%{query.query}"  or isbn="%{query.query}"' },
   { label: 'ui-inventory.isbn', value: 'isbn', queryTemplate: 'isbn="%{query.query}"' },

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -28,6 +28,7 @@ const getQueryTemplateValue = (queryValue, param) => {
     : `${param}>="${queryValue.replace(/"/g, '')}" or ${param}<"${queryValue.replace(/"/g, '')}"`;
 };
 
+const getQueryTemplateContributor = (queryValue) => `contributors.name ==/string "${queryValue}"`;
 const getQueryTemplateSubjects = (queryValue) => `subjects==/string "${queryValue.replace(/"/g, '')}"`;
 const getQueryTemplateCallNumber = (queryValue) => `itemEffectiveShelvingOrder==/string "${queryValue}"`;
 
@@ -82,6 +83,11 @@ export function buildQuery(queryParams, pathComponents, resourceData, logger, pr
 
   if (queryIndex === queryIndexes.CALL_NUMBER) {
     queryTemplate = getQueryTemplateCallNumber(queryValue);
+  }
+
+  if (queryIndex === queryIndexes.CONTRIBUTOR && queryParams?.selectedBrowseResult === 'true') {
+    queryTemplate = getQueryTemplateContributor(queryValue);
+    query.selectedBrowseResult = false; // reset this parameter so the next search uses `==` instead of `==/string`
   }
 
   if (queryIndex === queryIndexes.QUERY_SEARCH && queryValue.match('sortby')) {

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -87,7 +87,7 @@ export function buildQuery(queryParams, pathComponents, resourceData, logger, pr
 
   if (queryIndex === queryIndexes.CONTRIBUTOR && queryParams?.selectedBrowseResult === 'true') {
     queryTemplate = getQueryTemplateContributor(queryValue);
-    query.selectedBrowseResult = false; // reset this parameter so the next search uses `==` instead of `==/string`
+    query.selectedBrowseResult = false; // reset this parameter so the next search uses `=` instead of `==/string`
   }
 
   if (queryIndex === queryIndexes.QUERY_SEARCH && queryValue.match('sortby')) {


### PR DESCRIPTION
## Description
Use `==/string` search when clicking on Browse contributors result, but just `=` search when searching contributors

## Additional changes
Downgraded `history@5` to `history@4` due to incompatibility with `react-router@5`
Application behaves correctly because `<Root>` inside `stripes-core` uses `history@4`
But module level tests fail because `ui-inventory` uses `history@5`.

The source incompatibility lies in how `history` notifies `react-router` that location has changed.
Here's how `react-router` listens to this change: https://github.com/remix-run/react-router/blob/v5.3.3/packages/react-router/modules/Router.js#L47.
It accepts a single `location` argument that is saved inside state as `location`

`history@4` notifies listeners like so:
https://github.com/remix-run/history/blob/v4.10.1/modules/createBrowserHistory.js#L85
which calls https://github.com/remix-run/history/blob/3f69f9e07b0a739419704cffc3b3563133281548/modules/createTransitionManager.js#L66
It calls the handler and destructures the arguments array

But this is how `history@5` notifies listeners:
https://github.com/remix-run/history/blob/v5.3.0/packages/history/index.ts#L481

It calls the handler with object `{ location, action }`

So when `react-router` handles the call, `location` is not 
```
{
  pathname: ...,
  search: ...,
  ...etc
}
```
but instead
```
{
  action: 'PUSH', // or POP or whatever action
  location: {
    pathname: ...,
    search: ...,
    ...etc
  },
}
```

Hey @zburke, this is probably fixed in `react-router@6` because it accepts `history@5` in it's dependencies
https://github.com/remix-run/react-router/blob/v6.3.0/package.json#L44
Are we planning to upgrade to `react-router@6` any time soon?
Also, we definitely should not update `history` in `stripes-core`

## Screenshots

https://user-images.githubusercontent.com/19309423/190616364-6aef7b17-9705-4067-88f7-09a8e2f4f1b9.mp4



## Issues
[UIIN-2191](https://issues.folio.org/browse/UIIN-2191)