### PR TITLE
UIIN-2164: Add bound-with items to holdings list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Link from item view bound-with table's holdings HRID column to the holding view. Fixes additional part of UIIN-2195.
 * Fix error on creating new item.  Fixes UIIN-2227.
 * Missing holdings' source is populated in the UI with instance's. UIIN-2229.
+* Display bound-with items along with directly linked items at all associated holdings. Refs UIIN-2164.
 
 ## [9.2.0](https://github.com/folio-org/ui-inventory/tree/v9.2.0) (2022-10-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.1.0...v9.2.0)

--- a/src/Holding/ViewHolding/HoldingBoundWith/HoldingBoundWith.js
+++ b/src/Holding/ViewHolding/HoldingBoundWith/HoldingBoundWith.js
@@ -16,7 +16,7 @@ import useBoundWithHoldings from './useBoundWithHoldings';
 const HoldingBoundWith = ({ boundWithItems }) => {
   const { isLoading, boundWithHoldings } = useBoundWithHoldings(boundWithItems);
   const boundWithHoldingsMapById = keyBy(boundWithHoldings, 'id');
-  const data = boundWithItems.records?.map(boundWithItem => ({
+  const data = boundWithItems?.map(boundWithItem => ({
     item: boundWithItem,
     holdingsRecord: boundWithHoldingsMapById[boundWithItem.holdingsRecordId],
   }));
@@ -68,9 +68,7 @@ const HoldingBoundWith = ({ boundWithItems }) => {
 };
 
 HoldingBoundWith.propTypes = {
-  boundWithItems: PropTypes.shape({
-    records: PropTypes.arrayOf(PropTypes.object),
-  }),
+  boundWithItems: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default HoldingBoundWith;

--- a/src/Holding/ViewHolding/HoldingBoundWith/HoldingBoundWith.test.js
+++ b/src/Holding/ViewHolding/HoldingBoundWith/HoldingBoundWith.test.js
@@ -15,7 +15,7 @@ import useBoundWithHoldings from './useBoundWithHoldings';
 jest.mock('./useBoundWithHoldings', () => jest.fn());
 
 const renderHoldingBoundWith = ({
-  boundWithItems = {},
+  boundWithItems = [],
 } = {}) => (
   renderWithIntl(
     <Router>
@@ -30,7 +30,7 @@ describe('HoldingBoundWith', () => {
   });
 
   it('should display bound-with fields', () => {
-    renderHoldingBoundWith({ records: [{ hrid: 'BW-ITEM-1' }], hasLoaded: true });
+    renderHoldingBoundWith([{ hrid: 'BW-ITEM-1' }]);
 
     expect(screen.getByText('ui-inventory.itemHrid')).toBeInTheDocument();
   });

--- a/src/Holding/ViewHolding/HoldingBoundWith/useBoundWithHoldings.js
+++ b/src/Holding/ViewHolding/HoldingBoundWith/useBoundWithHoldings.js
@@ -6,7 +6,7 @@ const useBoundWithHoldings = (boundWithItems) => {
   const ky = useOkapiKy();
   const [namespace] = useNamespace({ key: 'boundWithHoldings' });
 
-  const holdingRecordIds = boundWithItems.records?.map(x => x.holdingsRecordId);
+  const holdingRecordIds = boundWithItems?.map(x => x.holdingsRecordId);
   const queryIds = `(${holdingRecordIds.join(' or ')})`;
 
   const { data, isLoading } = useQuery(

--- a/src/Holding/ViewHolding/HoldingBoundWith/useBoundWithHoldings.test.js
+++ b/src/Holding/ViewHolding/HoldingBoundWith/useBoundWithHoldings.test.js
@@ -29,7 +29,7 @@ describe('useBoundWithHoldings', () => {
   });
 
   it('should fetch bound-with holdings', async () => {
-    const boundWithItems = { records: [{ hrid: 'BW-ITEM-1', holdingsRecordId: '9e8dc8ce-68f3-4e75-8479-d548ce521157' }], hasLoaded: true };
+    const boundWithItems = [{ hrid: 'BW-ITEM-1', holdingsRecordId: '9e8dc8ce-68f3-4e75-8479-d548ce521157' }];
 
     const { result, waitFor } = renderHook(() => useBoundWithHoldings(boundWithItems), { wrapper });
 

--- a/src/Instance/ItemsList/ItemsList.js
+++ b/src/Instance/ItemsList/ItemsList.js
@@ -9,7 +9,7 @@ import {
   FormattedMessage,
   useIntl,
 } from 'react-intl';
-import { isEmpty } from 'lodash';
+import { isEmpty, keyBy } from 'lodash';
 
 import {
   Checkbox,
@@ -25,10 +25,12 @@ import ItemsListRow from './ItemsListRow';
 import {
   sortItems,
 } from './utils';
+import useBoundWithHoldings from '../../Holding/ViewHolding/HoldingBoundWith/useBoundWithHoldings';
 
 const getTableAria = (intl) => intl.formatMessage({ id: 'ui-inventory.items' });
 const getFormatter = (
   holding,
+  holdingsMapById,
   selectItemsForDrag,
   ifItemsSelected,
 ) => ({
@@ -60,8 +62,8 @@ const getFormatter = (
       <>
         <ItemBarcode
           item={item}
-          holdingId={holding.id}
-          instanceId={holding.instanceId}
+          holdingId={item.holdingsRecordId}
+          instanceId={holdingsMapById[item.holdingsRecordId]?.instanceId}
         />
         {item.discoverySuppress &&
         <span>
@@ -132,6 +134,9 @@ const ItemsList = ({
   selectItemsForDrag,
   getDraggingItems,
 }) => {
+  const { boundWithHoldings: holdings } = useBoundWithHoldings(items);
+  const holdingsMapById = keyBy(holdings, 'id');
+
   const intl = useIntl();
 
   const [itemsSorting, setItemsSorting] = useState({
@@ -147,8 +152,8 @@ const ItemsList = ({
     [holding.id, records, isItemsDragSelected, selectItemsForDrag],
   );
   const formatter = useMemo(
-    () => getFormatter(holding, selectItemsForDrag, isItemsDragSelected),
-    [holding, selectItemsForDrag, isItemsDragSelected],
+    () => getFormatter(holding, holdingsMapById, selectItemsForDrag, isItemsDragSelected),
+    [holding, holdingsMapById, selectItemsForDrag, isItemsDragSelected],
   );
   const rowProps = useMemo(() => ({
     draggable,

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -1024,7 +1024,7 @@ class ViewHoldingsRecord extends React.Component {
 
                       <HoldingReceivingHistory holding={holdingsRecord} />
 
-                      <HoldingBoundWith boundWithItems={boundWithItems} />
+                      <HoldingBoundWith boundWithItems={boundWithItems.records} />
 
                     </AccordionSet>
                   </AccordionStatus>

--- a/src/hooks/useHoldingItemsQuery.js
+++ b/src/hooks/useHoldingItemsQuery.js
@@ -22,7 +22,7 @@ const useHoldingItemsQuery = (
     ...options.searchParams,
   };
 
-  const queryFn = () => ky.get('inventory/items', { searchParams }).json();
+  const queryFn = () => ky.get('inventory/items-by-holdings-id', { searchParams }).json();
   const { data, isLoading, isFetching } = useQuery({ queryKey, queryFn, ...omit(options, ['searchParams']) });
 
   return {

--- a/src/hooks/useHoldingItemsQuery.test.js
+++ b/src/hooks/useHoldingItemsQuery.test.js
@@ -44,7 +44,7 @@ describe('useHoldingItemsQuery', () => {
 
     expect(result.current.items).toEqual(items.slice(0, limit));
     expect(mockGet).toHaveBeenCalledWith(
-      'inventory/items',
+      'inventory/items-by-holdings-id',
       {
         searchParams: {
           limit,


### PR DESCRIPTION
## Purpose
On the instance view, the holdings list should include all items, whether 
bound-with the holdings record or directly linked.

## Approach
/inventory/items-by-holdings-id fills this need directly.

I considered creating an alternate version of useHoldingsItemsQuery to use 
that API in place of /inventory/items, or passing in a parameter to indicate
which API to use, rather than just changing the existing hook.

I decided to change the existing useHoldingItemsQuery because 

1. it appears that all existing uses of the function now intend to include bound-with items
2. that seems to be the intention going forward -- i.e. there was
[intentionally no visible difference](https://issues.folio.org/browse/UIIN-2164?focusedCommentId=148699&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-148699) between the bound-with and directly linked item.

#### TODOS and Open Questions
- [ ] Handle all the ways in which a bound-with item in this list differs from a directly linked item, such as the ability to move the item to a different holdings record.  That was [intentionally deferred](https://issues.folio.org/browse/UIIN-2164?focusedCommentId=147644&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-147644).

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [X] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [X] Duplications on new code is 3% or less
  - [X] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [X] There are no breaking changes in this PR.

## Issues
https://issues.folio.org/browse/UIIN-2164