### PR TITLE
UIIN-2428: ISRI: Adjust jobProfiles GET request to fetch profiles by ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 * Instance/Holdings/Item notes, administrative notes character limit to 32K. Refs UIIN-2354.
 * Import testing-library deps from `@folio/jest-config-stripes`. Refs UIIN-2427.
 * Bump zustand to v4. Refs UIIN-2353.
+* ISRI: Adjust jobProfiles GET request to fetch profiles by ids. Refs UIIN-2428.
+* Sorting of profiles is not executed in alphabetical order in the Z39.50 target profiles View. Fixes UIIN-2424.
 
 ## [9.4.5](https://github.com/folio-org/ui-inventory/tree/v9.4.5) (2023-04-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.4...v9.4.5)

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,6 +10,7 @@ const DECLARED_LOST = 'Declared lost';
 
 export const BROWSE_INVENTORY_ROUTE = '/inventory/browse';
 export const INVENTORY_ROUTE = '/inventory';
+export const DATA_IMPORT_JOB_PROFILES_ROUTE = 'data-import-profiles/jobProfiles';
 
 export const searchModeSegments = {
   search: 'search',

--- a/src/settings/TargetProfileDetail.js
+++ b/src/settings/TargetProfileDetail.js
@@ -34,7 +34,31 @@ class TargetProfileDetail extends React.Component {
           }).isRequired,
         ),
       }).isRequired,
-      jobProfiles: PropTypes.shape({
+      defaultCreateJobProfile: PropTypes.shape({
+        records: PropTypes.arrayOf(
+          PropTypes.shape({
+            id: PropTypes.string.isRequired,
+            name: PropTypes.string.isRequired,
+          }).isRequired,
+        ),
+      }).isRequired,
+      defaultUpdateJobProfile: PropTypes.shape({
+        records: PropTypes.arrayOf(
+          PropTypes.shape({
+            id: PropTypes.string.isRequired,
+            name: PropTypes.string.isRequired,
+          }).isRequired,
+        ),
+      }).isRequired,
+      allowedCreateJobProfiles: PropTypes.shape({
+        records: PropTypes.arrayOf(
+          PropTypes.shape({
+            id: PropTypes.string.isRequired,
+            name: PropTypes.string.isRequired,
+          }).isRequired,
+        ),
+      }).isRequired,
+      allowedUpdateJobProfiles: PropTypes.shape({
         records: PropTypes.arrayOf(
           PropTypes.shape({
             id: PropTypes.string.isRequired,

--- a/src/settings/TargetProfileDetail.test.js
+++ b/src/settings/TargetProfileDetail.test.js
@@ -17,22 +17,48 @@ const identifierTypeResources = {
     hasLoaded: true,
   },
 };
-const jobProfilesResources = {
+const defaultCreateJobProfileResources = {
+  records: [{
+    id: 'createJobProfileTestId',
+    name: 'create name',
+  }],
+  other: { totalRecords: null },
+  hasLoaded: true,
+};
+const defaultUpdateJobProfileResources = {
+  records: [{
+    id: 'updateJobProfileTestId',
+    name: 'update name',
+  }],
+  other: { totalRecords: null },
+  hasLoaded: true,
+};
+const allowedCreateJobProfilesResources = {
   jobProfiles: {
     records: [{
       id: 'createJobProfileTestId',
       name: 'create name',
-    }, {
+    }],
+    other: { totalRecords: 1 },
+    hasLoaded: true,
+  },
+};
+const allowedUpdateJobProfilesResources = {
+  jobProfiles: {
+    records: [{
       id: 'updateJobProfileTestId',
       name: 'update name',
     }],
-    other: { totalRecords: 2 },
+    other: { totalRecords: 1 },
     hasLoaded: true,
   },
 };
 const resources = {
-  ...identifierTypeResources,
-  ...jobProfilesResources,
+  identifierType: identifierTypeResources.identifierType,
+  defaultCreateJobProfile: defaultCreateJobProfileResources,
+  defaultUpdateJobProfile: defaultUpdateJobProfileResources,
+  allowedCreateJobProfiles: allowedCreateJobProfilesResources.jobProfiles,
+  allowedUpdateJobProfiles: allowedUpdateJobProfilesResources.jobProfiles,
 };
 
 const defaultInitialValues = {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
 -->
On the view screen of Inventory/Z39.50 target profiles, we currently send a GET request to fetch all job profiles and then filter them by ids on UI.
It's needed to adjust a request path to include filtering by ids into `query` param to perform filtering on BE. It also fixes a bug with sorting profiles [UIIN-2424](https://issues.folio.org/browse/UIIN-2424).
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Fetch default profiles from endpoint `data-import-profiles/jobProfiles/{id}`
- Fetch allowed profiles using `query` param
- Update unit tests

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
