### PR TITLE
UIIN-2266 Browse Lists | Hyperlink one column to improve accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * ISRI: Update the Settings screen to allow multiple job profiles: View. Refs UIIN-2249.
 * Users with browse permissions can delete inventory records. Refs UIIN-2283.
 * Include browse permissions into Inventory permissions. Refs UIIN-2280.
+* Browse Lists | Hyperlink one column to improve accessibility. Refs UIIN-2266.
 
 ## [9.2.0](https://github.com/folio-org/ui-inventory/tree/v9.2.0) (2022-10-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.1.0...v9.2.0)

--- a/src/components/BrowseResultsList/BrowseResultsList.css
+++ b/src/components/BrowseResultsList/BrowseResultsList.css
@@ -4,4 +4,5 @@
 
 .authorityIcon {
   margin-right: 5px;
+  cursor: pointer;
 }

--- a/src/components/BrowseResultsList/BrowseResultsList.js
+++ b/src/components/BrowseResultsList/BrowseResultsList.js
@@ -6,7 +6,6 @@ import {
   useContext,
 } from 'react';
 import {
-  useHistory,
   useLocation,
 } from 'react-router-dom';
 
@@ -19,11 +18,7 @@ import {
 } from '@folio/stripes-acq-components';
 
 import {
-  browseModeOptions,
   BROWSE_RESULTS_COUNT,
-  FACETS,
-  INVENTORY_ROUTE,
-  queryIndexes,
 } from '../../constants';
 import { DataContext } from '../../contexts';
 import {
@@ -31,29 +26,10 @@ import {
   COLUMNS_WIDTHS,
   VISIBLE_COLUMNS_MAP,
 } from './constants';
+import { isRowPreventsClick } from './utils';
 import getBrowseResultsFormatter from './getBrowseResultsFormatter';
 
 import css from './BrowseResultsList.css';
-
-const getSearchParams = (row, qindex) => {
-  const optionsMap = {
-    [browseModeOptions.CALL_NUMBERS]: {
-      qindex: queryIndexes.CALL_NUMBER,
-      query: row.shelfKey,
-    },
-    [browseModeOptions.CONTRIBUTORS]: {
-      qindex: queryIndexes.CONTRIBUTOR,
-      query: row.name,
-      filters: `${FACETS.SEARCH_CONTRIBUTORS}.${row.contributorNameTypeId}`,
-    },
-    [browseModeOptions.SUBJECTS]: {
-      qindex: queryIndexes.SUBJECT,
-      query: row.subject,
-    },
-  };
-
-  return optionsMap[qindex];
-};
 
 const getItemToViewIndex = (selector) => {
   const match = selector.match(/^\[aria-rowindex="(\d+)"\]$/);
@@ -71,11 +47,11 @@ const BrowseResultsList = ({
     hasNextPage,
     hasPrevPage,
     onNeedMoreData,
+    pageConfig,
   },
   totalRecords,
 }) => {
   const data = useContext(DataContext);
-  const history = useHistory();
   const { search } = useLocation();
   const {
     itemToView,
@@ -86,41 +62,13 @@ const BrowseResultsList = ({
   const browseOption = queryString.parse(search).qindex;
   const listId = `browse-results-list-${browseOption}`;
 
-  const isRowPreventsClick = useCallback((row) => {
-    const isMissedMatchItemRow = !!row.isAnchor && row.totalRecords === 0;
-
-    return isMissedMatchItemRow || (
-      (browseOption === browseModeOptions.CALL_NUMBERS && !row.shelfKey) ||
-      (browseOption === browseModeOptions.CONTRIBUTORS && !row.contributorNameTypeId) ||
-      (browseOption === browseModeOptions.SUBJECTS && !row.totalRecords)
-    );
-  }, [browseOption]);
-
   const isSelected = useCallback(({ item, rowIndex }) => {
-    if (isRowPreventsClick(item)) return false;
+    if (isRowPreventsClick(item, browseOption)) return false;
 
     const itemIndex = itemToView?.selector && getItemToViewIndex(itemToView.selector);
 
     return itemIndex === rowIndex;
-  }, [isRowPreventsClick, itemToView]);
-
-  const onRowClick = useCallback(({ target }, row) => {
-    const isAuthorityAppLink = target.dataset?.link === 'authority-app' ||
-      target.getAttribute('class')?.includes('authorityIcon');
-
-    if (isAuthorityAppLink || isRowPreventsClick(row)) return;
-
-    history.push({
-      pathname: INVENTORY_ROUTE,
-      search: queryString.stringify({
-        selectedBrowseResult: true,
-        ...getSearchParams(row, browseOption),
-      }),
-      state: {
-        browseSearch: search,
-      }
-    });
-  }, [browseOption, history, isRowPreventsClick, search]);
+  }, [browseOption, itemToView]);
 
   return (
     <MultiColumnList
@@ -128,7 +76,7 @@ const BrowseResultsList = ({
       id={listId}
       totalCount={totalRecords}
       contentData={browseData}
-      formatter={getBrowseResultsFormatter(data, browseOption)}
+      formatter={getBrowseResultsFormatter({ data, browseOption, search, pageConfig })}
       visibleColumns={VISIBLE_COLUMNS_MAP[browseOption]}
       isEmptyMessage={isEmptyMessage}
       isSelected={isSelected}
@@ -138,7 +86,6 @@ const BrowseResultsList = ({
       autosize
       virtualize={false}
       hasMargin
-      onRowClick={onRowClick}
       onNeedMoreData={onNeedMoreData}
       pageAmount={BROWSE_RESULTS_COUNT}
       pagingType={MCLPagingTypes.PREV_NEXT}
@@ -161,6 +108,11 @@ BrowseResultsList.propTypes = {
     hasPrevPage: PropTypes.bool,
     hasNextPage: PropTypes.bool,
     onNeedMoreData: PropTypes.func.isRequired,
+    pageConfig: PropTypes.arrayOf(
+      PropTypes.number,
+      PropTypes.string,
+      PropTypes.string,
+    ),
   }).isRequired,
   totalRecords: PropTypes.number,
 };

--- a/src/components/BrowseResultsList/getBrowseResultsFormatter.js
+++ b/src/components/BrowseResultsList/getBrowseResultsFormatter.js
@@ -1,9 +1,20 @@
+import queryString from 'query-string';
 import { FormattedMessage } from 'react-intl';
 
 import { AppIcon } from '@folio/stripes/core';
-import { Tooltip } from '@folio/stripes/components';
+import {
+  TextLink,
+  Tooltip,
+} from '@folio/stripes/components';
 
-import { browseModeOptions } from '../../constants';
+import {
+  browseModeOptions,
+  INVENTORY_ROUTE,
+} from '../../constants';
+import {
+  getSearchParams,
+  isRowPreventsClick,
+} from './utils';
 import MissedMatchItem from '../MissedMatchItem';
 
 import css from './BrowseResultsList.css';
@@ -16,26 +27,63 @@ const getFullMatchRecord = (item, isAnchor) => {
   return item;
 };
 
+const getTargetRecord = (
+  item,
+  row,
+  browseOption,
+  browseSearch,
+  pageConfig,
+) => {
+  const record = getFullMatchRecord(item, row.isAnchor);
+  const searchParams = getSearchParams(row, browseOption);
+  const isNotClickable = isRowPreventsClick(row, browseOption);
+
+  if (isNotClickable) return record;
+
+  const toParams = {
+    pathname: INVENTORY_ROUTE,
+    search: queryString.stringify({
+      selectedBrowseResult: true,
+      ...searchParams,
+    }),
+    state: {
+      browseSearch,
+      pageConfig,
+    },
+  };
+
+  return (
+    <TextLink to={toParams}>
+      {record}
+    </TextLink>
+  );
+};
+
 const openInNewTab = (url) => window.open(url, '_blank', 'noopener,noreferrer');
 
-const getBrowseResultsFormatter = (data, browseOption) => {
+const getBrowseResultsFormatter = ({
+  data,
+  browseOption,
+  search: browseSearch,
+  pageConfig,
+}) => {
   return {
     title: r => getFullMatchRecord(r.instance?.title, r.isAnchor),
     subject: r => {
       if (r?.totalRecords) {
-        return getFullMatchRecord(r?.subject, r.isAnchor);
+        return getTargetRecord(r?.subject, r, browseOption, browseSearch, pageConfig);
       }
       return <MissedMatchItem query={r.subject} />;
     },
     callNumber: r => {
       if (r?.instance || r?.totalRecords) {
-        return getFullMatchRecord(r?.fullCallNumber, r.isAnchor);
+        return getTargetRecord(r?.fullCallNumber, r, browseOption, browseSearch, pageConfig);
       }
       return <MissedMatchItem query={r.fullCallNumber} />;
     },
     contributor: r => {
       if (r?.totalRecords) {
-        const fullMatchRecord = getFullMatchRecord(r.name, r.isAnchor);
+        const fullMatchRecord = getTargetRecord(r.name, r, browseOption, browseSearch, pageConfig);
         const isBrowseContributors = browseOption === browseModeOptions.CONTRIBUTORS;
 
         if (isBrowseContributors && r.authorityId) {

--- a/src/components/BrowseResultsList/utils.js
+++ b/src/components/BrowseResultsList/utils.js
@@ -1,0 +1,35 @@
+import {
+  browseModeOptions,
+  FACETS,
+  queryIndexes,
+} from '../../constants';
+
+export const isRowPreventsClick = (row, browseOption) => {
+  const isMissedMatchItemRow = !!row.isAnchor && row.totalRecords === 0;
+
+  return isMissedMatchItemRow || (
+    (browseOption === browseModeOptions.CALL_NUMBERS && !row.shelfKey) ||
+    (browseOption === browseModeOptions.CONTRIBUTORS && !row.contributorNameTypeId) ||
+    (browseOption === browseModeOptions.SUBJECTS && !row.totalRecords)
+  );
+};
+
+export const getSearchParams = (row, qindex) => {
+  const optionsMap = {
+    [browseModeOptions.CALL_NUMBERS]: {
+      qindex: queryIndexes.CALL_NUMBER,
+      query: row.shelfKey,
+    },
+    [browseModeOptions.CONTRIBUTORS]: {
+      qindex: queryIndexes.CONTRIBUTOR,
+      query: row.name,
+      filters: `${FACETS.SEARCH_CONTRIBUTORS}.${row.contributorNameTypeId}`,
+    },
+    [browseModeOptions.SUBJECTS]: {
+      qindex: queryIndexes.SUBJECT,
+      query: row.subject,
+    },
+  };
+
+  return optionsMap[qindex];
+};

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -323,7 +323,7 @@ class InstancesList extends React.Component {
     <>
       <SearchModeNavigation
         search={this.state.browsePageSearch}
-        state={this.state.browsePageConfig}
+        state={{ pageConfig: this.state.browsePageConfig }}
       />
       <FilterNavigation segment={this.props.segment} onChange={this.refocusOnInputSearch} />
     </>

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -168,9 +168,12 @@ class InstancesList extends React.Component {
       }
     });
 
+    const { browseSearch, pageConfig } = this.getBrowsePageState();
+
     this.setState({
-      browsePageSearch: this.getBrowsePageSearch(),
-      openedFromBrowse: !!this.getBrowsePageSearch(),
+      browsePageSearch: browseSearch,
+      browsePageConfig: pageConfig,
+      openedFromBrowse: !!browseSearch,
       optionSelected: '',
     });
   }
@@ -201,8 +204,11 @@ class InstancesList extends React.Component {
     return params.get('qindex');
   }
 
-  getBrowsePageSearch = () => {
-    return this.props.location.state?.browseSearch;
+  getBrowsePageState = () => {
+    return {
+      browseSearch: this.props.location.state?.browseSearch,
+      pageConfig: this.props.location.state?.pageConfig,
+    };
   }
 
   getInitialToggableColumns = () => {
@@ -315,7 +321,10 @@ class InstancesList extends React.Component {
 
   renderNavigation = () => (
     <>
-      <SearchModeNavigation search={this.state.browsePageSearch} />
+      <SearchModeNavigation
+        search={this.state.browsePageSearch}
+        state={this.state.browsePageConfig}
+      />
       <FilterNavigation segment={this.props.segment} onChange={this.refocusOnInputSearch} />
     </>
   );

--- a/src/components/SearchModeNavigation/SearchModeNavigation.js
+++ b/src/components/SearchModeNavigation/SearchModeNavigation.js
@@ -13,7 +13,7 @@ import {
   searchModeSegments,
 } from '../../constants';
 
-const SearchModeNavigation = ({ search }) => {
+const SearchModeNavigation = ({ search, state }) => {
   const { path } = useRouteMatch();
 
   const checkIsButtonActive = useCallback((segment) => (
@@ -29,6 +29,7 @@ const SearchModeNavigation = ({ search }) => {
             to={{
               pathname: searchModeRoutesMap[segment],
               search,
+              state,
             }}
             buttonStyle={checkIsButtonActive(segment)}
             id={`mode-navigation-${segment}`}
@@ -43,6 +44,7 @@ const SearchModeNavigation = ({ search }) => {
 
 SearchModeNavigation.propTypes = {
   search: PropTypes.string,
+  state: PropTypes.any,
 };
 
 export default SearchModeNavigation;

--- a/src/hooks/useInventoryBrowse/index.js
+++ b/src/hooks/useInventoryBrowse/index.js
@@ -1,1 +1,2 @@
+export * from './constants';
 export { default } from './useInventoryBrowse';

--- a/src/hooks/useInventoryBrowse/useInventoryBrowse.js
+++ b/src/hooks/useInventoryBrowse/useInventoryBrowse.js
@@ -1,7 +1,8 @@
 import queryString from 'query-string';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useQuery } from 'react-query';
 import { useLocation } from 'react-router-dom';
+import { noop } from 'lodash';
 
 import {
   useNamespace,
@@ -48,16 +49,17 @@ const getUpdatedPageQuery = (direction, anchor) => (_query, qindex) => {
 
 const useInventoryBrowse = ({
   filters = {},
+  pageParams = {},
   options = {},
 }) => {
   const ky = useOkapiKy();
-  const { search } = useLocation();
+  const { search, state } = useLocation();
   const [namespace] = useNamespace();
-  const [pageConfig, setPageConfig] = useState();
+  const { pageConfig = [], setPageConfig = noop } = pageParams;
 
   useEffect(() => {
-    setPageConfig(INIT_PAGE_CONFIG);
-  }, [filters]);
+    setPageConfig(state || INIT_PAGE_CONFIG);
+  }, []);
 
   const normalizedFilters = {
     ...Object.entries(filters).reduce((acc, [key, value]) => ({
@@ -131,6 +133,7 @@ const useInventoryBrowse = ({
       hasPrevPage: !!data.prev,
       hasNextPage: !!data.next,
       onNeedMoreData: updatePage,
+      pageConfig,
     },
     totalRecords: data.totalRecords,
   };

--- a/src/hooks/useInventoryBrowse/useInventoryBrowse.js
+++ b/src/hooks/useInventoryBrowse/useInventoryBrowse.js
@@ -58,7 +58,7 @@ const useInventoryBrowse = ({
   const { pageConfig = [], setPageConfig = noop } = pageParams;
 
   useEffect(() => {
-    setPageConfig(state || INIT_PAGE_CONFIG);
+    setPageConfig(state?.pageConfig || INIT_PAGE_CONFIG);
   }, []);
 
   const normalizedFilters = {

--- a/src/hooks/useInventoryBrowse/useInventoryBrowse.test.js
+++ b/src/hooks/useInventoryBrowse/useInventoryBrowse.test.js
@@ -5,7 +5,12 @@ import '../../../test/jest/__mock__';
 
 import { useOkapiKy } from '@folio/stripes/core';
 
-import { browseModeOptions, FACETS } from '../../constants';
+import {
+  browseModeOptions,
+  FACETS,
+  PAGE_DIRECTIONS,
+} from '../../constants';
+import { INIT_PAGE_CONFIG } from './constants';
 import useInventoryBrowse from './useInventoryBrowse';
 
 jest.mock('react-router-dom', () => ({
@@ -34,6 +39,10 @@ const filters = {
   qindex: browseModeOptions.CALL_NUMBERS,
   [FACETS.EFFECTIVE_LOCATION]: ['dc5f3f2d-9a39-4a54-bfb9-120c4e2c0bea'],
 };
+const pageParams = {
+  pageConfig: INIT_PAGE_CONFIG,
+  setPageConfig: jest.fn(),
+};
 
 describe('useInventoryBrowse', () => {
   const mockGet = jest.fn(() => ({
@@ -48,7 +57,7 @@ describe('useInventoryBrowse', () => {
   });
 
   it('should fetches browse data based on query and filters', async () => {
-    const { result, waitFor } = renderHook(() => useInventoryBrowse({ filters }), { wrapper });
+    const { result, waitFor } = renderHook(() => useInventoryBrowse({ filters, pageParams }), { wrapper });
 
     await waitFor(() => !result.current.isFetching);
 
@@ -56,11 +65,30 @@ describe('useInventoryBrowse', () => {
     expect(result.current.data).toEqual(items);
   });
 
-  it('should fetch browse data based on current anchor and direction', async () => {
-    const { result, waitFor } = renderHook(() => useInventoryBrowse({ filters }), { wrapper });
+  it('should provide updated page config state', async () => {
+    const { result, waitFor } = renderHook(() => useInventoryBrowse({ filters, pageParams }), { wrapper });
+
+    const direction = PAGE_DIRECTIONS.next;
 
     await waitFor(() => !result.current.isFetching);
-    await act(async () => result.current.pagination.onNeedMoreData(null, null, null, 'next'));
+    await act(async () => result.current.pagination.onNeedMoreData(null, null, null, direction));
+
+    const initPageConfig = pageParams.pageConfig;
+    const newPageConfig = pageParams.setPageConfig.mock.calls.at(-1)[0]([initPageConfig[0]]);
+
+    expect(newPageConfig).toEqual([initPageConfig[0] + 1, direction, data[direction]]);
+  });
+
+  it('should fetch browse data based on current anchor and direction', async () => {
+    const { result, waitFor } = renderHook(() => useInventoryBrowse({
+      filters,
+      pageParams: {
+        ...pageParams,
+        pageConfig: [1, PAGE_DIRECTIONS.next, data.next],
+      },
+    }), { wrapper });
+
+    await waitFor(() => !result.current.isFetching);
 
     expect(mockGet).toHaveBeenLastCalledWith(
       expect.any(String),

--- a/src/views/BrowseInventory/BrowseInventory.js
+++ b/src/views/BrowseInventory/BrowseInventory.js
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useHistory, useLocation } from 'react-router-dom';
 
@@ -27,6 +27,7 @@ import {
   useBrowseValidation,
   useInventoryBrowse,
 } from '../../hooks';
+import { INIT_PAGE_CONFIG } from '../../hooks/useInventoryBrowse';
 
 const BrowseInventory = () => {
   const history = useHistory();
@@ -35,6 +36,7 @@ const BrowseInventory = () => {
   const [namespace] = useNamespace();
   const { isFiltersOpened, toggleFilters } = useFiltersToogle(`${namespace}/filters`);
   const { deleteItemToView } = useItemToView('browse');
+  const [pageConfig, setPageConfig] = useState(INIT_PAGE_CONFIG);
 
   const [
     filters,
@@ -45,7 +47,9 @@ const BrowseInventory = () => {
     resetFilters,
     changeSearchIndex,
     searchIndex,
-  ] = useLocationFilters(location, history, () => {});
+  ] = useLocationFilters(location, history, () => {
+    setPageConfig(INIT_PAGE_CONFIG);
+  });
 
   const {
     data,
@@ -55,7 +59,8 @@ const BrowseInventory = () => {
     totalRecords,
   } = useInventoryBrowse({
     filters,
-    options: { onSettled: deleteItemToView }
+    pageParams: { pageConfig, setPageConfig },
+    options: { onSettled: deleteItemToView },
   });
 
   const { validateDataQuery } = useBrowseValidation(searchIndex);


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
 -->
https://issues.folio.org/browse/UIIN-2266

Make one of a MCL columns a `TextLink` component to navigate to the instance `Search` page.

---

_Additional scope_ - display the last watched records in a list when an user returns back to the `Browse` page. Relates to https://github.com/folio-org/ui-inventory/pull/1842
Currently `Browse` records are loaded based on provided filters (parsed from `search`) after bouncing back. That returns user back to initial query, but not the latest page.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- move `isRowPreventsClick` and `getSearchParams` from `BrowseResultsList.js` into separate utils to reuse it;
- update `getBrowseResultsFormatter` to allow `TextLink` rendering for columns, that will navigate to instance results on the `Search` page;
- hoist `pageConfig` state to the `BrowseInventory.js` and let `useLocationFilters` and `useInventoryBrowse` hooks manage it;
- provide and keep in the history state `pageConfig` when navigating from `Browse` to instance `Search` results and when switching back to the `Browse` (to load the records from the last anchor);
- update unit tests

<details>
<summary>Preview</summary>

![chrome_HpHB9rUALs](https://user-images.githubusercontent.com/88109087/210077481-f55d9f3f-1779-4524-9912-9936cc893c8d.gif)

</details>

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
