### PR TITLE
UIIN-2560: Display correct number of items in the Instance's Holding Item list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 * Adjust behaviour of View source for shared instances. Refs UIIN-2449.
 * Consortial Central Tenant: Handling of Instance Action Menu options. Refs UIIN-2498.
 * ECS: display shadow instances as shared. Refs UIIN-2552.
+* Display correct number of items in the Instance's Holding Item list. Refs UIIN-2560.
 
 ## [9.4.11](https://github.com/folio-org/ui-inventory/tree/v9.4.11) (2023-08-02)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.10...v9.4.11)

--- a/src/Instance/HoldingsList/Holding/HoldingAccordion.js
+++ b/src/Instance/HoldingsList/Holding/HoldingAccordion.js
@@ -26,7 +26,7 @@ const HoldingAccordion = ({
   withMoveDropdown,
 }) => {
   const searchParams = {
-    limit: 1,
+    limit: 0,
     offset: 0,
   };
 

--- a/src/Instance/ItemsList/ItemsListContainer.js
+++ b/src/Instance/ItemsList/ItemsListContainer.js
@@ -32,7 +32,8 @@ const ItemsListContainer = ({
     offset,
   };
 
-  const { isFetching, items, totalRecords } = useHoldingItemsQuery(holding.id, { searchParams });
+  const { isFetching, items } = useHoldingItemsQuery(holding.id, { searchParams });
+  const { totalRecords } = useHoldingItemsQuery(holding.id, { searchParams: { limit: 0 }, key: 'itemCount' });
 
   useEffect(() => {
     if(!isEmpty(items)) {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
* Display correct number of items in the Instance's Holding Item list because RMB sends estimated total of items

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Set `limit=0` to get exact number of items in `HoldingAccordion` component
* Create separate request to get exact number of items in `ItemsListContainer` component to avoid bugs when interact with pagination

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-2560](https://issues.folio.org/browse/UIIN-2560)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

### Before

https://github.com/folio-org/ui-inventory/assets/85172747/5182a162-6a3e-4fdd-ab69-375cd72d9388



### After

https://github.com/folio-org/ui-inventory/assets/85172747/a7ae2362-00b4-4c23-90ff-f7c865968779

