### PR TITLE
UIIN-2289: Do not render item list before holding records are loaded.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Clean up the rest of the old "Browse" related code from "Search" route. Refs UIIN-2285.
 * Wrong operator used in request when user selects a record in browse results. UIIN-2294.
 * Open instance details pane in cases when single item is not found after search. Fixes UIIN-2301.
+* Do not render item list before holding records are loaded. Fixes UIIN-2289.
 
 ## [9.2.0](https://github.com/folio-org/ui-inventory/tree/v9.2.0) (2022-10-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.1.0...v9.2.0)

--- a/src/Instance/ItemsList/ItemsList.js
+++ b/src/Instance/ItemsList/ItemsList.js
@@ -147,11 +147,9 @@ const ItemsList = ({
   selectItemsForDrag,
   getDraggingItems,
 }) => {
-  const { boundWithHoldings: holdings } = useBoundWithHoldings(items);
+  const { boundWithHoldings: holdings, isLoading } = useBoundWithHoldings(items);
   const holdingsMapById = keyBy(holdings, 'id');
-
   const intl = useIntl();
-
   const [itemsSorting, setItemsSorting] = useState({
     isDesc: false,
     column: 'barcode',
@@ -211,10 +209,9 @@ const ItemsList = ({
     setItemsSorting(newItemsSorting);
   }, [itemsSorting]);
 
-  if (!draggable && isEmpty(items)) return null;
+  if ((!draggable && isEmpty(items)) || isLoading) return null;
 
   return (
-
     <MultiColumnList
       id={`list-items-${holding.id}`}
       columnIdPrefix={`list-items-${holding.id}`}


### PR DESCRIPTION
Do not render the item list before holding records are loaded.

This was causing issues with cypress tests because the items would render with an incorrect link (with missing instanceId) to the item details screen.

https://issues.folio.org/browse/UIIN-2289