### PR TITLE
UIIN-2301: Open instance details pane in cases when single item is not found after search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@
 * ISRI: Update the Inventory modal for ISRI single multi-source Imports. Refs UIIN-2254.
 * ISRI: Update the Inventory modal for ISRI single multi-source Overlays. Refs UIIN-2255.
 * Clean up the rest of the old "Browse" related code from "Search" route. Refs UIIN-2285.
-* Wrong operator used in request when user selects a record in browse results. UIIN-2294
+* Wrong operator used in request when user selects a record in browse results. UIIN-2294.
+* Open instance details pane in cases when single item is not found after search. Fixes UIIN-2301.
 
 ## [9.2.0](https://github.com/folio-org/ui-inventory/tree/v9.2.0) (2022-10-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.1.0...v9.2.0)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -791,7 +791,7 @@ class InstancesList extends React.Component {
     const { searchInProgress } = this.state;
 
     if (!searchInProgress) {
-      return;
+      return instance;
     }
 
     const itemQuery = buildSingleItemQuery(qindex, query);
@@ -808,11 +808,13 @@ class InstancesList extends React.Component {
     // if no results have been found or more than one item has been found
     // do not open item view
     if (items?.length > 1 || !items?.[0]?.holdingsRecordId) {
-      return;
+      return instance;
     }
 
     const { id, holdingsRecordId } = items[0];
     goTo(`/inventory/view/${instance.id}/${holdingsRecordId}/${id}`, getParams());
+
+    return null;
   }
 
   onSelectRow = (_, instance) => {
@@ -824,8 +826,7 @@ class InstancesList extends React.Component {
       return instance;
     }
 
-    this.findAndOpenItem(instance);
-    return null;
+    return this.findAndOpenItem(instance);
   }
 
   render() {


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-2301

This is a regression after the work done in: https://github.com/folio-org/ui-inventory/pull/1928 related to opening up the item details pane.

If the single item is not found the instance detail pane should still open.