### PR TITLE
UIIN-2285 replace 'callNumber' search param with 'itemEffectiveShelvingOrder' for inventory search by 'Effective call number (item), shelving order' option

### DIFF
--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -124,7 +124,7 @@ export const instanceIndexes = [
   { label: 'ui-inventory.search.instanceNotes', value: 'instanceNotes', queryTemplate: 'notes.note all "%{query.query}" or administrativeNotes all "%{query.query}"' },
   { label: 'ui-inventory.search.instanceAdministrativeNotes', value: 'instanceAdministrativeNotes', queryTemplate: 'administrativeNotes all "%{query.query}"' },
   { label: 'ui-inventory.subject', value: 'subject', queryTemplate: 'subjects="%{query.query}"' },
-  { label: 'ui-inventory.effectiveCallNumberShelving', value: 'callNumber', queryTemplate: 'callNumber=%{query.query}' },
+  { label: 'ui-inventory.effectiveCallNumberShelving', value: 'callNumber', queryTemplate: 'itemEffectiveShelvingOrder==/string "%{query.query}"' },
   { label: 'ui-inventory.instanceHrid', value: 'hrid', queryTemplate: 'hrid=="%{query.query}"' },
   { label: 'ui-inventory.instanceId', value: 'id', queryTemplate: 'id="%{query.query}"' },
   { label: 'ui-inventory.authorityId', value: 'authorityId', queryTemplate: 'authorityId == %{query.query}' },


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
 -->
https://issues.folio.org/browse/UIIN-2285

Search option `callNumber` is used for browsing by call numbers. For inventory search by "Effective call number (item), shelving order" `itemEffectiveShelvingOrder` search option should be used.

<details>
<summary>Preview</summary>

![image](https://user-images.githubusercontent.com/88109087/212344301-020bb04f-b885-429f-a4ae-42603843c7b1.png)
![image](https://user-images.githubusercontent.com/88109087/212344627-6818560b-43bb-44ae-9354-135561e01e46.png)

</details>

Expected behavior:
- Morning Glory - https://bugfest-mg.int.aws.folio.org/inventory?qindex=callNumber&query=test&sort=title
- Nolana - https://bugfest-nolana.int.aws.folio.org/inventory?qindex=callNumber&query=test&sort=title

<details>
<summary>Preview</summary>

![image](https://user-images.githubusercontent.com/88109087/212345478-b6a75152-1013-42f2-8bec-8e6a2a9632ba.png)
![image](https://user-images.githubusercontent.com/88109087/212345299-19a82cd0-a5c3-4f7a-8acd-4a64d66754a7.png)

</details>

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Update query template for `Effective call number (item), shelving order` option from `callNumber=%{query.query}` to `itemEffectiveShelvingOrder==/string "%{query.query}"`
#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
