### PR TITLE
UIIN-2196: Relabel bound-with accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * No results return when you conduct a Contributor search. Fixes UIIN-2191.
 * Browse contributors | Second pane header doesn't update when user return to "Browse inventory" pane via the web-browser "Back" button. Fixes UIIN-2181.
 * Define new route for Inventory "Browse" page. Refs UIIN-2193.
+* Relabel 'Bound-with titles' accordion on item view. Fixes UIIN-2196.
 
 ## [9.1.0](https://github.com/folio-org/ui-inventory/tree/v9.1.0) (2022-06-28)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.0.0...v9.1.0)

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -112,7 +112,7 @@
   "updateItem": "Update item",
   "instanceTitle": "Instance: {title}.",
   "boundWith": "and {boundWithCount, plural, one {one more title} other {other titles}}",
-  "boundWithTitles": "Bound-with titles",
+  "boundWithTitles": "Bound-with and analytics",
   "holdingsLabelShort": "Holdings:",
   "holdingsTitle": " Holdings: {location} > {callNumber}",
   "holdingsPaneTitle": "Holdings • {location} • {callNumber}",


### PR DESCRIPTION
## Purpose
This accordion on the item view (and eventually on holdings view) displays more than just bound-with data.

This PR replaces #1787 per https://github.com/folio-org/ui-inventory/pull/1787#issuecomment-1255501986

## Approach
Simple rename of the label in en.json.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [X] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

## Issues
https://issues.folio.org/browse/UIIN-2196
