### PR TITLE
UIIN-2176: Link 1 column to improve accessibility

### DIFF
--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -34,6 +34,8 @@ import {
   checkScope,
   HasCommand,
   MCLPagingTypes,
+  TextLink,
+  DefaultMCLRowFormatter,
 } from '@folio/stripes/components';
 
 import FilterNavigation from '../FilterNavigation';
@@ -660,6 +662,15 @@ class InstancesList extends React.Component {
     );
   };
 
+  getRowURL = (id) => {
+    const {
+      match: { path },
+      location: { search },
+    } = this.props;
+
+    return `${path}/view/${id}${search}`;
+  };
+
   getIsAllRowsSelected = () => {
     const { parentResources } = this.props;
     const { selectedRows } = this.state;
@@ -869,6 +880,7 @@ class InstancesList extends React.Component {
         discoverySuppress,
         isBoundWith,
         staffSuppress,
+        id,
       }) => {
         return (
           <AppIcon
@@ -877,7 +889,12 @@ class InstancesList extends React.Component {
             iconKey="instance"
             iconAlignment="baseline"
           >
-            {title}
+            {/* {title} */}
+            <TextLink
+              to={this.getRowURL(id)}
+            >
+              {title}
+            </TextLink>
             {(isBoundWith) &&
             <AppIcon
               size="small"
@@ -986,7 +1003,9 @@ class InstancesList extends React.Component {
             }}
             getCellClass={this.formatCellStyles}
             customPaneSub={this.renderPaneSub()}
+            resultsRowClickHandlers={false}
             resultsFormatter={resultsFormatter}
+            resultsRowFormatter={DefaultMCLRowFormatter}
             onCreate={this.onCreate}
             viewRecordPerms="ui-inventory.instance.view"
             newRecordPerms="ui-inventory.instance.create"


### PR DESCRIPTION
## Purpose
Like in [ui-requests](https://github.com/folio-org/ui-requests/pull/849), change the result list to single-cell links to improve accessibility.

## Approach
I followed the very clear approach given by the Jira.  

#### TODOS and Open Questions
I did **not** implement the final step from UIREQ-716:
> supply your app's own resultIsSelected logic - in this PR, we hold the selected item in a state key that's set when the record link is clicked and cleared when the view record is dismissed.

... because the Inventory results list already has some (IMHO) complex selection logic.  If that's incorrect please let me know.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [X] There are no breaking changes in this PR.

## Issues
https://issues.folio.org/browse/UIIN-2176
