### PR TITLE
UIIN-2554: Make the isShared prop boolean to avoid crashes when calling methods from undefined.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 * Make the 'enabled' argument always boolean when calling useUserTenantPermissions. Refs UIIN-2540.
 * Instance details are not shown on Inventory pane. Fixes UIIN-2541.
 * Enclose the query in quotes to allow for parentheses. Fixes UIIN-2516.
+* Make the isShared prop boolean to avoid crashes when calling methods from undefined. Fixes UIIN-2554.
 
 ## [9.4.11](https://github.com/folio-org/ui-inventory/tree/v9.4.11) (2023-08-02)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.10...v9.4.11)

--- a/src/ViewInstanceWrapper.js
+++ b/src/ViewInstanceWrapper.js
@@ -18,7 +18,7 @@ const ViewInstanceWrapper = (props) => {
   const centralTenantId = stripes.user.user?.consortium?.centralTenantId;
   const { instance } = useInstance(id);
 
-  const isShared = instance?.shared;
+  const isShared = Boolean(instance?.shared);
   const tenantId = instance?.tenantId ?? stripes.okapi.tenant;
 
   const {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Make the `isShared` prop boolean to avoid crashes when calling methods from `undefined` (`isShared.toString()`).
It is env issue, but it interferes.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-2554](https://issues.folio.org/browse/UIIN-2554)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Related PRs
https://github.com/folio-org/ui-quick-marc/pull/583

<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
