### PR TITLE
UIIN-2355: Use correct reference to item resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 9.5.0 IN PROGRESS
 
 * Lift the local state from `<CheckboxFacet>` into `facetsStore` in zunstand. Fixes UIIN-2350, UIIN-2351.
+* Use correct reference to item resource. Fixes UIIN-2355.
 
 ## [9.4.1](https://github.com/folio-org/ui-inventory/tree/v9.4.1) (2023-03-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.0...v9.4.1)

--- a/src/routes/ItemRoute.js
+++ b/src/routes/ItemRoute.js
@@ -114,7 +114,7 @@ class ItemRoute extends React.Component {
         // Only one service point is of interest here: the SP used for the item's last check-in
         // (if the item has a check-in). Iff that service point ID is found, add a query param
         // to filter down to that one service point in the records returned.
-        const servicePointId = get(props.resources, 'items.records[0].lastCheckIn.servicePointId', '');
+        const servicePointId = get(props.resources, 'itemsResource.records[0].lastCheckIn.servicePointId', '');
         const query = servicePointId && `id==${servicePointId}`;
         return query ? { query } : {};
       },
@@ -125,8 +125,7 @@ class ItemRoute extends React.Component {
       path: 'users',
       records: 'users',
       params: (_q, _p, _r, _l, props) => {
-        const staffMemberId = get(props.resources, 'items.records[0].lastCheckIn.staffMemberId', '');
-
+        const staffMemberId = get(props.resources, 'itemsResource.records[0].lastCheckIn.staffMemberId', '');
         const query = staffMemberId && `id==${staffMemberId}`;
 
         return query ? { query } : null;


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-2355

The item resource was incorrectly referenced causing `staffMembers` resource to not load. 

This PR fixes the name of the resource so the staff member data is fetched correctly.