### PR TITLE
Adjust PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -16,9 +16,6 @@
   hold yourself to should be "can a developer parachuting into this
   project reconstruct the necessary context merely by reading this
   section."
-
-  If you have a relevant JIRA issue, add a link directly to the issue URL here.
-  Example: https://issues.folio.org/browse/UIIN-817
  -->
 
 ## Approach
@@ -30,44 +27,21 @@
  developers *work* with your solution in the future.
 -->
 
-#### TODOS and Open Questions
-<!-- OPTIONAL
-- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
+## Refs
+<!--
+  If you have a relevant JIRA issue, add a link directly to the issue URL here.
+  Example: https://issues.folio.org/browse/UIIN-817
 -->
 
-## Learning
+## Screenshots
 <!-- OPTIONAL
-  Help out not only your reviewer, but also your fellow developer!
-  Sometimes there are key pieces of information that you used to come up
-  with your solution. Don't let all that hard work go to waste! A
-  pull request is a *perfect opportunity to share the learning that
-  you did. Add links to blog posts, patterns, libraries or addons used
-  to solve this problem.
+ One picture is literally worth a thousand words. When the feature is
+ an interaction, an animated GIF is best. Most of the time it helps to
+ include "before" and "after" screenshots to quickly demonstrate the
+ value of the feature.
+
+ Here are some great tools to help you record gifs:
+
+ Windows: https://getsharex.com/
+ Mac: https://gifox.io/
 -->
-
-## Pre-Merge Checklist
-Before merging this PR, please go through the following list and take appropriate actions.
-- [ ] I've added appropriate record to the CHANGELOG.md
-- Does this PR meet or exceed the expected quality standards?
-  - [ ] Code coverage on new code is 80% or greater
-  - [ ] Duplications on new code is 3% or less
-  - [ ] There are no major code smells or security issues
-- Does this introduce breaking changes?
-  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
-  - [ ] There are no breaking changes in this PR.
-
-If there are breaking changes, please **STOP** and consider the following:
-
-- What other modules will these changes impact?
-- Do JIRAs exist to update the impacted modules?
-  - [ ] If not, please create them
-  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
-  - [ ] Do they have all they appropriate links to blocked/related issues?
-- Are the JIRAs under active development?
-  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
-- Do PRs exist for these changes?
-  - [ ] If so, have they been approved?
-
-Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.
-
-While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.


### PR DESCRIPTION
The purpose of this PR is to simplify PR template, because, as practice shows, no one uses the `Pre-Merge Checklist` section, however, this takes up a lot of space in the description of the PR.
So I suggest leaving just:

## Purpose
## Approach
## Refs
## Screenshots