### PR TITLE
UIIN-2478 De-dup holdingsRecordIds fetched

### DIFF
--- a/src/Holding/ViewHolding/HoldingBoundWith/useBoundWithHoldings.js
+++ b/src/Holding/ViewHolding/HoldingBoundWith/useBoundWithHoldings.js
@@ -1,7 +1,10 @@
 import useChunkedCQLFetch from '../../../hooks/useChunkedCQLFetch';
 
 const useBoundWithHoldings = (boundWithItems) => {
-  const holdingsRecordIds = boundWithItems?.map(x => x.holdingsRecordId);
+  let holdingsRecordIds = boundWithItems?.map(x => x.holdingsRecordId);
+
+  // De-dup the list of holdingsRecordIds for efficiency
+  holdingsRecordIds = [...new Set(holdingsRecordIds)];
 
   const { items: holdingsRecords, isLoading } = useChunkedCQLFetch({
     ids: holdingsRecordIds,


### PR DESCRIPTION
## Purpose
useBoundWithHoldings.js queries for a list of holdingsRecords by UUID.
It fails (sometimes) when the number of UUIDs is larger than 300, due to
something in the chunking logic in useChunkedCQLFetch().  Specifically
it appears to fail when the number of concurrent requests (5) and the
number of records fetched in each request (60) is not enough to retrieve
all the ids in a single batch of requests (60 * 5).  The final batch of records
(max length 60) does not succeed.  I haven't yet figured out why.

This patch mitigates the problem rather than solving it.

## Approach
This patch de-dupes the list of holdingsRecord UUIDs.  This should have
been done anyway.  Since this hook is used to retrieve the holdings records
for all of the items directly or bound-with to each holdings record, it will
now only fail if there are actually 300+ unique holdings records across
those items.  Which would be a crazy bound-with.  No normal holdings
record with any number of items at all should now fail in this class.
I have tested with 500+.

I will keep looking for what's wrong with with the underlying fetch, but
this should solve the issue on a practical level.

#### TODOS and Open Questions
- [ ] Solve the underlying issue if there ever are more than 300 unique UUIDs.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [X] There are no breaking changes in this PR.

## Issue
https://issues.folio.org/browse/UIIN-2478
