### PR TITLE
UIIN-2195: Link from bound-with table to instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * No results return when you conduct a Contributor search. Fixes UIIN-2191.
 * Browse contributors | Second pane header doesn't update when user return to "Browse inventory" pane via the web-browser "Back" button. Fixes UIIN-2181.
 * Define new route for Inventory "Browse" page. Refs UIIN-2193.
+* Link from bound-with table HRID column to instances. Fixes UIIN-2195.
 
 ## [9.1.0](https://github.com/folio-org/ui-inventory/tree/v9.1.0) (2022-06-28)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.0.0...v9.1.0)

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -678,7 +678,16 @@ class ItemView extends React.Component {
     };
 
     const boundWithTitleFormatter = {
-      'Instance HRID': x => x.briefInstance?.hrid,
+      'Instance HRID': x => {
+        return (
+          <Link
+            to={`/inventory/view/${x.briefInstance?.id}`}
+            className="instanceHrid"
+          >
+            <span>{x.briefInstance?.hrid}</span>
+          </Link>
+        );
+      },
       'Instance title': x => x.briefInstance?.title,
       'Holdings HRID': x => x.briefHoldingsRecord?.hrid,
     };

--- a/src/views/ItemView.test.js
+++ b/src/views/ItemView.test.js
@@ -116,5 +116,11 @@ describe('ItemView', () => {
     it('should list 2 bound-with items in the table', () => {
       expect(document.querySelectorAll('#item-list-bound-with-titles .mclRowContainer > [role=row]').length).toEqual(2);
     });
+
+    it('should link to the instance view from the HRID', () => {
+      const id = resources.items.records[0].boundWithTitles[0].briefInstance.id;
+      expect(document.querySelector('#item-list-bound-with-titles a.instanceHrid'))
+        .toHaveAttribute('href', '/inventory/view/' + id);
+    });
   });
 });


### PR DESCRIPTION
This PR replaces #1791 

## Purpose
The list of bound-with titles (instances) on the item view did not have 
any means of navigating to those instances for additional details.  
Now the HRID is a clickable link to the instance view.

## Approach
Adjust the formatter for that cell to enclose the HRID in a link.

## Learning
For the unit test I originally wanted to test that the intended URL opened
as expected on the click.  Zak pointed me to an [alternate design pattern](https://stackoverflow.com/a/57907719)
for Jest & react-testing-library that just checks that the URL is correct.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [X] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [X] Code coverage on new code is 80% or greater
  - [X] Duplications on new code is 3% or less
  - [X] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [X] There are no breaking changes in this PR.

## Issues
https://issues.folio.org/browse/UIIN-2195
