### PR TITLE
UIIN-2536: Add advanced search query for facets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 * Make the 'enabled' argument always boolean when calling useUserTenantPermissions. Refs UIIN-2540.
 * Instance details are not shown on Inventory pane. Fixes UIIN-2541.
 * Enclose the query in quotes to allow for parentheses. Fixes UIIN-2516.
+* Add advanced search query for facets. Fixes UIIN-2536.
 
 ## [9.4.11](https://github.com/folio-org/ui-inventory/tree/v9.4.11) (2023-08-02)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.10...v9.4.11)

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -22,7 +22,7 @@ const DEFAULT_SORT = 'title';
 const getQueryTemplateContributor = (queryValue) => `contributors.name==/string "${queryValue}"`;
 const getAdvancedSearchQueryTemplate = (queryIndex, matchOption) => fieldSearchConfigurations[queryIndex]?.[matchOption];
 
-const getAdvancedSearchTemplate = (queryValue) => {
+export const getAdvancedSearchTemplate = (queryValue) => {
   const splitIntoRowsRegex = /(?=\sor\s|\sand\s|\snot\s)/g;
 
   // split will return array of strings:

--- a/src/withFacets.js
+++ b/src/withFacets.js
@@ -19,12 +19,19 @@ import {
   CQL_FIND_ALL,
   browseModeOptions,
   browseModeMap,
+  queryIndexes,
 } from './constants';
+import { getAdvancedSearchTemplate } from './routes/buildManifestObject';
 
 function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
   const queryIndex = queryParams?.qindex ?? 'all';
+  const queryValue = queryParams?.query ?? '';
   const { indexes, filters } = browseModeMap[queryIndex] ? browseConfig : getFilterConfig(queryParams.segment);
-  const queryTemplate = getQueryTemplate(queryIndex, indexes);
+  let queryTemplate = getQueryTemplate(queryIndex, indexes);
+
+  if (queryIndex === queryIndexes.ADVANCED_SEARCH) {
+    queryTemplate = getAdvancedSearchTemplate(queryValue);
+  }
 
   // reset qindex otherwise makeQueryFunction does not use queryTemplate
   // https://github.com/folio-org/stripes-smart-components/blob/e918a620ad2ac2c5b06ce121cd0e061a03bcfdf6/lib/SearchAndSort/makeQueryFunction.js#L46

--- a/src/withFacets.test.js
+++ b/src/withFacets.test.js
@@ -1,0 +1,57 @@
+import { render, fireEvent } from '@folio/jest-config-stripes/testing-library/react';
+import withFacets from './withFacets';
+import { queryIndexes } from './constants';
+
+const WrappedComponent = ({
+  fetchFacets,
+  data = {},
+  properties = {},
+}) => {
+  return (
+    <button
+      type="button"
+      onClick={() => fetchFacets(data)(properties)}
+    >
+      fetchFacetsButton
+    </button>
+  );
+};
+
+const FacetsHoc = withFacets(WrappedComponent);
+
+describe('withFacets', () => {
+  describe('when Advanced search is used', () => {
+    it('should fetch facets with the correct params', async () => {
+      const mutator = {
+        facets: {
+          reset: jest.fn(),
+          GET: jest.fn().mockResolvedValue(),
+        },
+      };
+
+      const resources = {
+        query: {
+          qindex: queryIndexes.ADVANCED_SEARCH,
+          query: 'isbn containsAll test1 or title exactPhrase test2 or keyword startsWith test3',
+        },
+      };
+
+      const { getByText } = render(
+        <FacetsHoc
+          mutator={mutator}
+          resources={resources}
+          properties={{ facetToOpen: 'source' }}
+        />
+      );
+
+      fireEvent.click(getByText('fetchFacetsButton'));
+
+      expect(mutator.facets.GET).toHaveBeenCalledWith(expect.objectContaining({
+        params: {
+          facet: 'source:6',
+          query: 'isbn="*test1*" or title==/string "test2" or keyword all "test3*"',
+        },
+      }));
+    });
+  });
+});


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Add advanced search query for facets.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Issue
[UIIN-2536](https://issues.folio.org/browse/UIIN-2536)

## Screencast


https://github.com/folio-org/ui-inventory/assets/77053927/35771282-59fd-431b-8114-b31f5f982791


