### PR TITLE
UIIN-2018: remove bound-with link to item search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
 * Add ability to choose blank state for all select fields on holdings form. Fixes UIIN-2121.
 * Escape quotes in browse string. Fixes UIIN-2201.
 * Single record import: when using the Back button in the browser, a duplicate import is no longer created. Fixes UIIN-2197.
-* Display bound-with items in holdings view, and link from HRID to item view. Refs UIIN-2018.
+* Display bound-with items in holdings view. Refs UIIN-2018.
 * Display "Inactive" by inactive locations on holdings view. Fixes UIIN-1968.
 * SRI: fetch up to 1000 SRI sources, sorted by name. Fixes UIIN-2206.
 

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -1036,15 +1036,7 @@ class ViewHoldingsRecord extends React.Component {
                             'hrid': intl.formatMessage({ id: 'ui-inventory.itemHrid' }),
                           }}
                           formatter={{
-                            'hrid': x => (get(x, ['hrid'])
-                              ? (
-                                <Link
-                                  to={`/inventory/?qindex=hrid&segment=items&query=${get(x, ['hrid'])}`}
-                                  className="itemHrid"
-                                >
-                                  {get(x, ['hrid'])}
-                                </Link>)
-                              : noValue),
+                            'hrid': x => get(x, ['hrid']) || noValue,
                           }}
                         />
 

--- a/src/ViewHoldingsRecord.test.js
+++ b/src/ViewHoldingsRecord.test.js
@@ -122,18 +122,6 @@ describe('ViewHoldingsRecord actions', () => {
     expect(defaultProps.history.push).toHaveBeenCalled();
   });
 
-  it('should link from the HRID to the a search for the item', async () => {
-    renderViewHoldingsRecord();
-
-    const id = defaultProps.resources.boundWithItems.records[0].hrid;
-
-    await waitFor(() => {
-      const link = document.querySelector('#holdings-list-bound-with-items a.itemHrid');
-      expect(link)
-        .toHaveAttribute('href', '/inventory/?qindex=hrid&segment=items&query=' + id);
-    });
-  });
-
   it('should display "inactive" by an inactive temporary location', async () => {
     renderViewHoldingsRecord();
 


### PR DESCRIPTION
## Purpose

This PR reverts the part of #1810 that adds a link from the item HRID,
as well as a test case for the link.

The [interim solution for the link](https://issues.folio.org/browse/UIIN-2018?focusedCommentId=145944&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-145944) was not acceptable.

I will be working separately on a different solution for the link, but
@CharlotteWhitt requested this patch in the meantime.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [X] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [X] Code coverage on new code is 80% or greater
  - [X] Duplications on new code is 3% or less
  - [X] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

## Issues

https://issues.folio.org/browse/UIIN-2018