### PR TITLE
UIIN-2260: Fix holdings view bound-with table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Display bound-with items along with directly linked items at all associated holdings. Refs UIIN-2164.
 * Browse refactor: Show instance result in third pane when Number of titles = `1`. Refs UIIN-2186.
 * Optimistic locking error appears when user adds more than 1 tag to "Holdings" record. Fixes UIIN-2242.
+* Fix holdings view bound-with table also displaying directly linked items. Fixes UIIN-2260.  
 
 ## [9.2.0](https://github.com/folio-org/ui-inventory/tree/v9.2.0) (2022-10-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.1.0...v9.2.0)

--- a/src/Holding/ViewHolding/HoldingBoundWith/HoldingBoundWith.js
+++ b/src/Holding/ViewHolding/HoldingBoundWith/HoldingBoundWith.js
@@ -11,9 +11,11 @@ import {
 import { IntlConsumer } from '@folio/stripes/core';
 import { noValue } from '../../../constants';
 import { checkIfArrayIsEmpty } from '../../../utils';
+import useBoundWithItems from './useBoundWithItems';
 import useBoundWithHoldings from './useBoundWithHoldings';
 
-const HoldingBoundWith = ({ boundWithItems }) => {
+const HoldingBoundWith = ({ boundWithParts }) => {
+  const { boundWithItems } = useBoundWithItems(boundWithParts);
   const { isLoading, boundWithHoldings } = useBoundWithHoldings(boundWithItems);
   const boundWithHoldingsMapById = keyBy(boundWithHoldings, 'id');
   const data = boundWithItems?.map(boundWithItem => ({
@@ -68,7 +70,7 @@ const HoldingBoundWith = ({ boundWithItems }) => {
 };
 
 HoldingBoundWith.propTypes = {
-  boundWithItems: PropTypes.arrayOf(PropTypes.object),
+  boundWithParts: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default HoldingBoundWith;

--- a/src/Holding/ViewHolding/HoldingBoundWith/HoldingBoundWith.test.js
+++ b/src/Holding/ViewHolding/HoldingBoundWith/HoldingBoundWith.test.js
@@ -7,30 +7,34 @@ import '../../../../test/jest/__mock__';
 import renderWithIntl from '../../../../test/jest/helpers/renderWithIntl';
 
 import {
+  boundWithItems,
   boundWithHoldingsRecords,
 } from './fixtures';
 import HoldingBoundWith from './HoldingBoundWith';
+import useBoundWithItems from './useBoundWithItems';
 import useBoundWithHoldings from './useBoundWithHoldings';
 
+jest.mock('./useBoundWithItems', () => jest.fn());
 jest.mock('./useBoundWithHoldings', () => jest.fn());
 
 const renderHoldingBoundWith = ({
-  boundWithItems = [],
+  boundWithParts = [],
 } = {}) => (
   renderWithIntl(
     <Router>
-      <HoldingBoundWith boundWithItems={boundWithItems} />
+      <HoldingBoundWith boundWithParts={boundWithParts} />
     </Router>
   )
 );
 
 describe('HoldingBoundWith', () => {
   beforeEach(() => {
+    useBoundWithItems.mockClear().mockReturnValue({ boundWithItems });
     useBoundWithHoldings.mockClear().mockReturnValue({ boundWithHoldingsRecords });
   });
 
   it('should display bound-with fields', () => {
-    renderHoldingBoundWith([{ hrid: 'BW-ITEM-1' }]);
+    renderHoldingBoundWith([{ itemId: 'f4b8c3d1-f461-4551-aa7b-5f45e64f236c' }]);
 
     expect(screen.getByText('ui-inventory.itemHrid')).toBeInTheDocument();
   });

--- a/src/Holding/ViewHolding/HoldingBoundWith/fixtures.js
+++ b/src/Holding/ViewHolding/HoldingBoundWith/fixtures.js
@@ -1,7 +1,11 @@
-// Disabling eslint below because the pattern is to name fixtures
-// eslint-disable-next-line import/prefer-default-export
 export const boundWithHoldingsRecords = [
   {
     hrid: 'BW-1',
   },
+];
+
+export const boundWithItems = [
+  {
+    itemId: 'f4b8c3d1-f461-4551-aa7b-5f45e64f236c',
+  }
 ];

--- a/src/Holding/ViewHolding/HoldingBoundWith/useBoundWithItems.js
+++ b/src/Holding/ViewHolding/HoldingBoundWith/useBoundWithItems.js
@@ -1,0 +1,24 @@
+import { useQuery } from 'react-query';
+
+import { useOkapiKy, useNamespace } from '@folio/stripes/core';
+
+const useBoundWithItems = (boundWithParts) => {
+  const ky = useOkapiKy();
+  const [namespace] = useNamespace({ key: 'boundWithItems' });
+
+  const itemIds = boundWithParts?.map(x => x.itemId);
+  const queryIds = `(${itemIds.join(' or ')})`;
+
+  const { data, isLoading } = useQuery(
+    [namespace, queryIds],
+    () => ky.get(`item-storage/items?query=id=${queryIds}`).json(),
+    { enabled: Boolean(queryIds) }
+  );
+
+  return {
+    isLoading,
+    boundWithItems: data?.items || [],
+  };
+};
+
+export default useBoundWithItems;

--- a/src/Holding/ViewHolding/HoldingBoundWith/useBoundWithItems.test.js
+++ b/src/Holding/ViewHolding/HoldingBoundWith/useBoundWithItems.test.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+import { renderHook } from '@testing-library/react-hooks';
+
+import '../../../../test/jest/__mock__';
+
+import { useOkapiKy } from '@folio/stripes/core';
+
+import { boundWithItems } from './fixtures';
+import useBoundWithItems from './useBoundWithItems';
+
+const queryClient = new QueryClient();
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+describe('useBoundWithItems', () => {
+  beforeEach(() => {
+    useOkapiKy.mockClear().mockReturnValue({
+      get: () => ({
+        json: () => Promise.resolve({ items: boundWithItems }),
+      }),
+    });
+  });
+
+  it('should fetch bound-with items', async () => {
+    const boundWithParts = [{ itemId: 'f4b8c3d1-f461-4551-aa7b-5f45e64f236c' }];
+
+    const { result, waitFor } = renderHook(() => useBoundWithItems(boundWithParts), { wrapper });
+
+    await waitFor(() => !result.current.isLoading);
+
+    expect(result.current.boundWithItems).toEqual(boundWithItems);
+  });
+});

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -110,10 +110,10 @@ class ViewHoldingsRecord extends React.Component {
         path: 'source-storage/records/%{marcRecordId}',
       },
     },
-    boundWithItems: {
+    boundWithParts: {
       type: 'okapi',
-      records: 'items',
-      path: 'inventory/items-by-holdings-id',
+      records: 'boundWithParts',
+      path: 'inventory-storage/bound-with-parts',
       params: {
         query: '(holdingsRecordId==:{holdingsrecordid})',
         limit: '5000',
@@ -464,7 +464,7 @@ class ViewHoldingsRecord extends React.Component {
       resources: {
         items,
         tagSettings,
-        boundWithItems,
+        boundWithParts,
       },
       referenceTables,
       goTo,
@@ -1019,7 +1019,7 @@ class ViewHoldingsRecord extends React.Component {
 
                       <HoldingReceivingHistory holding={holdingsRecord} />
 
-                      <HoldingBoundWith boundWithItems={boundWithItems.records} />
+                      <HoldingBoundWith boundWithParts={boundWithParts.records} />
 
                     </AccordionSet>
                   </AccordionStatus>
@@ -1051,7 +1051,7 @@ ViewHoldingsRecord.propTypes = {
     tagSettings: PropTypes.shape({
       records: PropTypes.arrayOf(PropTypes.object),
     }),
-    boundWithItems: PropTypes.shape({
+    boundWithParts: PropTypes.shape({
       records: PropTypes.arrayOf(PropTypes.object),
     }),
   }).isRequired,

--- a/src/ViewHoldingsRecord.test.js
+++ b/src/ViewHoldingsRecord.test.js
@@ -33,7 +33,7 @@ const defaultProps = {
     instances1: { records: [{ id: 'instanceId' }], hasLoaded: true },
     permanentLocation: { hasLoaded: true },
     temporaryLocation: { hasLoaded: true },
-    boundWithItems: { records: [{ hrid: 'BW-ITEM-1' }], hasLoaded: true },
+    boundWithParts: { records: [{ itemId: '9e8dc8ce-68f3-4e75-8479-d548ce521157' }], hasLoaded: true },
   },
   mutator: {
     instances1: {


### PR DESCRIPTION
On the holdings view, the bound-with table should list only bound-with items, and not 
directly-linked items.

## Approach
The UI previously used inventory/items-by-holdings-id to populate that table, which
includes directly linked items.  That was an oversight.  This approach uses 
/inventory-storage/bound-with-parts to get the correct list of item HRIDs, followed by
/items-storage/items to get the actual items.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [X] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [X] Code coverage on new code is 80% or greater
  - [X] Duplications on new code is 3% or less
  - [X] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [X] There are no breaking changes in this PR.

## Issues
https://issues.folio.org/browse/UIIN-2260