### PR TITLE
UIIN-2181 Set default segment prop value to instances

### DIFF
--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -102,6 +102,7 @@ class InstancesList extends React.Component {
   static defaultProps = {
     browseOnly: false,
     showSingleResult: true,
+    segment: segments.instances,
   };
 
   static propTypes = {


### PR DESCRIPTION
## Description
Set default value of `segment` prop
This is checked inside `componentDidUpdate` to equal `segments.instances` so `state.optionSelected` is not synced with `qindex`

## Screenshots

https://user-images.githubusercontent.com/19309423/193043177-98a1997b-d980-46b3-974d-36548652de23.mp4


## Issues
[UIIN-2181](https://issues.folio.org/browse/UIIN-2181)