### PR TITLE
UIIN-2434 Don't reset browse query when on Browse route and click Browse segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Instance/Holdings/Item notes, administrative notes character limit to 32K. Refs UIIN-2354.
 * Import testing-library deps from `@folio/jest-config-stripes`. Refs UIIN-2427.
 * Bump zustand to v4. Refs UIIN-2353.
+* Don't reset browse query when on Browse route and click Browse segment. Fixes UIIN-2434.
 
 ## [9.4.5](https://github.com/folio-org/ui-inventory/tree/v9.4.5) (2023-04-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.4...v9.4.5)

--- a/src/components/SearchModeNavigation/SearchModeNavigation.js
+++ b/src/components/SearchModeNavigation/SearchModeNavigation.js
@@ -1,7 +1,10 @@
 import PropTypes from 'prop-types';
 import { useCallback } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { useRouteMatch } from 'react-router-dom';
+import {
+  useRouteMatch,
+  useLocation,
+} from 'react-router-dom';
 
 import {
   Button,
@@ -15,6 +18,7 @@ import {
 
 const SearchModeNavigation = ({ search, state }) => {
   const { path } = useRouteMatch();
+  const { search: currentSearch } = useLocation();
 
   const checkIsButtonActive = useCallback((segment) => (
     path === searchModeRoutesMap[segment] ? 'primary' : 'default'
@@ -24,14 +28,14 @@ const SearchModeNavigation = ({ search, state }) => {
     <ButtonGroup fullWidth>
       {
         Object.keys(searchModeSegments).map(segment => {
-          const isCurrentSegment = path === searchModeSegments[segment];
+          const isCurrentSegment = path === searchModeRoutesMap[segment];
 
           return (
             <Button
               key={`${segment}`}
               to={{
                 pathname: searchModeRoutesMap[segment],
-                search: isCurrentSegment ? null : search,
+                search: isCurrentSegment ? currentSearch : search,
                 state,
               }}
               buttonStyle={checkIsButtonActive(segment)}

--- a/src/components/SearchModeNavigation/SearchModeNavigation.test.js
+++ b/src/components/SearchModeNavigation/SearchModeNavigation.test.js
@@ -9,8 +9,8 @@ import {
 } from '../../../test/jest/helpers';
 import SearchModeNavigation from './SearchModeNavigation';
 
-const renderSearchModeNavigation = (props = {}) => renderWithIntl(
-  <MemoryRouter>
+const renderSearchModeNavigation = (props = {}, initialRoute = '/inventory/browse') => renderWithIntl(
+  <MemoryRouter initialEntries={[initialRoute]}>
     <SearchModeNavigation
       {...props}
     />
@@ -24,5 +24,15 @@ describe('SearchModeNavigation', () => {
 
     expect(screen.getByText('Search')).toBeInTheDocument();
     expect(screen.getByText('Browse')).toBeInTheDocument();
+  });
+
+  describe('when current segment is browse', () => {
+    it('should keep browse query in url in browse button', () => {
+      renderSearchModeNavigation();
+
+      const browseButton = screen.findByRole('button', { name: 'Browse' });
+
+      expect(browseButton.href).toEqual('');
+    });
   });
 });


### PR DESCRIPTION
## Description
Change `to` of a segment switch button to keep current search when clicking on current segment

## Screenshots

https://github.com/folio-org/ui-inventory/assets/19309423/4854471e-f814-4519-a74f-3ee8ce42d206


## Issues
[UIIN-2434](https://issues.folio.org/browse/UIIN-2434)