### PR TITLE
UIIN-2439: Inventory 2nd pane Actions menu: Adjust New action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * *BREAKING* Bump `react` to `v18`. Refs UIIN-2508.
 * Add `Shared` facet to Instance/Holdings/Items search. Refs UIIN-2393.
 * Add `Shared` search parameter when the user is redirected to the quick-marc page to identify shared record. Refs UIIN-2517.
+* Inventory 2nd pane Actions menu: Adjust New action. Refs UIIN-2439.
 
 ## [9.4.11](https://github.com/folio-org/ui-inventory/tree/v9.4.11) (2023-08-02)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.10...v9.4.11)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -57,6 +57,7 @@ import {
   isTestEnv,
   handleKeyCommand,
   buildSingleItemQuery,
+  isUserInConsortiumMode,
 } from '../../utils';
 import {
   INSTANCES_ID_REPORT_TIMEOUT,
@@ -736,18 +737,14 @@ class InstancesList extends React.Component {
       <>
         <MenuSection label={intl.formatMessage({ id: 'ui-inventory.actions' })} id="actions-menu-section">
           <IfPermission perm="ui-inventory.instance.create">
-            <Button
-              buttonStyle="dropdownItem"
-              id="clickable-newinventory"
-              onClick={buildOnClickHandler(this.openCreateInstance)}
-            >
-              <Icon
-                icon="plus-sign"
-                size="medium"
-                iconClassName={css.actionIcon}
-              />
-              <FormattedMessage id="stripes-smart-components.new" />
-            </Button>
+            {this.getActionItem({
+              id: 'clickable-newinventory',
+              icon: checkIfUserInCentralTenant(stripes) ? 'graph' : 'plus-sign',
+              messageId: !isUserInConsortiumMode(stripes)
+                ? 'stripes-smart-components.new'
+                : (checkIfUserInCentralTenant(stripes) ? 'ui-inventory.newSharedRecord' : 'ui-inventory.newLocalRecord'),
+              onClickHandler: buildOnClickHandler(this.openCreateInstance),
+            })}
           </IfPermission>
           {!checkIfUserInCentralTenant(stripes) && (
             <Pluggable

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -512,6 +512,8 @@
   "fastAdd": "Fast add",
   "newMARCRecord": "New MARC Bib Record",
   "newFastAddRecord": "New Fast Add Record",
+  "newLocalRecord": "New local record",
+  "newSharedRecord": "New shared record",
   "location.confirm.confirmBtn": "Yes",
   "location.confirm.common.header": "Attention!",
   "location.confirm.inactive.header": "Inactive location",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
 -->
In a consortium environment, Instance records may be shared amongst the member institutions or restricted to a single member tenant. When creating new Instances, FOLIO needs to distinguish whether a new instance is being created as Local or Shared.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Display `New local record` for Member library tenant 
- Display `New shared record` for Central tenant 
- Display `New` for non-consortial tenant [no change]
- Refactor unit tests for InstancesList component and add new ones

## Screenshots
![image](https://github.com/folio-org/ui-inventory/assets/55138456/f7989ea8-b147-43de-b1b1-16038f5aef55)
![image](https://github.com/folio-org/ui-inventory/assets/55138456/67bb44b9-19e7-4565-b528-e43704efcc93)
![image](https://github.com/folio-org/ui-inventory/assets/55138456/ce0e2339-694f-492b-a437-baec6b3738df)
