### PR TITLE
UIIN-2354 Validator Instance/Holdings/Item notes character limit 32K

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * The 'Missing' and 'Withdrawn' options in the actions menu are absent after clicking on the 'Actions' button for item status "In process". Fixes UIIN-2338.
 * Item Create/Edit screens: Replace custom RepeatableField with component from stripes. Refs UIIN-2397.
 * Item Create/Edit screens: Repeatable field trashcan is not aligned with the data row. Fixes UIIN-2374.
+* Instance/Holdings/Item notes, administrative notes character limit to 32K. Refs UIIN-2354.
 
 ## [9.4.5](https://github.com/folio-org/ui-inventory/tree/v9.4.5) (2023-04-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.4...v9.4.5)

--- a/src/edit/administrativeNoteFields.js
+++ b/src/edit/administrativeNoteFields.js
@@ -11,10 +11,16 @@ import {
   TextArea,
 } from '@folio/stripes/components';
 
+import {
+  validateFieldLength
+} from '../utils';
+
 const AdministrativeNoteFields = () => {
   const { formatMessage } = useIntl();
 
   const administrativeNoteLabel = formatMessage({ id: 'ui-inventory.administrativeNote' });
+  const START_WITH_MAX_LENGTH = 32000;
+  const validateStartWithMaxLength = value => validateFieldLength(value, START_WITH_MAX_LENGTH);
 
   const legend = (
     <Label tagName="legend">
@@ -29,6 +35,7 @@ const AdministrativeNoteFields = () => {
       component={TextArea}
       rows={1}
       fullWidth
+      validate={validateStartWithMaxLength}
     />
   );
 

--- a/src/edit/holdings/repeatableFields/NoteFields.js
+++ b/src/edit/holdings/repeatableFields/NoteFields.js
@@ -17,6 +17,10 @@ import {
   TextArea,
 } from '@folio/stripes/components';
 
+import {
+  validateFieldLength
+} from '../../../utils';
+
 const NoteFields = ({
   noteTypeOptions,
   canAdd,
@@ -28,6 +32,9 @@ const NoteFields = ({
   const noteTypeLabel = formatMessage({ id: 'ui-inventory.noteType' });
   const noteLabel = formatMessage({ id: 'ui-inventory.note' });
   const staffOnlyLabel = formatMessage({ id: 'ui-inventory.staffOnly' });
+
+  const START_WITH_MAX_LENGTH = 32000;
+  const validateStartWithMaxLength = value => validateFieldLength(value, START_WITH_MAX_LENGTH);
 
   const headLabels = (
     <Row>
@@ -75,6 +82,7 @@ const NoteFields = ({
           rows={1}
           disabled={!canEdit}
           required
+          validate={validateStartWithMaxLength}
         />
       </Col>
       <Col xs={12} lg={1}>

--- a/src/edit/noteFields.js
+++ b/src/edit/noteFields.js
@@ -17,6 +17,10 @@ import {
   Label,
 } from '@folio/stripes/components';
 
+import {
+  validateFieldLength
+} from '../utils';
+
 const NoteFields = props => {
   const { formatMessage } = useIntl();
 
@@ -37,6 +41,9 @@ const NoteFields = props => {
   const isNoteTypeRequired = requiredFields.some(field => field === noteTypeIdField);
   const isNoteRequired = requiredFields.some(field => field === 'note');
   const isStaffOnlyRequired = requiredFields.some(field => field === 'staffOnly');
+
+  const START_WITH_MAX_LENGTH = 32000;
+  const validateStartWithMaxLength = value => validateFieldLength(value, START_WITH_MAX_LENGTH);
 
   const headLabels = (
     <Row>
@@ -78,6 +85,7 @@ const NoteFields = props => {
           rows={1}
           disabled={!canEdit}
           required={isNoteRequired}
+          validate={validateStartWithMaxLength}
         />
       </Col>
       <Col xs={3} lg={2}>


### PR DESCRIPTION
## Description
Set Validator field Instance/Holdings/Item notes character limit 32K

## Issue
[UIIN-2354](https://issues.folio.org/browse/UIIN-2354)


