### PR TITLE
UIIN-2552: ECS: display shadow instances as shared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 * Show Effective location facet for all Call Number browse sub-options. Fixes UIIN-2499.
 * Enable pagination/item number information in the Instance's Holding Item list. Fixes UIIN-2530.
 * Adjust behaviour of View source for shared instances. Refs UIIN-2449.
+* ECS: display shadow instances as shared. Refs UIIN-2552.
 
 ## [9.4.11](https://github.com/folio-org/ui-inventory/tree/v9.4.11) (2023-08-02)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.10...v9.4.11)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -35,11 +35,11 @@ import { getPublishingInfo } from './Instance/InstanceDetails/utils';
 import {
   getDate,
   handleKeyCommand,
+  isInstanceShadowCopy,
   isMARCSource,
   isUserInConsortiumMode,
 } from './utils';
 import {
-  CONSORTIUM_PREFIX,
   indentifierTypeNames,
   layers,
   REQUEST_OPEN_STATUSES,
@@ -504,7 +504,7 @@ class ViewInstance extends React.Component {
     };
 
     const suppressEditInstanceForMemberTenant = checkIfUserInMemberTenant(stripes)
-      && instance?.source.startsWith(CONSORTIUM_PREFIX)
+      && isShared
       && !this.hasCentralTenantPerm(editInstancePerm);
 
     const showInventoryMenuSection = (
@@ -769,11 +769,13 @@ class ViewInstance extends React.Component {
       isShared,
     } = this.props;
 
+    const isInstanceShared = Boolean(isShared || isInstanceShadowCopy(instance?.source));
+
     return (
       <FormattedMessage
         id={`ui-inventory.${isUserInConsortiumMode(stripes) ? 'consortia.' : ''}instanceRecordTitle`}
         values={{
-          isShared,
+          isShared: isInstanceShared,
           title: instance?.title,
           publisherAndDate: getPublishingInfo(instance),
         }}

--- a/src/ViewInstance.test.js
+++ b/src/ViewInstance.test.js
@@ -248,11 +248,27 @@ describe('ViewInstance', () => {
         it('should render instance shared, title, publisher, and publication date', () => {
           const selectedInstance = {
             ...instance,
-            source: 'CONSORTIUM-FOLIO',
+            shared: true,
+            source: 'FOLIO',
           };
           StripesConnectedInstance.prototype.instance.mockImplementation(() => selectedInstance);
 
           const { getByText } = renderViewInstance({ selectedInstance, isShared: true });
+          const expectedTitle = 'Shared instance • #youthaction • Information Age Publishing, Inc. • 2015';
+
+          expect(getByText(expectedTitle)).toBeInTheDocument();
+        });
+      });
+
+      describe('shadow copy of instance', () => {
+        it('should render instance shared, title, publisher, and publication date', () => {
+          const selectedInstance = {
+            ...instance,
+            source: 'CONSORTIUM-FOLIO',
+          };
+          StripesConnectedInstance.prototype.instance.mockImplementation(() => selectedInstance);
+
+          const { getByText } = renderViewInstance({ selectedInstance, isShared: false });
           const expectedTitle = 'Shared instance • #youthaction • Information Age Publishing, Inc. • 2015';
 
           expect(getByText(expectedTitle)).toBeInTheDocument();

--- a/src/edit/InstanceForm.js
+++ b/src/edit/InstanceForm.js
@@ -65,6 +65,7 @@ import {
   handleKeyCommand,
   psTitleRelationshipId,
   validateOptionalField,
+  isInstanceShadowCopy,
 } from '../utils';
 import {
   validateTitles,
@@ -189,6 +190,7 @@ class InstanceForm extends React.Component {
 
     const getEditInstanceTitle = () => {
       const publishingInfo = getPublishingInfo(initialValues);
+      const isInstanceShared = initialValues.shared || isInstanceShadowCopy(initialValues.source);
 
       return (
         <>
@@ -198,7 +200,7 @@ class InstanceForm extends React.Component {
             id={`ui-inventory.editInstance.${isUserInConsortiumMode(stripes) ? 'consortia.' : ''}title`}
             values={{
               title: initialValues.title,
-              isShared: initialValues.shared,
+              isShared: isInstanceShared,
             }}
           />
           {publishingInfo}

--- a/src/utils.js
+++ b/src/utils.js
@@ -780,3 +780,5 @@ export const isMARCSource = (source) => {
 };
 
 export const isUserInConsortiumMode = stripes => stripes.hasInterface('consortia');
+
+export const isInstanceShadowCopy = (source) => [`${CONSORTIUM_PREFIX}FOLIO`, `${CONSORTIUM_PREFIX}MARC`].includes(source);


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Currently, shadow instance records (source value = MARC-shared/FOLIO-shared) are shown as local because the response from mod-search returns property shared = false, and the record is stored in a local member tenant storage. It is needed to display such instances as shared - check for source value as well.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Create `util` to check if instance is a shadow copy of the shared instance (check for source value)
- Adjust View details/Edit screen header for shadow instances

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://issues.folio.org/browse/UIIN-2552

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![image](https://github.com/folio-org/ui-inventory/assets/55138456/009aa430-355e-4f4b-bd09-00e599054378)
![image](https://github.com/folio-org/ui-inventory/assets/55138456/aa876963-2adf-4fd2-9e1a-0e9840186dcf)
