### PR TITLE
UIIN-2345 The MCL row container width is breaking the horizontal space limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Do not allow for item removal when an item has a loan with a status set to `Declared lost`. Fixes UIIN-2138.
 * Do not allow for item removal when an item has a loan with a status set to `Awaiting delivery`. Fixes UIIN-2187.
+* Fix max width for contributors column in Instances search. Fixes UIIN-2345.
 
 ## [9.4.0](https://github.com/folio-org/ui-inventory/tree/v9.4.0) (2023-02-23)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.3.0...v9.4.0)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -994,6 +994,9 @@ class InstancesList extends React.Component {
               callNumber: '15%',
               subject: '50%',
               contributor: '50%',
+              contributors: {
+                max: '400px',
+              },
               numberOfTitles: '15%',
               select: '30px',
               title: '40%',


### PR DESCRIPTION
## Description
Set max width for `contributors` column in Instances search results list

## Screenshots
![image](https://user-images.githubusercontent.com/19309423/223734458-a74a76fa-8ac7-4908-8a2d-c875d44edfdb.png)

## Issues
[UIIN-2345](https://issues.folio.org/browse/UIIN-2345)