### PR TITLE
UIIN-1969: Show inactive locations on item view

### DIFF
--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -266,7 +266,8 @@ class ItemForm extends React.Component {
 
     const labelLocation = get(holdingLocation, ['name'], '');
     const labelCallNumber = holdingsRecord.callNumber || '';
-    const effectiveLocation = get(initialValues, ['effectiveLocation', 'name'], '-');
+    const effectiveLocation = locationsById[initialValues.effectiveLocation.id];
+    const effectiveLocationName = get(initialValues, ['effectiveLocation', 'name'], '-');
 
     const shortcuts = [
       {
@@ -359,7 +360,10 @@ class ItemForm extends React.Component {
                       <Col xs={4}>
                         <KeyValue
                           label={<FormattedMessage id="ui-inventory.effectiveLocation" />}
-                          value={effectiveLocation}
+                          value={effectiveLocationName}
+                          subValue={!effectiveLocation.isActive &&
+                            <FormattedMessage id="ui-inventory.inactive" />
+                          }
                         />
                       </Col>
                       <Col xs={8}>

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -610,14 +610,29 @@ class ItemView extends React.Component {
     };
 
     const holdingLocation = {
-      permanentLocation: get(permanentHoldingsLocation, 'name', '-'),
-      temporaryLocation: get(temporaryHoldingsLocation, 'name', '-'),
+      permanentLocation: {
+        name: get(permanentHoldingsLocation, 'name', '-'),
+        isActive: permanentHoldingsLocation?.isActive,
+      },
+      temporaryLocation: {
+        name: get(temporaryHoldingsLocation, 'name', '-'),
+        isActive: temporaryHoldingsLocation?.isActive,
+      },
     };
 
     const itemLocation = {
-      permanentLocation: get(item, ['permanentLocation', 'name'], '-'),
-      temporaryLocation: get(item, ['temporaryLocation', 'name'], '-'),
-      effectiveLocation: get(item, ['effectiveLocation', 'name'], '-'),
+      permanentLocation: {
+        name: get(item, ['permanentLocation', 'name'], '-'),
+        isActive: locationsById[item.permanentLocation?.id]?.isActive,
+      },
+      temporaryLocation: {
+        name: get(item, ['temporaryLocation', 'name'], '-'),
+        isActive: locationsById[item.temporaryLocation?.id]?.isActive,
+      },
+      effectiveLocation: {
+        name: get(item, ['effectiveLocation', 'name'], '-'),
+        isActive: locationsById[item.effectiveLocation.id].isActive,
+      },
     };
 
     const electronicAccess = { electronicAccess: get(item, 'electronicAccess', []) };
@@ -694,7 +709,10 @@ class ItemView extends React.Component {
       <Col xs={2}>
         <KeyValue
           label={<FormattedMessage id="ui-inventory.effectiveLocation" />}
-          value={checkIfElementIsEmpty(itemLocation.effectiveLocation)}
+          value={checkIfElementIsEmpty(itemLocation.effectiveLocation.name)}
+          subValue={!itemLocation.effectiveLocation.isActive &&
+            <FormattedMessage id="ui-inventory.inactive" />
+          }
         />
       </Col>
     );
@@ -889,7 +907,15 @@ class ItemView extends React.Component {
                     <div>
                       <FormattedMessage id="ui-inventory.holdingsLabelShort" />
                       <Link to={`/inventory/view/${instance.id}/${holdingsRecord.id}`}>
-                        { ` ${holdingLocation.permanentLocation} > ${callNumberLabel(holdingsRecord)}` }
+                        {(!holdingLocation.permanentLocation.isActive) &&
+                          <span>
+                            {' '}
+                            <em><FormattedMessage id="ui-inventory.inactive" /></em>
+                          </span>
+                        }
+                        {
+                          ` ${holdingLocation.permanentLocation.name} > ${callNumberLabel(holdingsRecord)}`
+                        }
                       </Link>
                     </div>
                   </Col>
@@ -1317,13 +1343,19 @@ class ItemView extends React.Component {
                         >
                           <KeyValue
                             label={<FormattedMessage id="ui-inventory.permanentLocation" />}
-                            value={checkIfElementIsEmpty(holdingLocation.permanentLocation)}
+                            value={checkIfElementIsEmpty(holdingLocation.permanentLocation.name)}
+                            subValue={!holdingLocation.permanentLocation.isActive &&
+                              <FormattedMessage id="ui-inventory.inactive" />
+                            }
                           />
                         </Col>
                         <Col sm={4}>
                           <KeyValue
                             label={<FormattedMessage id="ui-inventory.temporaryLocation" />}
-                            value={checkIfElementIsEmpty(holdingLocation.temporaryLocation)}
+                            value={checkIfElementIsEmpty(holdingLocation.temporaryLocation.name)}
+                            subValue={holdingLocation.temporaryLocation.isActive === false &&
+                              <FormattedMessage id="ui-inventory.inactive" />
+                            }
                           />
                         </Col>
                       </Row>
@@ -1345,13 +1377,19 @@ class ItemView extends React.Component {
                         >
                           <KeyValue
                             label={<FormattedMessage id="ui-inventory.permanentLocation" />}
-                            value={checkIfElementIsEmpty(itemLocation.permanentLocation)}
+                            value={checkIfElementIsEmpty(itemLocation.permanentLocation.name)}
+                            subValue={itemLocation.permanentLocation.isActive === false &&
+                              <FormattedMessage id="ui-inventory.inactive" />
+                            }
                           />
                         </Col>
                         <Col sm={4}>
                           <KeyValue
                             label={<FormattedMessage id="ui-inventory.temporaryLocation" />}
-                            value={checkIfElementIsEmpty(itemLocation.temporaryLocation)}
+                            value={checkIfElementIsEmpty(itemLocation.temporaryLocation.name)}
+                            subValue={itemLocation.temporaryLocation.isActive === false &&
+                              <FormattedMessage id="ui-inventory.inactive" />
+                            }
                           />
                         </Col>
                       </Row>

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -713,6 +713,7 @@ class ItemView extends React.Component {
           subValue={!itemLocation.effectiveLocation.isActive &&
             <FormattedMessage id="ui-inventory.inactive" />
           }
+          data-testid="item-effective-location"
         />
       </Col>
     );
@@ -1347,6 +1348,7 @@ class ItemView extends React.Component {
                             subValue={!holdingLocation.permanentLocation.isActive &&
                               <FormattedMessage id="ui-inventory.inactive" />
                             }
+                            data-testid="holding-permanent-location"
                           />
                         </Col>
                         <Col sm={4}>
@@ -1356,6 +1358,7 @@ class ItemView extends React.Component {
                             subValue={holdingLocation.temporaryLocation.isActive === false &&
                               <FormattedMessage id="ui-inventory.inactive" />
                             }
+                            data-testid="holding-temporary-location"
                           />
                         </Col>
                       </Row>
@@ -1381,6 +1384,7 @@ class ItemView extends React.Component {
                             subValue={itemLocation.permanentLocation.isActive === false &&
                               <FormattedMessage id="ui-inventory.inactive" />
                             }
+                            data-testid="item-permanent-location"
                           />
                         </Col>
                         <Col sm={4}>
@@ -1390,6 +1394,7 @@ class ItemView extends React.Component {
                             subValue={itemLocation.temporaryLocation.isActive === false &&
                               <FormattedMessage id="ui-inventory.inactive" />
                             }
+                            data-testid="item-temporary-location"
                           />
                         </Col>
                       </Row>

--- a/src/views/ItemView.test.js
+++ b/src/views/ItemView.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { noop } from 'lodash';
+import { waitFor } from '@testing-library/react';
 
 import '../../test/jest/__mock__';
 
@@ -28,6 +29,7 @@ const resources = {
     records: [
       {
         permanentLocationId: 1,
+        temporaryLocationId: 'inactiveLocation',
       }
     ],
   },
@@ -37,6 +39,18 @@ const resources = {
         id: 'item1',
         status: {
           name: 'Available',
+        },
+        permanentLocation: {
+          id: 'inactiveLocation',
+          name: 'Location 1',
+        },
+        temporaryLocation: {
+          id: 'inactiveLocation',
+          name: 'Location 1',
+        },
+        effectiveLocation: {
+          id: 'inactiveLocation',
+          name: 'Location 1',
         },
         isBoundWith: true,
         boundWithTitles: [
@@ -81,7 +95,9 @@ const resources = {
 
 const referenceTables = {
   itemNoteTypes: [],
-  locationsById: [],
+  locationsById: {
+    inactiveLocation: { name: 'Location 1', isActive: false },
+  },
 };
 
 const ItemViewSetup = () => (
@@ -121,6 +137,41 @@ describe('ItemView', () => {
       const id = resources.items.records[0].boundWithTitles[0].briefInstance.id;
       expect(document.querySelector('#item-list-bound-with-titles a.instanceHrid'))
         .toHaveAttribute('href', '/inventory/view/' + id);
+    });
+
+    it('should display "inactive" by an inactive holding permanent location', async () => {
+      await waitFor(() => {
+        const location = document.querySelector('*[data-testid=holding-permanent-location]').innerHTML;
+        expect(location).toContain('ui-inventory.inactive');
+      });
+    });
+
+    it('should display "inactive" by an inactive holding temporary location', async () => {
+      await waitFor(() => {
+        const location = document.querySelector('*[data-testid=holding-temporary-location]').innerHTML;
+        expect(location).toContain('ui-inventory.inactive');
+      });
+    });
+
+    it('should display "inactive" by an inactive item permanent location', async () => {
+      await waitFor(() => {
+        const location = document.querySelector('*[data-testid=item-permanent-location]').innerHTML;
+        expect(location).toContain('ui-inventory.inactive');
+      });
+    });
+
+    it('should display "inactive" by an inactive item temporary location', async () => {
+      await waitFor(() => {
+        const location = document.querySelector('*[data-testid=item-temporary-location]').innerHTML;
+        expect(location).toContain('ui-inventory.inactive');
+      });
+    });
+
+    it('should display "inactive" by an inactive item effective location', async () => {
+      await waitFor(() => {
+        const location = document.querySelector('*[data-testid=item-effective-location]').innerHTML;
+        expect(location).toContain('ui-inventory.inactive');
+      });
     });
   });
 });


### PR DESCRIPTION
## Purpose

Anywhere a location is specified on the item view, it should display the word 'Inactive' if 
that is the case.  This mirrors UIIN-1968 which did the same for the holdings view.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [X] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

## Issues
https://issues.folio.org/browse/UIIN-1969
