### PR TITLE
UIIN-2443: Rename hrid qindex for item to avoid collisions with holdings ans instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@
 * Moved the print button from QuickMarkView, into the ViewSource. Due to the folio-org/ui-quick-marc#468. Refs UIIN-2324.
 * Change title for the print popup. Refs UIIN-2329.
 * Move @testing-library/* to dev-deps. Refs UIIN-2309.
+* Rename `hrid` qindex for item to avoid collisions with holdings and instances. Fixes UIIN-2443.
 
 ## [9.2.0](https://github.com/folio-org/ui-inventory/tree/v9.2.0) (2022-10-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.1.0...v9.2.0)

--- a/src/constants.js
+++ b/src/constants.js
@@ -434,6 +434,6 @@ export const SINGLE_ITEM_QUERY_TEMPLATES = {
   'items.barcode': 'barcode==%{query}',
   isbn: 'isbn==%{query}',
   issn: 'issn==%{query}',
-  hrid: 'hrid==%{query}',
+  itemHrid: 'hrid==%{query}',
   iid: 'id==%{query}',
 };

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -248,7 +248,7 @@ export const itemIndexes = [
   { label: 'ui-inventory.search.itemNotes', value: 'holdingsNotes', queryTemplate: 'item.notes.note all "%{query.query}" or item.administrativeNotes all "%{query.query}"' },
   { label: 'ui-inventory.search.itemAdministrativeNotes', value: 'itemAdministrativeNotes', queryTemplate: 'item.administrativeNotes all "%{query.query}"' },
   { label: 'ui-inventory.search.itemCirculationNotes', value: 'itemCirculationNotes', queryTemplate: 'item.circulationNotes.note all "%{query.query}"' },
-  { label: 'ui-inventory.itemHrid', value: 'hrid', queryTemplate: 'items.hrid=="%{query.query}"' },
+  { label: 'ui-inventory.itemHrid', value: 'itemHrid', queryTemplate: 'items.hrid=="%{query.query}"' },
   { label: 'ui-inventory.search.item.uuid', value: 'iid', queryTemplate: 'item.id=="%{query.query}"' },
   { label: 'ui-inventory.search.allFields', value: 'allFields', queryTemplate: 'cql.all all "%{query.query}"' },
   { label: 'ui-inventory.querySearch', value: 'querySearch', queryTemplate: '%{query.query}' },


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-2443

The issue here was related to the work done in: https://issues.folio.org/browse/UIIN-2036.

In UIIN-2036 the idea was to be able to automatically open an item details view if the search was performed on one of these indexes:

````js
  'items.barcode': 'barcode==%{query}',
  isbn: 'isbn==%{query}',
  issn: 'issn==%{query}',
  hrid: 'hrid==%{query}',
  iid: 'id==%{query}'
````

and the returned instance had a single item attached to it.

The problem with that approach is that the `hrid` index name has been the same for instances, holdings and items. 
If somebody searched for holdings record hrid there was no way to detect it and the code alway assumed that the search for item hrid was performed causing to open the item details screen (even though the intention was to search for the holdings record).

This PR renames the hrid index for the item so it's clear that somebody is searching by item hrid (and not instance or holdings record).


