### PR TITLE
UIIN-2176: Fix search results title color contrast

### DIFF
--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -964,7 +964,7 @@ class InstancesList extends React.Component {
         isWithinScope={checkScope}
         scope={document.body}
       >
-        <div data-test-inventory-instances>
+        <div data-test-inventory-instances className={css.inventoryInstances}>
           <SearchAndSort
             key={searchAndSortKey}
             actionMenu={this.getActionMenu}
@@ -1004,7 +1004,7 @@ class InstancesList extends React.Component {
             customPaneSub={this.renderPaneSub()}
             resultsRowClickHandlers={false}
             resultsFormatter={resultsFormatter}
-            resultsRowFormatter={DefaultMCLRowFormatter}
+            resultRowFormatter={DefaultMCLRowFormatter}
             onCreate={this.onCreate}
             viewRecordPerms="ui-inventory.instance.view"
             newRecordPerms="ui-inventory.instance.create"

--- a/src/components/InstancesList/instances.css
+++ b/src/components/InstancesList/instances.css
@@ -22,3 +22,9 @@
   font-weight: var(--text-weight-bold);
   color: var(--error);
 }
+
+/* A version of these rules are present in TextLink.css, but overridden by MCL.css */
+.inventoryInstances div[class*="Selected"] a:visited {
+  color: var(--link-color-visited-current);
+  text-decoration-color: var(--link-color-visited-current);
+}


### PR DESCRIPTION
## Purpose

After #1962 changed the links on the instances search results from row-level to column-level
(on the title field), there was insufficient color contrast between the title text and background.
This fixes the foreground color to the expected white.

## Approach

First, I fixed a bug in the designated row formatter that I introduced in #1962.
The designation of DefaultMCLRowFormatter
had no effect because the argument name resultRowFormatter was typoed result**s**RowFormatter.
Due to the typo, [anchoredRowFormatter was being used by mistake](https://github.com/folio-org/stripes-smart-components/blob/master/lib/SearchAndSort/SearchAndSort.js#L1230).

Second, the necessary CSS selector from TextLink:
`div[class*=Selected] .root---FBI0e:visited`
was being overridden by CSS from MCL with equal specificity:
`.mclRow---e3WhT.mclSelected---SXZ12 a:visited`

I could not identify how to change the loading order of the two CSS includes, so
I re-overrode the MCL CSS with some custom CSS.

![css-specificity](https://user-images.githubusercontent.com/31278545/219501986-62be5c27-338a-46d1-8bd1-10742a8f15ff.PNG)

Finally I did not update CHANGELOG.md since this Jira is already referenced in the 
latest version.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

## Issues
https://issues.folio.org/browse/UIIN-2176
