### PR TITLE
UIIN-2350: Lift the local state from CheckboxFacet into facetsStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 9.5.0 IN PROGRESS
 
-* Lift the local state from `<CheckboxFacet>` into `facetsStore` in zunstand. Fixes UIIN-2350.
+* Lift the local state from `<CheckboxFacet>` into `facetsStore` in zunstand. Fixes UIIN-2350, UIIN-2351.
 
 ## [9.4.1](https://github.com/folio-org/ui-inventory/tree/v9.4.1) (2023-03-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.0...v9.4.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 9.5.0 IN PROGRESS
 
+* Lift the local state from `<CheckboxFacet>` into `facetsStore` in zunstand. Fixes UIIN-2350.
+
 ## [9.4.1](https://github.com/folio-org/ui-inventory/tree/v9.4.1) (2023-03-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.0...v9.4.1)
 

--- a/src/components/CheckboxFacet/CheckboxFacet.js
+++ b/src/components/CheckboxFacet/CheckboxFacet.js
@@ -5,6 +5,7 @@ import CheckboxFacetList from './CheckboxFacetList';
 
 import { accentFold } from '../../utils';
 import { DEFAULT_FILTERS_NUMBER } from '../../constants';
+import { getSearchTerm } from '../../stores/facetsStore';
 
 const SHOW_OPTIONS_COUNT = 5;
 const SHOW_OPTIONS_INCREMENT = 5;
@@ -34,7 +35,6 @@ export default class CheckboxFacet extends React.Component {
 
   state = {
     more: SHOW_OPTIONS_COUNT,
-    searchTerm: '',
     isMoreClicked: false,
   };
 
@@ -72,7 +72,6 @@ export default class CheckboxFacet extends React.Component {
       name,
     } = this.props;
 
-    this.setState({ searchTerm });
     onSearch({ name, value: searchTerm });
   };
 
@@ -109,9 +108,10 @@ export default class CheckboxFacet extends React.Component {
       onFetch,
     } = this.props;
 
+    const searchTerm = getSearchTerm(name);
+
     const {
       more,
-      searchTerm,
     } = this.state;
 
     let filteredOptions = dataOptions;

--- a/src/stores/facetsStore.js
+++ b/src/stores/facetsStore.js
@@ -21,6 +21,11 @@ const facetsStore = create((set) => ({
   resetFacetSettings: () => set({ facetSettings: {} }),
 }));
 
+// selectors
+export const getSearchTerm = (name) => {
+  return facetsStore.getState().facetSettings?.[name]?.value ?? '';
+};
+
 // hooks
 export const useFacetSettings = () => facetsStore(store => [
   store.facetSettings,

--- a/src/stores/facetsStore.test.js
+++ b/src/stores/facetsStore.test.js
@@ -1,4 +1,4 @@
-import facetsStore from './facetsStore';
+import facetsStore, { getSearchTerm } from './facetsStore';
 
 const getFacetSettings = () => facetsStore.getState().facetSettings;
 
@@ -31,6 +31,15 @@ describe('facetsStore', () => {
       resetFacetSettings();
 
       expect(getFacetSettings()).toEqual({});
+    });
+  });
+
+  describe('getSearchTerm', () => {
+    test('getting search term value', () => {
+      const { setFacetSettings } = facetsStore.getState();
+      setFacetSettings('test', { value: 2 });
+
+      expect(getSearchTerm('test')).toEqual(2);
     });
   });
 });


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-2350
https://issues.folio.org/browse/UIIN-2351
https://issues.folio.org/browse/UIIN-2352

The previous implementation stored the `searchTerm` within the local state of the `<CheckboxFacet>` component. When the `Reset all` action was initiated, this local state was not updated, resulting in the facets remaining hidden due to synchronization issues.

This PR addresses the problem by replacing the local state with the global state managed by the `facetsStore` (a zustand store). The store already maintains the `searchTerm` for all facets and is appropriately synchronized with the `Reset all` `button.
