### PR TITLE
UIIN-2001: Delete bound-with parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * Cannot save new Z39.50 Settings profile due to missing required fields. Fixes UIIN-2298.
 * Hide Export to json option in Action menu. Refs UIIN-2304.
 * Bump `@folio/stripes-acq-components` version to `4.0.0`. Refs UIIN-2319.
+* Delete bound-with parts.  Refs UIIN-2001.
 
 ## [9.2.0](https://github.com/folio-org/ui-inventory/tree/v9.2.0) (2022-10-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.1.0...v9.2.0)

--- a/src/Item/EditItem/EditItem.js
+++ b/src/Item/EditItem/EditItem.js
@@ -71,6 +71,10 @@ const EditItem = ({
   const { mutateBoundWiths } = useBoundWithsMutation();
 
   const updateBoundWiths = (values) => {
+    if (values.boundWithTitles === undefined) {
+      values.boundWithTitles = [];
+    }
+
     const boundWiths = {
       'itemId': values.id,
       'boundWithContents': values.boundWithTitles.map(title => {

--- a/src/Item/EditItem/EditItem.js
+++ b/src/Item/EditItem/EditItem.js
@@ -79,7 +79,7 @@ const EditItem = ({
         };
       }),
     };
-    mutateBoundWiths(boundWiths).catch(onError);
+    return mutateBoundWiths(boundWiths);
   };
 
   const onSubmit = useCallback((values) => {
@@ -87,9 +87,9 @@ const EditItem = ({
       delete item.barcode;
     }
 
-    updateBoundWiths(values);
-
-    return mutateItem(values).catch(onError);
+    return updateBoundWiths(values)
+      .then(() => mutateItem(values))
+      .catch(onError);
   }, [mutateItem]);
 
   if (isInstanceLoading || isHoldingLoading || isItemLoading) return <LoadingView />;

--- a/src/Item/EditItem/EditItem.js
+++ b/src/Item/EditItem/EditItem.js
@@ -21,6 +21,7 @@ import { parseHttpError } from '../../utils';
 import {
   useItem,
   useItemMutation,
+  useBoundWithsMutation,
 } from '../hooks';
 
 const EditItem = ({
@@ -67,10 +68,26 @@ const EditItem = ({
 
   const { mutateItem } = useItemMutation({ onSuccess });
 
+  const { mutateBoundWiths } = useBoundWithsMutation();
+
+  const updateBoundWiths = (values) => {
+    const boundWiths = {
+      'itemId': values.id,
+      'boundWithContents': values.boundWithTitles.map(title => {
+        return {
+          'holdingsRecordId': title.briefHoldingsRecord.id,
+        };
+      }),
+    };
+    mutateBoundWiths(boundWiths).catch(onError);
+  };
+
   const onSubmit = useCallback((values) => {
     if (!values.barcode) {
       delete item.barcode;
     }
+
+    updateBoundWiths(values);
 
     return mutateItem(values).catch(onError);
   }, [mutateItem]);

--- a/src/Item/EditItem/EditItem.test.js
+++ b/src/Item/EditItem/EditItem.test.js
@@ -95,6 +95,7 @@ describe('EditItem', () => {
       id: 'itemId',
       permanentLocationId: '',
       temporaryLocationId: '',
+      boundWithTitles: [],
     });
 
     expect(mutateItem).toHaveBeenCalled();

--- a/src/Item/EditItem/EditItem.test.js
+++ b/src/Item/EditItem/EditItem.test.js
@@ -104,4 +104,19 @@ describe('EditItem', () => {
 
     await waitFor(() => expect(mutateItem).toHaveBeenCalled());
   });
+
+  it('should work even with undefined boundWithTitles', async () => {
+    const error = new Error({ response: 'optimistic locking with no bound-with titles' });
+    mutateItem.mockClear().mockImplementation(() => Promise.reject(error));
+
+    renderEditItem();
+    ItemForm.mock.calls[0][0].onSubmit({
+      id: 'itemId',
+      permanentLocationId: '',
+      temporaryLocationId: '',
+      // no boundWithTitles
+    });
+
+    await waitFor(() => expect(mutateItem).toHaveBeenCalled());
+  });
 });

--- a/src/Item/EditItem/EditItem.test.js
+++ b/src/Item/EditItem/EditItem.test.js
@@ -1,7 +1,7 @@
 import '../../../test/jest/__mock__';
 
 import { MemoryRouter } from 'react-router-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
 import { instance } from '../../../test/fixtures/instance';
@@ -9,7 +9,7 @@ import {
   useInstanceQuery,
   useHolding,
 } from '../../common/hooks';
-import { useItem, useItemMutation } from '../hooks';
+import { useItem, useItemMutation, useBoundWithsMutation } from '../hooks';
 import EditItem from './EditItem';
 import ItemForm from '../../edit/items/ItemForm';
 
@@ -23,7 +23,12 @@ jest.mock('../../common/hooks', () => ({
 jest.mock('../hooks', () => ({
   ...jest.requireActual('../hooks'),
   useItem: jest.fn().mockReturnValue({ item: {}, isLoading: false }),
-  useItemMutation: jest.fn().mockReturnValue({ mutateItem: jest.fn() }),
+  useItemMutation: jest.fn().mockReturnValue({
+    mutateItem: jest.fn()
+  }),
+  useBoundWithsMutation: jest.fn().mockReturnValue({
+    mutateBoundWiths: jest.fn(() => Promise.resolve({ data: {} }))
+  }),
 }));
 
 const defaultProps = {
@@ -51,7 +56,6 @@ const renderEditItem = (props = {}) => render(
   { wrapper },
 );
 
-
 describe('EditItem', () => {
   const mutateItem = jest.fn(() => Promise.resolve({ data: {} }));
 
@@ -60,6 +64,7 @@ describe('EditItem', () => {
     useHolding.mockClear();
     useItem.mockClear();
     useItemMutation.mockClear().mockReturnValue({ mutateItem });
+    useBoundWithsMutation.mockClear();
   });
 
   it('should render ItemForm', () => {
@@ -85,12 +90,11 @@ describe('EditItem', () => {
     expect(screen.getByText('LoadingView')).toBeInTheDocument();
   });
 
-  it('should handle optimistic locking exception', () => {
+  it('should handle optimistic locking exception', async () => {
     const error = new Error({ response: 'optimistic locking' });
     mutateItem.mockClear().mockImplementation(() => Promise.reject(error));
 
     renderEditItem();
-
     ItemForm.mock.calls[0][0].onSubmit({
       id: 'itemId',
       permanentLocationId: '',
@@ -98,6 +102,6 @@ describe('EditItem', () => {
       boundWithTitles: [],
     });
 
-    expect(mutateItem).toHaveBeenCalled();
+    await waitFor(() => expect(mutateItem).toHaveBeenCalled());
   });
 });

--- a/src/Item/hooks/index.js
+++ b/src/Item/hooks/index.js
@@ -1,2 +1,3 @@
 export { default as useItem } from './useItem';
 export { default as useItemMutation } from './useItemMutation';
+export { default as useBoundWithsMutation } from './useBoundWithsMutation';

--- a/src/Item/hooks/useBoundWithsMutation/index.js
+++ b/src/Item/hooks/useBoundWithsMutation/index.js
@@ -1,0 +1,1 @@
+export { default } from './useBoundWithsMutation';

--- a/src/Item/hooks/useBoundWithsMutation/useBoundWithsMutation.js
+++ b/src/Item/hooks/useBoundWithsMutation/useBoundWithsMutation.js
@@ -1,0 +1,24 @@
+import {
+  useMutation,
+} from 'react-query';
+
+import { useOkapiKy } from '@folio/stripes/core';
+
+const useBoundWithsMutation = (options = {}) => {
+  const ky = useOkapiKy();
+
+  const { mutateAsync } = useMutation({
+    mutationFn: (boundWiths) => {
+      const kyMethod = 'put';
+      const kyPath = 'inventory-storage/bound-withs';
+      return ky[kyMethod](kyPath, { json: boundWiths });
+    },
+    ...options,
+  });
+
+  return {
+    mutateBoundWiths: mutateAsync,
+  };
+};
+
+export default useBoundWithsMutation;

--- a/src/Item/hooks/useBoundWithsMutation/useBoundWithsMutation.test.js
+++ b/src/Item/hooks/useBoundWithsMutation/useBoundWithsMutation.test.js
@@ -1,0 +1,36 @@
+import '../../../../test/jest/__mock__';
+
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useOkapiKy } from '@folio/stripes/core';
+
+import useBoundWithsMutation from './useBoundWithsMutation';
+
+const queryClient = new QueryClient();
+
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+describe('useBoundWithsMutation', () => {
+  it('should make a put request', async () => {
+    const putMock = jest.fn();
+
+    useOkapiKy.mockClear().mockReturnValue({
+      put: putMock,
+    });
+
+    const { result } = renderHook(
+      () => useBoundWithsMutation(),
+      { wrapper },
+    );
+
+    await result.current.mutateBoundWiths();
+
+    expect(putMock).toHaveBeenCalled();
+  });
+});

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -890,6 +890,37 @@ class ItemForm extends React.Component {
                   >
                     <ElectronicAccessFields relationship={electronicAccessRelationships} />
                   </Accordion>
+                  <Accordion
+                    id="acc10"
+                    label={<FormattedMessage id="ui-inventory.boundWithTitles" />}
+                  >
+                    <RepeatableField
+                      name="boundWithTitles"
+                      label={<FormattedMessage id="ui-inventory.boundWithTitles" />}
+                      canAdd={false}
+                      template={[
+                        {
+                          name: 'briefInstance.hrid',
+                          label: <FormattedMessage id="ui-inventory.instanceHrid" />,
+                          component: TextField,
+                          disabled: true,
+                          value: boundWithTitle => boundWithTitle.briefInstance.hrid,
+                        },
+                        {
+                          name: 'briefInstance.title',
+                          label: <FormattedMessage id="ui-inventory.instanceTitleLabel" />,
+                          component: TextField,
+                          disabled: true,
+                        },
+                        {
+                          name: 'briefHoldingsRecord.hrid',
+                          label: <FormattedMessage id="ui-inventory.holdingsHrid" />,
+                          component: TextField,
+                          disabled: true,
+                        },
+                      ]}
+                    />
+                  </Accordion>
                 </AccordionSet>
               </AccordionStatus>
             </Pane>


### PR DESCRIPTION
## Purpose
Delete linked bound-with parts.  Represented in the UI as an edit to the item record.

## Approach
- Utilizes the new [PUT /inventory-storage/bound-withs](https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/p/bound-with-part.html#inventory_storage_bound_withs_put) API to replace the item's entire set of linked bound-with parts.  
- Although that API does both deletes and adds as needed, there's no UI functionality for Add yet so I've disabled the 'add' button.

### TODOS and Open Questions
- If the bound-with API call succeeds but then the Item update call fails, there is no rollback of the BW change.  I'm told there is no transactional behavior in the UI.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [X] There are no breaking changes in this PR.

## Issues
https://issues.folio.org/browse/UIIN-2001