### PR TITLE
UIIN-2227: Fix NPE on Add Item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-inventory
 
 ## 9.3.0 IN PROGRESS
+* Fix error on creating new item.  Fixes UIIN-2227.
 
 ## [9.2.0](https://github.com/folio-org/ui-inventory/tree/v9.2.0) (2022-10-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.1.0...v9.2.0)

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -266,7 +266,7 @@ class ItemForm extends React.Component {
 
     const labelLocation = get(holdingLocation, ['name'], '');
     const labelCallNumber = holdingsRecord.callNumber || '';
-    const effectiveLocation = locationsById[initialValues.effectiveLocation.id];
+    const effectiveLocation = locationsById[initialValues?.effectiveLocation?.id];
     const effectiveLocationName = get(initialValues, ['effectiveLocation', 'name'], '-');
 
     const shortcuts = [
@@ -361,7 +361,7 @@ class ItemForm extends React.Component {
                         <KeyValue
                           label={<FormattedMessage id="ui-inventory.effectiveLocation" />}
                           value={effectiveLocationName}
-                          subValue={!effectiveLocation.isActive &&
+                          subValue={!effectiveLocation?.isActive &&
                             <FormattedMessage id="ui-inventory.inactive" />
                           }
                         />


### PR DESCRIPTION
## Purpose
I caused an NPE on effectiveLocation in ItemForm.js with PR #1832.  The context was a change
to how an existing item's effectiveLocation is displayed, where it should never be null.  But
I failed to consider the AddItem context where it is not yet set.  This PR adds null checks.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [X] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [X] Duplications on new code is 3% or less
  - [X] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [X] There are no breaking changes in this PR.

## Issues
https://issues.folio.org/browse/UIIN-2227