### PR TITLE
UIIN-2187: Do not allow for item removal with associated loan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 9.5.0 IN PROGRESS
 
+* Do not allow for item removal when an item has a loan with a status set to `Declared lost`. Fixes UIIN-2138.
+* Do not allow for item removal when an item has a loan with a status set to `Awaiting delivery`. Fixes UIIN-2187.
+
 ## [9.4.0](https://github.com/folio-org/ui-inventory/tree/v9.4.0) (2023-02-23)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.3.0...v9.4.0)
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,7 @@ const IN_TRANSIT = 'In transit';
 const CHECKED_OUT = 'Checked out';
 const AGED_TO_LOST = 'Aged to lost';
 const CLAIMED_RETURNED = 'Claimed returned';
+const DECLARED_LOST = 'Declared lost';
 
 export const BROWSE_INVENTORY_ROUTE = '/inventory/browse';
 export const INVENTORY_ROUTE = '/inventory';
@@ -27,7 +28,7 @@ export const itemStatusesMap = {
   AWAITING_DELIVERY,
   CHECKED_OUT,
   CLAIMED_RETURNED,
-  DECLARED_LOST: 'Declared lost',
+  DECLARED_LOST,
   IN_PROCESS: 'In process',
   IN_PROCESS_NON_REQUESTABLE: 'In process (non-requestable)',
   IN_TRANSIT,
@@ -69,6 +70,8 @@ export const NOT_REMOVABLE_ITEM_STATUSES = [
   AWAITING_PICKUP,
   AGED_TO_LOST,
   CLAIMED_RETURNED,
+  AWAITING_DELIVERY,
+  DECLARED_LOST,
 ];
 
 export const itemStatuses = [


### PR DESCRIPTION
Do not allow for item removal when an item has a loan with a status set to `Declared lost` or `Awaiting delivery`. 

https://issues.folio.org/browse/UIIN-2187
https://issues.folio.org/browse/UIIN-2138