### PR TITLE
UIIN-2445: Escape quotes to search for Subject and Contributor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Prevent double-escaping of query when Browsing. Fixes UIIN-2435.
 * When adding items, cursor is in the barcode field as default. Refs UIIN-2205.
 * Quick export from instance detail view. Refs UIIN-2430.
+* Escape quotes to search for Subjects and Contributor. Refs UIIN-2445.
 
 ## [9.4.5](https://github.com/folio-org/ui-inventory/tree/v9.4.5) (2023-04-03)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.4...v9.4.5)

--- a/src/Instance/InstanceMovement/InstanceMovementDetails/InstanceMovementDetails.test.js
+++ b/src/Instance/InstanceMovement/InstanceMovementDetails/InstanceMovementDetails.test.js
@@ -73,7 +73,7 @@ describe('InstanceMovementDetails', () => {
   });
   it('render Action Menu', () => {
     renderInstanceMovementDetails();
-    const actionMenu = screen.getByText(/Action Menu/i)
+    const actionMenu = screen.getByText(/Action Menu/i);
     expect(actionMenu).toBeInTheDocument();
   });
   it('render HoldingsListContainer', () => {

--- a/src/components/BrowseResultsList/utils.js
+++ b/src/components/BrowseResultsList/utils.js
@@ -28,7 +28,7 @@ export const getSearchParams = (row, qindex) => {
     [browseModeOptions.SUBJECTS]: {
       qindex: queryIndexes.SUBJECT,
       query: row.value,
-      authorityId: row.authorityId,
+      ...(row.authorityId && { filters: `${FACETS.AUTHORITY_ID}.${row.authorityId}` }),
     },
   };
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -250,6 +250,7 @@ export const FACETS = {
   NAME_TYPE: 'nameType',
   SEARCH_CONTRIBUTORS: 'searchContributors',
   HOLDINGS_TYPE: 'holdingsType',
+  AUTHORITY_ID: 'authorityId',
 };
 
 export const FACETS_CQL = {
@@ -284,6 +285,7 @@ export const FACETS_CQL = {
   NAME_TYPE: 'contributorNameTypeId',
   SEARCH_CONTRIBUTORS: 'contributors.contributorNameTypeId',
   HOLDINGS_TYPE: 'holdings.holdingsTypeId',
+  AUTHORITY_ID: 'authorityId',
 };
 
 export const FACETS_TO_REQUEST = {

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -106,6 +106,11 @@ export const instanceFilterConfig = [
     cql: FACETS_CQL.SEARCH_CONTRIBUTORS,
     values: [],
   },
+  {
+    name: FACETS.AUTHORITY_ID,
+    cql: FACETS_CQL.AUTHORITY_ID,
+    values: [],
+  },
 ];
 
 export const instanceIndexes = [
@@ -122,7 +127,7 @@ export const instanceIndexes = [
   { label: 'ui-inventory.search.oclc', value: 'oclc', queryTemplate: 'oclc="%{query.query}"' },
   { label: 'ui-inventory.search.instanceNotes', value: 'instanceNotes', queryTemplate: 'notes.note all "%{query.query}" or administrativeNotes all "%{query.query}"' },
   { label: 'ui-inventory.search.instanceAdministrativeNotes', value: 'instanceAdministrativeNotes', queryTemplate: 'administrativeNotes all "%{query.query}"' },
-  { label: 'ui-inventory.subject', value: 'subject', queryTemplate: ({ query, authorityId }) => `subjects.value==/string "${query}"${authorityId ? ` and authorityId=="${authorityId}"` : ''}` },
+  { label: 'ui-inventory.subject', value: 'subject', queryTemplate: 'subjects.value==/string "%{query.query}"' },
   { label: 'ui-inventory.effectiveCallNumberShelving', value: 'callNumber', queryTemplate: 'itemEffectiveShelvingOrder==/string "%{query.query}"' },
   { label: 'ui-inventory.instanceHrid', value: 'hrid', queryTemplate: 'hrid=="%{query.query}"' },
   { label: 'ui-inventory.instanceId', value: 'id', queryTemplate: 'id="%{query.query}"' },

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -19,7 +19,6 @@ const INITIAL_RESULT_COUNT = 100;
 const DEFAULT_SORT = 'title';
 
 const getQueryTemplateContributor = (queryValue) => `contributors.name==/string "${queryValue}"`;
-const getQueryTemplateSubjects = (queryValue, andAuthorityId) => `subjects.value==/string "${queryValue}"${andAuthorityId}`;
 const getQueryTemplateCallNumber = (queryValue) => `itemEffectiveShelvingOrder==/string "${queryValue}"`;
 
 export function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
@@ -27,23 +26,17 @@ export function buildQuery(queryParams, pathComponents, resourceData, logger, pr
   const query = { ...resourceData.query };
   const queryIndex = queryParams?.qindex ?? 'all';
   const queryValue = get(queryParams, 'query', '');
-  const authorityId = queryParams?.authorityId;
   let queryTemplate = getQueryTemplate(queryIndex, indexes);
 
   if (queryParams?.selectedBrowseResult) {
-    if (queryIndex === queryIndexes.SUBJECT) {
-      const queryVal = queryValue.replace(/"/g, '\\"');
-      const andAuthorityId = authorityId ? ` and authorityId==${authorityId}` : '';
-
-      queryTemplate = getQueryTemplateSubjects(queryVal, andAuthorityId);
-    }
-
     if (queryIndex === queryIndexes.CALL_NUMBER) {
       queryTemplate = getQueryTemplateCallNumber(queryValue);
     }
 
     if (queryIndex === queryIndexes.CONTRIBUTOR) {
-      queryTemplate = getQueryTemplateContributor(queryValue);
+      const escapedQueryValue = queryValue.replaceAll('"', '\\"');
+
+      queryTemplate = getQueryTemplateContributor(escapedQueryValue);
     }
 
     query.selectedBrowseResult = null; // reset this parameter so the next search uses `=` instead of `==/string`
@@ -174,7 +167,6 @@ export function buildManifestObject() {
         filters: '',
         sort: '',
         selectedBrowseResult: false,
-        authorityId: '',
       },
     },
     resultCount: { initialValue: INITIAL_RESULT_COUNT },

--- a/test/jest/helpers/Harness.js
+++ b/test/jest/helpers/Harness.js
@@ -48,15 +48,6 @@ Harness.propTypes = {
       translations: PropTypes.object,
     })
   ),
-  shouldMockOffsetSize: PropTypes.bool,
-  width: PropTypes.number,
-  height: PropTypes.number,
-};
-
-Harness.defaultProps = {
-  width: 500,
-  height: 500,
-  shouldMockOffsetSize: true,
 };
 
 export default Harness;


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Escape quotes to search for `Subject` and `Contributor`.

## Description
- escaped query to search for `Contributor`;
- search by subjects has the same `queryTemplate` for both `Search` and `Browse` lookups, so I removed the redundant.
- changed the `Subjects` `queryTemplate` to get `authorityId` via `filters` parameter to utilize already existing query escaping in `makeQueryFunction`. 
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
 -->

## Issues
[UIIN-2445](https://issues.folio.org/browse/UIIN-2445)

## Screencast


https://github.com/folio-org/ui-inventory/assets/77053927/4d8d4307-9d94-4f29-99f3-d1db9ea86f61




## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
