### PR TITLE
UIIN-2442 Clear lastOpenRecord when closing an Instance record

### DIFF
--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -220,10 +220,13 @@ class InstancesList extends React.Component {
       this.setSegmentSortBy(sortBy);
     }
 
-    const id = this.props.location.pathname.split('/')[3];
+    const prevId = this.getInstanceIdFromLocation(prevProps.location);
+    const id = this.getInstanceIdFromLocation(this.props.location);
 
     if (id) {
       setItem(`${this.props.namespace}.${this.props.segment}.lastOpenRecord`, id);
+    } else if (prevId) {
+      setItem(`${this.props.namespace}.${this.props.segment}.lastOpenRecord`, null);
     }
   }
 
@@ -247,6 +250,10 @@ class InstancesList extends React.Component {
 
     return stripes.okapi.tenant === stripes.user.user.consortium?.centralTenantId;
   }
+
+  getInstanceIdFromLocation = (location) => {
+    return location.pathname.split('/')[3];
+  };
 
   clearStorage = () => {
     const {

--- a/src/edit/holdings/RemoteStorageWarning.test.js
+++ b/src/edit/holdings/RemoteStorageWarning.test.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Form } from 'react-final-form';
-import { screen } from '@folio/jest-config-stripes/testing-library/react';
-import { cleanup } from '@folio/jest-config-stripes/testing-library/react-hooks';
+import {
+  screen,
+  cleanup,
+} from '@folio/jest-config-stripes/testing-library/react';
 import '../../../test/jest/__mock__';
 import { renderWithIntl, translationsProperties } from '../../../test/jest/helpers';
 import { RemoteStorageWarning } from './RemoteStorageWarning';

--- a/src/edit/items/RemoteStorageWarning.test.js
+++ b/src/edit/items/RemoteStorageWarning.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Form } from 'react-final-form';
-import { cleanup } from '@folio/jest-config-stripes/testing-library/react-hooks';
+
+import { cleanup } from '@folio/jest-config-stripes/testing-library/react';
+
 import '../../../test/jest/__mock__';
 import { renderWithIntl, translationsProperties } from '../../../test/jest/helpers';
 import { RemoteStorageWarning } from './RemoteStorageWarning';


### PR DESCRIPTION
## Description
When closing an Instance record we need to clear `lastOpenRecord` from storage

## Issues
[UIIN-2442](https://issues.folio.org/browse/UIIN-2442)