### PR TITLE
UIIN-2541: Instance details are not shown on Inventory pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * Sorting on the Instance's Holdings item table is not working. Fixes UIIN-2528.
 * ECS: use mod-search to get tenantId for local/shared instance details. Refs UIIN-2538.
 * Make the 'enabled' argument always boolean when calling useUserTenantPermissions. Refs UIIN-2540.
+* Instance details are not shown on Inventory pane. Fixes UIIN-2541.
 
 ## [9.4.11](https://github.com/folio-org/ui-inventory/tree/v9.4.11) (2023-08-02)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.10...v9.4.11)

--- a/src/ViewInstanceWrapper.js
+++ b/src/ViewInstanceWrapper.js
@@ -19,7 +19,7 @@ const ViewInstanceWrapper = (props) => {
   const { instance } = useInstance(id);
 
   const isShared = instance?.shared;
-  const tenantId = instance?.tenantId;
+  const tenantId = instance?.tenantId ?? stripes.okapi.tenant;
 
   const {
     userPermissions: centralTenantPermissions,

--- a/src/common/hooks/useInstance.js
+++ b/src/common/hooks/useInstance.js
@@ -4,7 +4,7 @@ import useSearchInstanceByIdQuery from './useSearchInstanceByIdQuery';
 import useInstanceQuery from './useInstanceQuery';
 
 const useInstance = (id) => {
-  const { instance: _instance } = useSearchInstanceByIdQuery(id);
+  const { isLoading: isSearchInstanceByIdLoading, instance: _instance } = useSearchInstanceByIdQuery(id);
 
   const instanceTenantId = _instance?.tenantId;
   const isShared = _instance?.shared;
@@ -12,7 +12,7 @@ const useInstance = (id) => {
   const { isLoading, instance: data } = useInstanceQuery(
     id,
     { tenantId: instanceTenantId },
-    { enabled: Boolean(id && instanceTenantId) }
+    { enabled: Boolean(id && !isSearchInstanceByIdLoading) }
   );
 
   const instance = useMemo(


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Do not rely on `tenantId` property for getting instance details because this is not a required field
- If the `tenantId` is not provided then okapi tenant headed won't be overwritten
 
## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://issues.folio.org/browse/UIIN-2541

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
