### PR TITLE
UIIN-2320: Wire ErrorModal in cases of HTTP errors during item and holding mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * Bump stripes to `8.0.0` for Orchid/2023-R1. Refs UIIN-2303.
 * Improve the layout of the actions menu on the the item record. Fixes UIIN-2263.
 * Remove extra whitespace when parsing statistical code options. Fixes UIIN-2320.
+* Wire `<ErrorModal>` in cases of http errors during item and holding mutations. Fixes UIIN-2320.
 
 ## [9.2.0](https://github.com/folio-org/ui-inventory/tree/v9.2.0) (2022-10-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.1.0...v9.2.0)

--- a/src/Holding/EditHolding/EditHolding.js
+++ b/src/Holding/EditHolding/EditHolding.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import { cloneDeep } from 'lodash';
 
 import { useStripes } from '@folio/stripes/core';
-import { LoadingView } from '@folio/stripes/components';
+import { LoadingView, ErrorModal } from '@folio/stripes/components';
 
 import {
   useHolding,
@@ -80,20 +80,30 @@ const EditHolding = ({
   if (isInstanceLoading || isItemsLoading || isHoldingLoading) return <LoadingView />;
 
   return (
-    <HoldingsForm
-      httpError={httpError}
-      location={location}
-      initialValues={holding}
-      onSubmit={onSubmit}
-      onCancel={onCancel}
-      okapi={stripes.okapi}
-      instance={instance}
-      referenceTables={referenceTables}
-      stripes={stripes}
-      itemCount={itemCount}
-      goTo={goTo}
-      isMARCRecord={isMARCRecord}
-    />
+    <>
+      <HoldingsForm
+        httpError={httpError}
+        location={location}
+        initialValues={holding}
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+        okapi={stripes.okapi}
+        instance={instance}
+        referenceTables={referenceTables}
+        stripes={stripes}
+        itemCount={itemCount}
+        goTo={goTo}
+        isMARCRecord={isMARCRecord}
+      />
+      {httpError && !httpError?.errorType &&
+        <ErrorModal
+          open
+          label={<FormattedMessage id="ui-inventory.instance.saveError" />}
+          content={httpError?.status ? `${httpError.status}: ${httpError.message}` : httpError.message}
+          onClose={() => setHttpError()}
+        />
+      }
+    </>
   );
 };
 

--- a/src/Item/EditItem/EditItem.js
+++ b/src/Item/EditItem/EditItem.js
@@ -9,6 +9,7 @@ import { FormattedMessage } from 'react-intl';
 import { useStripes } from '@folio/stripes/core';
 import {
   LoadingView,
+  ErrorModal,
 } from '@folio/stripes/components';
 
 import {
@@ -64,7 +65,6 @@ const EditItem = ({
     setHttpError(parsedError);
   };
 
-
   const { mutateItem } = useItemMutation({ onSuccess });
 
   const onSubmit = useCallback((values) => {
@@ -78,21 +78,31 @@ const EditItem = ({
   if (isInstanceLoading || isHoldingLoading || isItemLoading) return <LoadingView />;
 
   return (
-    <ItemForm
-      httpError={httpError}
-      form={`itemform_${holding.id}`}
-      id={holding.id}
-      key={holding.id}
-      initialValues={item}
-      onSubmit={onSubmit}
-      onCancel={onCancel}
-      okapi={stripes.okapi}
-      instance={instance}
-      holdingsRecord={holding}
-      referenceTables={referenceData}
-      intl={stripes.intl}
-      stripes={stripes}
-    />
+    <>
+      <ItemForm
+        httpError={httpError}
+        form={`itemform_${holding.id}`}
+        id={holding.id}
+        key={holding.id}
+        initialValues={item}
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+        okapi={stripes.okapi}
+        instance={instance}
+        holdingsRecord={holding}
+        referenceTables={referenceData}
+        intl={stripes.intl}
+        stripes={stripes}
+      />
+      {httpError && !httpError?.errorType &&
+        <ErrorModal
+          open
+          label={<FormattedMessage id="ui-inventory.instance.saveError" />}
+          content={httpError?.status ? `${httpError.status}: ${httpError.message}` : httpError.message}
+          onClose={() => setHttpError()}
+        />
+      }
+    </>
   );
 };
 

--- a/src/components/TitleField/TitleField.js
+++ b/src/components/TitleField/TitleField.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import {
-  ConnectedTitle,
-  UnconnectedTitle,
-} from '..';
+import ConnectedTitle from '../ConnectedTitle';
+import UnconnectedTitle from '../UnconnectedTitle';
 
 const TitleField = ({ field, index, fields, titleIdKey, isDisabled }) => {
   const {

--- a/src/edit/precedingTitleFields.js
+++ b/src/edit/precedingTitleFields.js
@@ -5,7 +5,7 @@ import { FieldArray } from 'react-final-form-arrays';
 
 import { RepeatableField } from '@folio/stripes/components';
 
-import { TitleField } from '../components';
+import TitleField from '../components/TitleField';
 
 const PrecedingTitles = ({ canAdd, canEdit, canDelete, isDisabled }) => (
   <FieldArray


### PR DESCRIPTION
The HTTP errors were already handled correctly by mutation hooks but they were not rendered on the screen.

This PR is wiring error modal on `EditHolding` and `EditItem` components to make sure that the errors are displayed correctly.

https://issues.folio.org/browse/UIIN-2322

