### PR TITLE
UIIN-2257: Upgrade moment from 2.24.0 to >= 2.29.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -892,7 +892,7 @@
     "history": "^4.10.0",
     "ky": "^0.23.0",
     "lodash": "^4.17.4",
-    "moment": "~2.24.0",
+    "moment": "~2.29.4",
     "prop-types": "^15.5.10",
     "query-string": "^5.0.0",
     "react-beautiful-dnd": "^13.0.0",
@@ -917,6 +917,6 @@
     "@folio/plugin-find-instance": "^6.0.0"
   },
   "resolutions": {
-    "moment": "~2.24.0"
+    "moment": "~2.29.4"
   }
 }


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-2257

Upgrade moment from 2.24.0 to >= 2.29.4 fixes these vulnerabilities:

https://nvd.nist.gov/vuln/detail/CVE-2022-31129 Regular Expression Denial of Service (ReDoS)
https://nvd.nist.gov/vuln/detail/CVE-2022-24785 Directory Traversal