### PR TITLE
UIIN-2289: Rename instances1 resource on ItemsRoute to avoid colliding with holding records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Users with browse permissions can delete inventory records. Refs UIIN-2283.
 * Include browse permissions into Inventory permissions. Refs UIIN-2280.
 * Browse Lists | Hyperlink one column to improve accessibility. Refs UIIN-2266.
+* Rename `instances1` resource on `ItemsRoute` to avoid colliding with holding records. Refs UIIN-2289.
 
 ## [9.2.0](https://github.com/folio-org/ui-inventory/tree/v9.2.0) (2022-10-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.1.0...v9.2.0)

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -136,6 +136,7 @@ class ViewHoldingsRecord extends React.Component {
 
   componentDidMount() {
     const holdingsRecordPromise = this.props.mutator.holdingsRecords.GET();
+    this.props.mutator.instances1.reset();
     const instances1Promise = this.props.mutator.instances1.GET();
 
     Promise.all([holdingsRecordPromise, instances1Promise])
@@ -1064,6 +1065,7 @@ ViewHoldingsRecord.propTypes = {
   mutator: PropTypes.shape({
     instances1: PropTypes.shape({
       GET: PropTypes.func.isRequired,
+      reset: PropTypes.func.isRequired,
     }),
     holdingsRecords: PropTypes.shape({
       GET: PropTypes.func.isRequired,

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -135,6 +135,7 @@ class ViewHoldingsRecord extends React.Component {
   }
 
   componentDidMount() {
+    this.props.mutator.holdingsRecords.reset();
     const holdingsRecordPromise = this.props.mutator.holdingsRecords.GET();
     this.props.mutator.instances1.reset();
     const instances1Promise = this.props.mutator.instances1.GET();

--- a/src/ViewHoldingsRecord.test.js
+++ b/src/ViewHoldingsRecord.test.js
@@ -38,6 +38,7 @@ const defaultProps = {
   mutator: {
     instances1: {
       GET: jest.fn(() => Promise.resolve({ id: 'instanceId' })),
+      reset: jest.fn(() => Promise.resolve()),
     },
     holdingsRecords: {
       GET: jest.fn(() => Promise.resolve({ hrid: 'hrid' })),

--- a/src/routes/ItemRoute.js
+++ b/src/routes/ItemRoute.js
@@ -104,9 +104,10 @@ class ItemRoute extends React.Component {
       type: 'okapi',
       path: 'holdings-storage/holdings/:{holdingsrecordid}',
     },
-    instances1: {
+    instanceRecords: {
       type: 'okapi',
       path: 'inventory/instances/:{id}',
+      resourceShouldRefresh: true,
     },
     servicePoints: {
       type: 'okapi',
@@ -178,12 +179,12 @@ class ItemRoute extends React.Component {
       resources: {
         itemsResource,
         holdingsRecords,
-        instances1,
+        instanceRecords,
       },
     } = this.props;
 
     if (!itemsResource?.hasLoaded ||
-      !instances1?.hasLoaded ||
+      !instanceRecords?.hasLoaded ||
       !holdingsRecords?.hasLoaded) {
       return true;
     }

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -136,9 +136,9 @@ class ItemView extends React.Component {
   };
 
   copyItem = item => {
-    const { resources: { holdingsRecords, instances1 } } = this.props;
+    const { resources: { holdingsRecords, instanceRecords } } = this.props;
     const holdingsRecord = holdingsRecords.records[0];
-    const instance = instances1.records[0];
+    const instance = instanceRecords.records[0];
 
     this.props.mutator.itemsResource.POST(item).then((data) => {
       this.props.goTo(`/inventory/view/${instance.id}/${holdingsRecord.id}/${data.id}`);
@@ -395,7 +395,7 @@ class ItemView extends React.Component {
       resources: {
         itemsResource,
         holdingsRecords,
-        instances1,
+        instanceRecords,
         requests,
         staffMembers,
         servicePoints,
@@ -429,7 +429,7 @@ class ItemView extends React.Component {
       </Link> :
       '-';
 
-    const instance = instances1.records[0];
+    const instance = instanceRecords.records[0];
     const item = itemsResource.records[0] || {};
     const holdingsRecord = holdingsRecords.records[0];
     const { locationsById } = referenceTables;
@@ -1518,7 +1518,7 @@ ItemView.propTypes = {
     hasPerm: PropTypes.func.isRequired,
   }).isRequired,
   resources: PropTypes.shape({
-    instances1: PropTypes.shape({ records: PropTypes.arrayOf(PropTypes.object) }),
+    instanceRecords: PropTypes.shape({ records: PropTypes.arrayOf(PropTypes.object) }),
     loanTypes: PropTypes.shape({ records: PropTypes.arrayOf(PropTypes.object) }),
     requests: PropTypes.shape({
       records: PropTypes.arrayOf(PropTypes.object),

--- a/src/views/ItemView.test.js
+++ b/src/views/ItemView.test.js
@@ -80,7 +80,7 @@ const resources = {
       },
     ],
   },
-  instances1: {
+  instanceRecords: {
     records: [
       {
         id: 1,


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-2289

Due to a limitation in `stripes-connect` the resources are not attached to the given component instance. This can cause some unexpected issues from time to time when the resource name is shared between multiple components. For example, when one component is unmounted when another is mounted the fetched data may get wiped unexpectedly from the redux store.

This PR uses unique names for instances of resource in ItemRoute and HoldingRecordView to avoid these types of collisions.