### PR TITLE
UIIN-2478: Fix useBoundWithHoldings for 100+ items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Adjust the Instance Edit screen header. Refs UIIN-2437.
 * Inventory: Retain Search/Browse query/options/filter and facet selections UNLESS user resets/clear selections. Refs UIIN-2433.
 * Statistical Code dropdown "contains" type ahead functionality needed (Instance/Holdings/Items). Refs UIIN-2466.
+* Fix problem with a large number of items on a single holdings record. Refs UIIN-2478.
 
 ## [9.4.7](https://github.com/folio-org/ui-inventory/tree/v9.4.7) (2023-06-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.6...v9.4.7)

--- a/src/hooks/useChunkedCQLFetch.js
+++ b/src/hooks/useChunkedCQLFetch.js
@@ -1,0 +1,84 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useQueries } from 'react-query';
+
+import { chunk } from 'lodash';
+
+import { useOkapiKy } from '@folio/stripes/core';
+
+// When fetching from a potentially large list of items,
+// make sure to chunk the request to avoid hitting limits.
+const useChunkedCQLFetch = ({
+  endpoint, // endpoint to hit to fetch items
+  ids, // List of ids to fetch
+  reduceFunction // Function to reduce fetched objects at the end into single array
+}) => {
+  const ky = useOkapiKy();
+
+  const CONCURRENT_REQUESTS = 5; // Number of requests to make concurrently
+  const STEP_SIZE = 60; // Number of ids to request for per concurrent request
+
+  const chunkedItems = chunk(ids, STEP_SIZE);
+  // chunkedItems will be an array of arrays of size CONCURRENT_REQUESTS * STEP_SIZE
+  // We need to parallelise CONCURRENT_REQUESTS at a time,
+  // and ensure we only fire the next lot once the previous lot are through
+
+  const [isLoading, setIsLoading] = useState(ids?.length > 0);
+
+  // Set up query array, and only enable the first CONCURRENT_REQUESTS requests
+  const getQueryArray = useCallback(() => {
+    const queryArray = [];
+    chunkedItems.forEach((chunkedItem, chunkedItemIndex) => {
+      const query = chunkedItem.map(item => `id==${item}`).join(' or ');
+      queryArray.push({
+        queryKey: ['ERM', endpoint, chunkedItem],
+        queryFn: () => ky.get(`${endpoint}?limit=1000&query=${query}`).json(),
+        // Only enable once the previous slice has all been fetched
+        enabled: chunkedItemIndex < CONCURRENT_REQUESTS
+      });
+    });
+
+    return queryArray;
+  }, [chunkedItems, endpoint, ky]);
+
+  const itemQueries = useQueries(getQueryArray());
+
+  // Once chunk has finished fetching, fetch next chunk
+  useEffect(() => {
+    const chunkedQuery = chunk(itemQueries, CONCURRENT_REQUESTS);
+    chunkedQuery.forEach((q, i) => {
+      // Check that all previous chunk are fetched,
+      // and that all of our current chunk are not fetched and not loading
+      if (
+        i !== 0 &&
+        chunkedQuery[i - 1]?.every(pq => pq.isFetched === true) &&
+        q.every(req => req.isFetched === false) &&
+        q.every(req => req.isLoading === false)
+      ) {
+        // Trigger fetch for each request in the chunk
+        q.forEach(req => {
+          req.refetch();
+        });
+      }
+    });
+  }, [itemQueries]);
+
+  // Keep easy track of whether this hook is all loaded or not
+  // (This slightly flattens the "isLoading/isFetched" distinction, but it's an ease of use prop)
+  useEffect(() => {
+    const newLoading = ids?.length > 0 && (!itemQueries?.length || itemQueries?.some(uq => !uq.isFetched));
+
+    if (isLoading !== newLoading) {
+      setIsLoading(newLoading);
+    }
+  }, [isLoading, itemQueries, ids?.length]);
+
+
+  return {
+    itemQueries,
+    isLoading,
+    // Offer all fetched orderLines in flattened array once ready
+    items: isLoading ? [] : reduceFunction(itemQueries)
+  };
+};
+
+export default useChunkedCQLFetch;


### PR DESCRIPTION
## Purpose
useBoundWithHoldings calls GET holdings-storage/holdings with a query of a list of holdings UUIDs combined with 'or'.  This works but fails when the number of holdings UUIDs causes the URL to exceed the length limit. 

## Approach
There are several CQL "chunking" solutions via react-query useQuer**ies**()  across the UI modules:
https://github.com/search?q=org%3Afolio-org%20useQueries&type=code

The most recent, easiest to use, and (looks to me) most robust is in stripes-erm-components:
https://github.com/folio-org/stripes-erm-components/blob/master/lib/hooks/useChunkedCQLFetch.js

ui-inventory currently doesn't appear to use stripes-erm-components (not surprising, it's not part of ERM).  Since I'm solving this as part of a potential release patch, I didn't want to add a new dependency, so I've temporarily COPIED THE FILE WHOLE into ui-inventory.  I would suggest "promoting"? the hook from stripes-erm-components into stripes-components and then importing it from there.

#### TODOS and Open Questions
- [ ] Remove the copied useChunkedCQLFetch.js, import from somewhere.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [X] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [X] There are no breaking changes in this PR.

## Issue
https://issues.folio.org/browse/UIIN-2478

