### PR TITLE
UIIN-2275: Use correct index when searching for subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Warn on `sessionStorage` errors instead of swallowing them.
 * Add `inventory-storage.bound-with-parts.collection.get` to `Inventory: All permissions`. Fixes UIIN-2273.
 * Add `inventory-storage.bound-with-parts.collection.get` to `Inventory: View instances, holdings, and items`. Fixes UIIN-2273.
+* Use correct index when searching for `subject`. Fixes UIIN-2275.
 
 ## [9.2.0](https://github.com/folio-org/ui-inventory/tree/v9.2.0) (2022-10-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.1.0...v9.2.0)

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -18,10 +18,6 @@ import facetsStore from '../stores/facetsStore';
 const INITIAL_RESULT_COUNT = 100;
 const DEFAULT_SORT = 'title';
 
-const getQueryTemplateContributor = (queryValue) => `contributors.name ==/string "${queryValue}"`;
-const getQueryTemplateSubjects = (queryValue) => `subjects==/string "${queryValue.replace(/"/g, '\\"')}"`;
-const getQueryTemplateCallNumber = (queryValue) => `itemEffectiveShelvingOrder==/string "${queryValue}"`;
-
 export function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
   const { indexes, sortMap, filters } = getFilterConfig(queryParams.segment);
   const query = { ...resourceData.query };
@@ -33,19 +29,6 @@ export function buildQuery(queryParams, pathComponents, resourceData, logger, pr
     // eslint-disable-next-line camelcase
     const identifierTypes = resourceData?.identifier_types?.records ?? [];
     queryTemplate = getIsbnIssnTemplate(queryTemplate, identifierTypes, queryIndex);
-  }
-
-  if (queryIndex === queryIndexes.SUBJECT) {
-    queryTemplate = getQueryTemplateSubjects(queryValue);
-  }
-
-  if (queryIndex === queryIndexes.CALL_NUMBER) {
-    queryTemplate = getQueryTemplateCallNumber(queryValue);
-  }
-
-  if (queryIndex === queryIndexes.CONTRIBUTOR && queryParams?.selectedBrowseResult === 'true') {
-    queryTemplate = getQueryTemplateContributor(queryValue);
-    query.selectedBrowseResult = false; // reset this parameter so the next search uses `=` instead of `==/string`
   }
 
   if (queryIndex === queryIndexes.QUERY_SEARCH && queryValue.match('sortby')) {


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-2275

The but related to this searching by the subject was introduced by https://issues.folio.org/browse/UIIN-2075 which was added because the "subject" index also exists on the "browse" tab.

Since the "browse" was moved to its own route now we can get rid of this when the query is constructed under the instances route.