### PR TITLE
UIIN-2276 warn on sessionStorage error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Add create/update widget to HRID Settings page. UIIN-2139.
 * Do not fetch bound with data if the boundWithParts data is not present. Fixes UIIN-2272.
 * Revert back to `all` operator for title (All) index. Fixes UIIN-2274.
+* Warn on `sessionStorage` errors instead of swallowing them.
 
 ## [9.2.0](https://github.com/folio-org/ui-inventory/tree/v9.2.0) (2022-10-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.1.0...v9.2.0)

--- a/src/storage.js
+++ b/src/storage.js
@@ -3,6 +3,8 @@ export const getItem = (name) => {
   try {
     return JSON.parse(sessionStorage.getItem(name));
   } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn(`the value ${name} could not be retrieved due to an error`, e);
     return null;
   }
 };
@@ -11,6 +13,7 @@ export const setItem = (name, value) => {
   try {
     sessionStorage.setItem(name, JSON.stringify(value));
   } catch (e) {
-    //
+    // eslint-disable-next-line no-console
+    console.warn(`the value ${name} could not be stored due to an error`, e);
   }
 };


### PR DESCRIPTION
Show a console warning when catching a `sessionStorage` error instead of just swallowing it.

Refs [UIIN-2276](https://issues.folio.org/browse/UIIN-2276)
