### PR TITLE
UIIN-2342 Browse results are not updated when field with Subject/Contributor value is linked/unlinked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Do not allow for item removal when an item has a loan with a status set to `Awaiting delivery`. Fixes UIIN-2187.
 * Fix max width for contributors column in Instances search. Fixes UIIN-2345.
 * Retain search query, result list and page number after switching between Search and Browse searches. Refs UIIN-2337.
+* Browse results are not updated when field with Subject/Contributor value is linked/unlinked. Fixes UIIN-2342.
 
 ## [9.4.0](https://github.com/folio-org/ui-inventory/tree/v9.4.0) (2023-02-23)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.3.0...v9.4.0)

--- a/src/hooks/useInventoryBrowse/useInventoryBrowse.js
+++ b/src/hooks/useInventoryBrowse/useInventoryBrowse.js
@@ -21,7 +21,6 @@ import {
 } from '../../constants';
 import usePrevious from '../usePrevious';
 import {
-  FIVE_MINUTES,
   INITIAL_SEARCH_PARAMS_MAP,
   INIT_PAGE_CONFIG,
   PAGINATION_SEARCH_PARAMS_MAP,
@@ -116,7 +115,7 @@ const useInventoryBrowse = ({
     }, {
       enabled: Boolean(pageConfig && qindex && hasFilters),
       keepPreviousData: qindex === prevSearchIndex || hasFilters,
-      staleTime: FIVE_MINUTES,
+      staleTime: 0,
       ...options,
     },
   );


### PR DESCRIPTION
## Description
Update browse results when visiting Browse page again

## Approach
Decrease `staleTime` to `0` to instantly invalidate existing data so users can refresh it when they want.

## Screenshots

https://user-images.githubusercontent.com/19309423/224754472-bef66e68-beca-4b37-8e7b-6ffd6ac21e9c.mp4



## Issues
[UIIN-2342](https://issues.folio.org/browse/UIIN-2342)