### PR TITLE
UIIN-2285 UIIN-2294 Wrong operator used in request when user selects a record in browse results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
 * ISRI: Update the Inventory modal for ISRI single source Overlays. Refs UIIN-2253.
 * ISRI: Update the Inventory modal for ISRI single multi-source Imports. Refs UIIN-2254.
 * ISRI: Update the Inventory modal for ISRI single multi-source Overlays. Refs UIIN-2255.
+* Clean up the rest of the old "Browse" related code from "Search" route. Refs UIIN-2285.
+* Wrong operator used in request when user selects a record in browse results. UIIN-2294
 
 ## [9.2.0](https://github.com/folio-org/ui-inventory/tree/v9.2.0) (2022-10-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.1.0...v9.2.0)

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -18,12 +18,32 @@ import facetsStore from '../stores/facetsStore';
 const INITIAL_RESULT_COUNT = 100;
 const DEFAULT_SORT = 'title';
 
+const getQueryTemplateContributor = (queryValue) => `contributors.name ==/string "${queryValue}"`;
+const getQueryTemplateSubjects = (queryValue) => `subjects==/string "${queryValue.replace(/"/g, '\\"')}"`;
+const getQueryTemplateCallNumber = (queryValue) => `itemEffectiveShelvingOrder==/string "${queryValue}"`;
+
 export function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
   const { indexes, sortMap, filters } = getFilterConfig(queryParams.segment);
   const query = { ...resourceData.query };
   const queryIndex = queryParams?.qindex ?? 'all';
   const queryValue = get(queryParams, 'query', '');
   let queryTemplate = getQueryTemplate(queryIndex, indexes);
