### PR TITLE
Fix stripes-smart-components imports

### DIFF
--- a/src/components/BrowseResultsPane/BrowseResultsPane.js
+++ b/src/components/BrowseResultsPane/BrowseResultsPane.js
@@ -12,7 +12,7 @@ import {
 } from '@folio/stripes/core';
 import {
   ExpandFilterPaneButton,
-} from '@folio/stripes-smart-components';
+} from '@folio/stripes/smart-components';
 import {
   getFiltersCount,
   NoResultsMessage,

--- a/src/views/BrowseInventory/BrowseInventory.js
+++ b/src/views/BrowseInventory/BrowseInventory.js
@@ -7,7 +7,7 @@ import {
 } from '@folio/stripes/core';
 import {
   PersistedPaneset,
-} from '@folio/stripes-smart-components';
+} from '@folio/stripes/smart-components';
 import {
   FiltersPane,
   ResetButton,


### PR DESCRIPTION
## Description
Fix imports of `stripes-smart-components`. Should be `@folio/stripes/smart-components` instead of `@folio/stripes-smart-components`