### PR TITLE
UIIN-2517: Add 'Shared' search parameter when the user is redirected to the quick-marc page to identify shared record.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * User with limited permissions gets an error modal when navigating to the Inventory app. Fixes UIIN-2490.
 * *BREAKING* Bump `react` to `v18`. Refs UIIN-2508.
 * Add `Shared` facet to Instance/Holdings/Items search. Refs UIIN-2393.
+* Add `Shared` search parameter when the user is redirected to the quick-marc page to identify shared record. Refs UIIN-2517.
 
 ## [9.4.10](https://github.com/folio-org/ui-inventory/tree/v9.4.10) (2023-07-28)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.9...v9.4.10)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -32,6 +32,7 @@ import withLocation from './withLocation';
 import InstancePlugin from './components/InstancePlugin';
 import { getPublishingInfo } from './Instance/InstanceDetails/utils';
 import {
+  checkIfSharedInstance,
   getDate,
   handleKeyCommand,
   isMARCSource,
@@ -291,10 +292,12 @@ class ViewInstance extends React.Component {
 
     const ci = makeConnectedInstance(this.props, stripes.logger);
     const instance = ci.instance();
+    const isSharedInstance = checkIfSharedInstance(stripes, instance);
 
     const searchParams = new URLSearchParams(location.search);
 
     searchParams.delete('relatedRecordVersion');
+    searchParams.append('shared', isSharedInstance.toString());
 
     history.push({
       pathname: `/inventory/quick-marc/${page}/${instance.id}`,

--- a/src/routes/QuickMarcRoute.js
+++ b/src/routes/QuickMarcRoute.js
@@ -8,6 +8,7 @@ const QuickMarcRoute = ({ match, history, location }) => {
   const onClose = useCallback((recordRoute) => {
     const newSearchParams = new URLSearchParams(location.search);
     newSearchParams.delete('relatedRecordVersion');
+    newSearchParams.delete('shared');
 
     history.push({
       pathname: `/inventory/view/${recordRoute ?? ''}`,

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,6 +21,7 @@ import {
 } from 'lodash';
 import moment from 'moment';
 
+import { checkIfUserInCentralTenant } from '@folio/stripes/core';
 import { FormattedUTCDate } from '@folio/stripes/components';
 
 import {
@@ -777,4 +778,8 @@ export const buildSingleItemQuery = (qindex, query) => {
 
 export const isMARCSource = (source) => {
   return ['MARC', `${CONSORTIUM_PREFIX}MARC`].includes(source);
+};
+
+export const checkIfSharedInstance = (stripes, instance) => {
+  return instance.source?.includes(CONSORTIUM_PREFIX) || checkIfUserInCentralTenant(stripes);
 };

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -7,6 +7,7 @@ import {
   validateNumericField,
   validateAlphaNumericField,
   getQueryTemplate,
+  checkIfSharedInstance,
 } from './utils';
 import { browseModeOptions } from './constants';
 
@@ -143,3 +144,36 @@ describe('getQueryTemplate', () => {
     });
   });
 });
+
+describe('checkIfSharedInstance', () => {
+  describe('when source contains the `CONSORTIUM-` prefix', () => {
+    it('should return true', () => {
+      const instance = { source: 'CONSORTIUM-FOLIO' };
+      const stripes = {};
+
+      expect(checkIfSharedInstance(stripes, instance)).toBeTruthy();
+    });
+  });
+
+  describe('when the user is in the central tenant', () => {
+    it('should return true', () => {
+      const instance = { source: 'FOLIO' };
+      const stripes = {
+        hasInterface: () => true,
+        okapi: {
+          tenant: 'consortia',
+        },
+        user: {
+          user: {
+            consortium: {
+              centralTenantId: 'consortia',
+            },
+          },
+        },
+      };
+
+      expect(checkIfSharedInstance(stripes, instance)).toBeTruthy();
+    });
+  });
+});
+


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Add `Shared` search parameter when the user is redirected to the quick-marc page to identify shared record.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
 -->

## Issues
[UIIN-2517](https://issues.folio.org/browse/UIIN-2517)

## Related PRs
https://github.com/folio-org/ui-quick-marc/pull/570

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