+
+  if (queryParams?.selectedBrowseResult) {
+    if (queryIndex === queryIndexes.SUBJECT) {
+      queryTemplate = getQueryTemplateSubjects(queryValue);
+    }
+
+    if (queryIndex === queryIndexes.CALL_NUMBER) {
+      queryTemplate = getQueryTemplateCallNumber(queryValue);
+    }
+
+    if (queryIndex === queryIndexes.CONTRIBUTOR) {
+      queryTemplate = getQueryTemplateContributor(queryValue);
+    }
+
+    query.selectedBrowseResult = null; // reset this parameter so the next search uses `=` instead of `==/string`
+  }
 
   if (queryIndex.match(/isbn|issn/)) {
     // eslint-disable-next-line camelcase

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -18,7 +18,7 @@ import facetsStore from '../stores/facetsStore';
 const INITIAL_RESULT_COUNT = 100;
 const DEFAULT_SORT = 'title';
 
-const getQueryTemplateContributor = (queryValue) => `contributors.name ==/string "${queryValue}"`;
+const getQueryTemplateContributor = (queryValue) => `contributors.name==/string "${queryValue}"`;
 const getQueryTemplateSubjects = (queryValue) => `subjects==/string "${queryValue.replace(/"/g, '\\"')}"`;
 const getQueryTemplateCallNumber = (queryValue) => `itemEffectiveShelvingOrder==/string "${queryValue}"`;
 

--- a/src/routes/buildManifestObject.test.js
+++ b/src/routes/buildManifestObject.test.js
@@ -1,0 +1,90 @@
+import '../../test/jest/__mock__';
+
+import { queryIndexes } from '../constants';
+import { instanceIndexes } from '../filterConfig';
+import { buildQuery } from './buildManifestObject';
+
+const getQueryTemplate = (qindex) => instanceIndexes.find(({ value }) => value === qindex).queryTemplate;
+
+const getBuildQueryArgs = ({
+  queryParams = {},
+  pathComponents = {},
+  resourceData = {},
+  logger = { log: jest.fn() },
+} = {}) => {
+  const resData = { query: { ...queryParams }, ...resourceData };
+
+  return [queryParams, pathComponents, resData, logger];
+};
+
+const defaultQueryParamsMap = {
+  [queryIndexes.CALL_NUMBER]: { qindex: queryIndexes.CALL_NUMBER, query: 'Some call number query' },
+  [queryIndexes.CONTRIBUTOR]: { qindex: queryIndexes.CONTRIBUTOR, query: 'Some contributor query' },
+  [queryIndexes.SUBJECT]: { qindex: queryIndexes.SUBJECT, query: 'Some subject query' },
+};
+
+describe('buildQuery', () => {
+  describe('build query for inventory search', () => {
+    it('should build query for \'Effective call number (item), shelving order\' search option', () => {
+      const qindex = queryIndexes.CALL_NUMBER;
+      const queryParams = { ...defaultQueryParamsMap[qindex] };
+      const cql = buildQuery(...getBuildQueryArgs({ queryParams }));
+
+      const queryTemplate = getQueryTemplate(qindex);
+      expect(cql).toEqual(expect.stringContaining(`${queryTemplate.replace('%{query.query}', defaultQueryParamsMap[qindex].query)}`));
+    });
+
+    it('should build query for \'Contributor\' search option', () => {
+      const qindex = queryIndexes.CONTRIBUTOR;
+      const queryParams = { ...defaultQueryParamsMap[qindex] };
+      const cql = buildQuery(...getBuildQueryArgs({ queryParams }));
+
+      const queryTemplate = getQueryTemplate(qindex);
+      expect(cql).toEqual(expect.stringContaining(`${queryTemplate.replace('%{query.query}', defaultQueryParamsMap[qindex].query)}`));
+    });
+
+    it('should build query for \'Subject\' search option', () => {
+      const qindex = queryIndexes.SUBJECT;
+      const queryParams = { ...defaultQueryParamsMap[qindex] };
+      const cql = buildQuery(...getBuildQueryArgs({ queryParams }));
+
+      const queryTemplate = getQueryTemplate(qindex);
+      expect(cql).toEqual(expect.stringContaining(`${queryTemplate.replace('%{query.query}', defaultQueryParamsMap[qindex].query)}`));
+    });
+  });
+
+  describe('build query based on selected browse record', () => {
+    it('should build query for \'Call numbers\' browse option', () => {
+      const qindex = queryIndexes.CALL_NUMBER;
+      const queryParams = {
+        ...defaultQueryParamsMap[qindex],
+        selectedBrowseResult: true,
+      };
+      const cql = buildQuery(...getBuildQueryArgs({ queryParams }));
+
+      expect(cql).toEqual(expect.stringContaining(`itemEffectiveShelvingOrder==/string "${defaultQueryParamsMap[qindex].query}"`));
+    });
+
+    it('should build query for \'Contributors\' browse option', () => {
+      const qindex = queryIndexes.CONTRIBUTOR;
+      const queryParams = {
+        ...defaultQueryParamsMap[qindex],
+        selectedBrowseResult: true,
+      };
+      const cql = buildQuery(...getBuildQueryArgs({ queryParams }));
+
+      expect(cql).toEqual(expect.stringContaining(`contributors.name==/string "${defaultQueryParamsMap[qindex].query}"`));
+    });
+
+    it('should build query for \'Subjects\' browse option', () => {
+      const qindex = queryIndexes.SUBJECT;
+      const queryParams = {
+        ...defaultQueryParamsMap[qindex],
+        selectedBrowseResult: true,
+      };
+      const cql = buildQuery(...getBuildQueryArgs({ queryParams }));
+
+      expect(cql).toEqual(expect.stringContaining(`subjects==/string "${defaultQueryParamsMap[qindex].query}"`));
+    });
+  });
+});


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
 -->
https://issues.folio.org/browse/UIIN-2285
https://issues.folio.org/browse/UIIN-2294

PR https://github.com/folio-org/ui-inventory/pull/1908 included the removal of a piece of code responsible for correctly building the query when an entry is selected on the `Browse` page and navigated to the `Search` page in Inventory. That part of code didn't work properly, so it should be changed.
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Check `selectedBrowseResult` for true in the query parameters and build a query that will return the same number of instances as in the corresponding browse row. Otherwise, use the default query template.
## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
