### PR TITLE
UIIN-2136: Block item deletion for items with status 'Claimed returned'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * Hyperlink one column in the results list to improve accessibility. Fixes UIIN-2176.
 * Bump stripes to `8.0.0` for Orchid/2023-R1. Refs UIIN-2303.
 * Improve the layout of the actions menu on the the item record. Fixes UIIN-2263.
+* Block item deletion for items with status `Claimed returned`. Fixes UIIN-2136.
 
 ## [9.2.0](https://github.com/folio-org/ui-inventory/tree/v9.2.0) (2022-10-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.1.0...v9.2.0)

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,6 +5,7 @@ const AWAITING_PICKUP = 'Awaiting pickup';
 const IN_TRANSIT = 'In transit';
 const CHECKED_OUT = 'Checked out';
 const AGED_TO_LOST = 'Aged to lost';
+const CLAIMED_RETURNED = 'Claimed returned';
 
 export const BROWSE_INVENTORY_ROUTE = '/inventory/browse';
 export const INVENTORY_ROUTE = '/inventory';
@@ -25,7 +26,7 @@ export const itemStatusesMap = {
   AWAITING_PICKUP,
   AWAITING_DELIVERY,
   CHECKED_OUT,
-  CLAIMED_RETURNED: 'Claimed returned',
+  CLAIMED_RETURNED,
   DECLARED_LOST: 'Declared lost',
   IN_PROCESS: 'In process',
   IN_PROCESS_NON_REQUESTABLE: 'In process (non-requestable)',
@@ -67,6 +68,7 @@ export const NOT_REMOVABLE_ITEM_STATUSES = [
   CHECKED_OUT,
   AWAITING_PICKUP,
   AGED_TO_LOST,
+  CLAIMED_RETURNED,
 ];
 
 export const itemStatuses = [


### PR DESCRIPTION
Block item deletion for items with status 'Claimed returned'.

https://issues.folio.org/browse/UIIN-2137

