### PR TITLE
UIIN-2112: Navigating away and back to item-edit or holdings-edit screen throws NPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Instance/Holdings/Item notes, administrative notes character limit to 32K. Refs UIIN-2354.
 * Import testing-library deps from `@folio/jest-config-stripes`. Refs UIIN-2427.
 * Bump zustand to v4. Refs UIIN-2353.
+* Navigating away and back to item-edit or holdings-edit screen throws NPE. Fixes UIIN-2112.
 
 ## [9.4.5](https://github.com/folio-org/ui-inventory/tree/v9.4.5) (2023-04-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.4...v9.4.5)

--- a/src/edit/electronicAccessFields.js
+++ b/src/edit/electronicAccessFields.js
@@ -145,6 +145,7 @@ ElectronicAccessFields.propTypes = {
 };
 
 ElectronicAccessFields.defaultProps = {
+  relationship: [],
   canAdd: true,
   canEdit: true,
   canDelete: true,

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -201,15 +201,15 @@ class ItemForm extends React.Component {
       httpError,
 
       referenceTables: {
-        locationsById,
-        materialTypes,
+        locationsById = [],
+        materialTypes = [],
         loanTypes = [],
-        itemNoteTypes,
-        electronicAccessRelationships,
-        callNumberTypes,
-        statisticalCodes,
-        statisticalCodeTypes,
-        itemDamagedStatuses,
+        itemNoteTypes = [],
+        electronicAccessRelationships = [],
+        callNumberTypes = [],
+        statisticalCodes = [],
+        statisticalCodeTypes = [],
+        itemDamagedStatuses = [],
       },
       handleSubmit,
       pristine,
@@ -217,7 +217,7 @@ class ItemForm extends React.Component {
       history,
     } = this.props;
 
-    const holdingLocation = locationsById[holdingsRecord.permanentLocationId];
+    const holdingLocation = locationsById[holdingsRecord?.permanentLocationId];
     const item = initialValues;
 
     const refLookup = (referenceTable, id) => {

--- a/src/routes/CreateHoldingRoute.js
+++ b/src/routes/CreateHoldingRoute.js
@@ -10,7 +10,7 @@ const CreateHoldingRoute = ({ match }) => {
 
   return (
     <CreateHolding
-      referenceData={referenceData}
+      referenceData={referenceData || {}}
       instanceId={match.params.id}
     />
   );

--- a/src/routes/CreateItemRoute.js
+++ b/src/routes/CreateItemRoute.js
@@ -10,7 +10,7 @@ const CreateItemRoute = () => {
 
   return (
     <CreateItem
-      referenceData={referenceData}
+      referenceData={referenceData || {}}
       instanceId={id}
       holdingId={holdingId}
     />

--- a/src/routes/DuplicateHoldingRoute.js
+++ b/src/routes/DuplicateHoldingRoute.js
@@ -10,7 +10,7 @@ const DuplicateHoldingRoute = () => {
 
   return (
     <DuplicateHolding
-      referenceTables={referenceTables}
+      referenceTables={referenceTables || {}}
       instanceId={instanceId}
       holdingId={holdingId}
     />

--- a/src/routes/DuplicateItemRoute.js
+++ b/src/routes/DuplicateItemRoute.js
@@ -10,7 +10,7 @@ const DuplicateItemRoute = () => {
 
   return (
     <DuplicateItem
-      referenceData={referenceData}
+      referenceData={referenceData || {}}
       instanceId={id}
       holdingId={holdingsrecordid}
       itemId={itemid}

--- a/src/routes/EditHoldingRoute.js
+++ b/src/routes/EditHoldingRoute.js
@@ -10,7 +10,7 @@ const EditHoldingRoute = () => {
 
   return (
     <EditHolding
-      referenceTables={referenceTables}
+      referenceTables={referenceTables || {}}
       instanceId={instanceId}
       holdingId={holdingId}
     />

--- a/src/routes/EditItemRoute.js
+++ b/src/routes/EditItemRoute.js
@@ -10,7 +10,7 @@ const EditItemRoute = () => {
 
   return (
     <EditItem
-      referenceData={referenceData}
+      referenceData={referenceData || {}}
       instanceId={id}
       holdingId={holdingId}
       itemId={itemId}


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
 -->
Navigating away and back to an open item-edit or holdings-record-edit pane causes an NPE. Reloading resolves the issue.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Add default values for undefined Objects and Arrays

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
