### PR TITLE
UIIN-1695 JEST/RTL test cases for succeedingTitleFields

### DIFF
--- a/src/edit/succeedingTitleFields.test.js
+++ b/src/edit/succeedingTitleFields.test.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '../../test/jest/__mock__';
+import stripesFinalForm from '@folio/stripes/final-form';
+import renderWithRouter from '../../test/jest/helpers/renderWithRouter';
+import renderWithIntl from '../../test/jest/helpers/renderWithIntl';
+import SucceedingTitles from './succeedingTitleFields';
+import translationsProperties from '../../test/jest/helpers/translationsProperties';
+
+jest.mock('../components', () => ({
+  TitleField: jest.fn( () => 'mocked TitleField'),
+}));
+
+jest.unmock('@folio/stripes/components');
+
+const onSubmit = jest.fn();
+const Form = ({ handleSubmit }) => (
+  <form onSubmit={handleSubmit}>
+    <SucceedingTitles />
+  </form>
+);
+
+Form.propTypes = {
+  handleSubmit: PropTypes.func.isRequired,
+};
+
+const WrappedForm = stripesFinalForm({
+  navigationCheck: true,
+  enableReinitialize: false,
+})(Form);
+
+const renderSucceedingTitles = () => renderWithIntl(
+  renderWithRouter(<WrappedForm onSubmit={onSubmit} />),
+  translationsProperties,
+);
+
+afterEach(() => jest.clearAllMocks());
+
+describe('SucceedingTitles', () => {
+  test('Add succeeding title should be in the document', () => {
+    const { getByText } = renderSucceedingTitles();
+    expect(getByText('Add succeeding title')).toBeInTheDocument();
+    expect(getByText('Succeeding titles')).toBeInTheDocument();
+    screen.debug();
+  });
+  it('click Add succeeding title button', () => {
+    const { getByText } = renderSucceedingTitles();
+    const succeedingButton = getByText(/Add succeeding title/i);
+    userEvent.click(succeedingButton);
+    expect(getByText(/mocked TitleField/i)).toBeInTheDocument();
+  });
+});

--- a/src/edit/succeedingTitleFields.test.js
+++ b/src/edit/succeedingTitleFields.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '../../test/jest/__mock__';
 import stripesFinalForm from '@folio/stripes/final-form';
@@ -10,7 +9,7 @@ import SucceedingTitles from './succeedingTitleFields';
 import translationsProperties from '../../test/jest/helpers/translationsProperties';
 
 jest.mock('../components', () => ({
-  TitleField: jest.fn( () => 'mocked TitleField'),
+  TitleField: jest.fn(() => 'mocked TitleField'),
 }));
 
 jest.unmock('@folio/stripes/components');
@@ -43,7 +42,6 @@ describe('SucceedingTitles', () => {
     const { getByText } = renderSucceedingTitles();
     expect(getByText('Add succeeding title')).toBeInTheDocument();
     expect(getByText('Succeeding titles')).toBeInTheDocument();
-    screen.debug();
   });
   it('click Add succeeding title button', () => {
     const { getByText } = renderSucceedingTitles();


### PR DESCRIPTION
Refs:
UIIN-1695
succeedingTitleFields
URL: https://issues.folio.org/browse/UIIN-1695