### PR TITLE
UIIN-2320 - Remove extra whitespace when parsing statistical code options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * Hyperlink one column in the results list to improve accessibility. Fixes UIIN-2176.
 * Bump stripes to `8.0.0` for Orchid/2023-R1. Refs UIIN-2303.
 * Improve the layout of the actions menu on the the item record. Fixes UIIN-2263.
+* Remove extra whitespace when parsing statistical code options. Fixes UIIN-2320.
 
 ## [9.2.0](https://github.com/folio-org/ui-inventory/tree/v9.2.0) (2022-10-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.1.0...v9.2.0)

--- a/src/facetUtils.js
+++ b/src/facetUtils.js
@@ -213,7 +213,7 @@ const parseStatisticalCodeOption = (entry, count) => {
     code,
     statisticalCodeType,
   } = entry;
-  const label = `${statisticalCodeType?.name}:    ${code} - ${name}`;
+  const label = `${statisticalCodeType?.name}: ${code} - ${name}`;
   const option = {
     label,
     value,


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-2320

Extra whitespace was causing issues when searching for a given statistical code.