### PR TITLE
UIIN-2516: Enclose the query in quotes to allow for parentheses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * Sorting on the Instance's Holdings item table is not working. Fixes UIIN-2528.
 * ECS: use mod-search to get tenantId for local/shared instance details. Refs UIIN-2538.
 * Make the 'enabled' argument always boolean when calling useUserTenantPermissions. Refs UIIN-2540.
+* Enclose the query in quotes to allow for parentheses. Fixes UIIN-2516.
 
 ## [9.4.11](https://github.com/folio-org/ui-inventory/tree/v9.4.11) (2023-08-02)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.10...v9.4.11)

--- a/src/Instance/InstanceEdit/InstanceEdit.test.js
+++ b/src/Instance/InstanceEdit/InstanceEdit.test.js
@@ -38,12 +38,12 @@ const stripesStub = {
   locale: 'en-US',
   plugins: {},
 };
-const mockInstance= {
+const mockInstance = {
   ...instance,
   shared: false,
   tenantId: 'tenantId',
 };
-jest.mock('../../common/hooks/useInstance', () => jest.fn())
+jest.mock('../../common/hooks/useInstance', () => jest.fn());
 
 const InstanceEditSetup = () => (
   <Router>

--- a/src/constants.js
+++ b/src/constants.js
@@ -468,11 +468,11 @@ export const SYSTEM_USER_ID = '00000000-0000-0000-0000-000000000000';
 export const SYSTEM_USER_NAME = 'System';
 
 export const SINGLE_ITEM_QUERY_TEMPLATES = {
-  'items.barcode': 'barcode==%{query}',
-  isbn: 'isbn==%{query}',
-  issn: 'issn==%{query}',
-  itemHrid: 'hrid==%{query}',
-  iid: 'id==%{query}',
+  'items.barcode': 'barcode=="%{query}"',
+  isbn: 'isbn=="%{query}"',
+  issn: 'issn=="%{query}"',
+  itemHrid: 'hrid=="%{query}"',
+  iid: 'id=="%{query}"',
 };
 
 export const fieldSearchConfigurations = {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Enclose the query in quotes to allow for parentheses.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Issue
[UIIN-2516](https://issues.folio.org/browse/UIIN-2516)
## Screencast

https://github.com/folio-org/ui-inventory/assets/77053927/b6e074c4-f155-4252-81f7-6886e8049610



## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
