### PR TITLE
UIIN-2566: Don't reset filters after changing a search option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 * Consortial Central Tenant: Handling of Instance Action Menu options. Refs UIIN-2498.
 * ECS: display shadow instances as shared. Refs UIIN-2552.
 * Display correct number of items in the Instance's Holding accordion. Fixes UIIN-2550.
+* Don't reset filters after changing a search option. Fixes UIIN-2566.
 
 ## [9.4.11](https://github.com/folio-org/ui-inventory/tree/v9.4.11) (2023-08-02)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.10...v9.4.11)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -220,9 +220,7 @@ class InstancesList extends React.Component {
   }
 
   componentWillUnmount() {
-    const { parentMutator } = this.props;
     this.unlisten();
-    parentMutator.records.reset();
   }
 
   extraParamsToReset = {
@@ -1117,14 +1115,7 @@ class InstancesList extends React.Component {
     const visibleColumns = this.getVisibleColumns();
     const columnMapping = this.getColumnMapping();
 
-    const onChangeIndex = (e, { isAdvancedSearchModal } = {}) => {
-      if (!isAdvancedSearchModal) {
-        parentMutator.query.update({
-          filters: '',
-          ...this.extraParamsToReset,
-        });
-      }
-
+    const onChangeIndex = () => {
       this.setState({ isSingleResult: true });
     };
 

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -221,16 +221,6 @@ describe('InstancesList', () => {
       });
     });
 
-    describe('when the component is unmounted', () => {
-      it('should reset records', () => {
-        mockRecordsReset.mockClear();
-
-        const { unmount } = renderInstancesList({ segment: 'instances' });
-        unmount();
-        expect(mockRecordsReset).toHaveBeenCalled();
-      });
-    });
-
     describe('when clicking on the `Browse` tab', () => {
       it('should pass the correct search by clicking on the `Browse` tab', () => {
         const search = '?qindex=subject&query=book';
@@ -444,45 +434,9 @@ describe('InstancesList', () => {
 
         expect(screen.getByRole('searchbox', { name: 'Search' })).toHaveValue('search query');
       });
-    });
 
-    describe('when using advanced search', () => {
-      it('should set advanced search query in search input', () => {
-        renderInstancesList({ segment: 'instances' });
-
-        fireEvent.click(screen.getByRole('button', { name: 'Advanced search' }));
-        fireEvent.change(screen.getAllByRole('textbox', { name: 'Search for' })[0], {
-          target: { value: 'test' }
-        });
-
-        const advancedSearchSubmit = screen.getAllByRole('button', { name: 'Search' })[0];
-        fireEvent.click(advancedSearchSubmit);
-
-        expect(screen.getAllByLabelText('Search')[0].value).toEqual('keyword containsAll test');
-      });
-
-      describe('when current search option is advancedSearch and user clicks Search in the advanced search modal', () => {
-        it('should not fire onChangeIndex functionality', async () => {
-          history = createMemoryHistory({ initialEntries: [{
-            search: '?qindex=advancedSearch&query=test',
-          }] });
-
-          renderInstancesList({ segment: 'instances' });
-
-          fireEvent.click(screen.getByRole('button', { name: 'Advanced search' }));
-          fireEvent.change(screen.getAllByRole('textbox', { name: 'Search for' })[0], {
-            target: { value: 'test2' }
-          });
-          const advancedSearchSubmit = screen.getAllByRole('button', { name: 'Search' })[0];
-
-          await act(async () => { fireEvent.click(advancedSearchSubmit); });
-
-          expect(updateMock).not.toHaveBeenCalled();
-        });
-      });
-
-      describe('when current search option is advancedSearch and user clicks Search in the advanced search modal', () => {
-        it('should not reset filters', async () => {
+      describe('when the search option is changed', () => {
+        it('should not change the URL in the onChangeIndex function', async () => {
           history = createMemoryHistory({ initialEntries: [{
             search: '?qindex=advancedSearch&query=keyword containsAll test&filters=language.eng',
           }] });
@@ -498,33 +452,32 @@ describe('InstancesList', () => {
 
           await act(async () => { fireEvent.click(advancedSearchSubmit); });
 
-          await waitFor(() => { expect(history.push).toHaveBeenCalledWith(
-            '/?filters=language.eng&qindex=advancedSearch&query=keyword%20containsAll%20test2'
-          ); })
-        });
-      });
-
-      describe('when current search option is not the advancedSearch and user clicks Search in the advanced search modal', () => {
-        it('should reset filters', async () => {
-          history = createMemoryHistory({ initialEntries: [{
-            search: '?qindex=title&query=test&filters=language.eng',
-          }] });
-          history.push = jest.fn();
-
-          renderInstancesList({ segment: 'instances' });
-
-          fireEvent.click(screen.getByRole('button', { name: 'Advanced search' }));
-          fireEvent.change(screen.getAllByRole('textbox', { name: 'Search for' })[0], {
-            target: { value: 'test2' }
-          });
-          const advancedSearchSubmit = screen.getAllByRole('button', { name: 'Search' })[0];
-
-          await act(async () => { fireEvent.click(advancedSearchSubmit); });
+          expect(updateMock).not.toHaveBeenCalled();
+          expect(mockQueryReplace).not.toHaveBeenCalled();
 
           await waitFor(() => {
-            expect(history.push).toHaveBeenCalledWith('/?qindex=advancedSearch&query=title%20containsAll%20test2');
-          })
+            expect(history.push).toHaveBeenNthCalledWith(
+              1,
+              '/?filters=language.eng&qindex=advancedSearch&query=keyword%20containsAll%20test2'
+            );
+          });
         });
+      });
+    });
+
+    describe('when using advanced search', () => {
+      it('should set advanced search query in search input', () => {
+        renderInstancesList({ segment: 'instances' });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Advanced search' }));
+        fireEvent.change(screen.getAllByRole('textbox', { name: 'Search for' })[0], {
+          target: { value: 'test' }
+        });
+
+        const advancedSearchSubmit = screen.getAllByRole('button', { name: 'Search' })[0];
+        fireEvent.click(advancedSearchSubmit);
+
+        expect(screen.getAllByLabelText('Search')[0].value).toEqual('keyword containsAll test');
       });
     });
   });

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -456,8 +456,8 @@ describe('InstancesList', () => {
           expect(mockQueryReplace).not.toHaveBeenCalled();
 
           await waitFor(() => {
-            expect(history.push).toHaveBeenNthCalledWith(
-              1,
+            expect(history.push).toHaveBeenCalledTimes(1);
+            expect(history.push).toHaveBeenCalledWith(
               '/?filters=language.eng&qindex=advancedSearch&query=keyword%20containsAll%20test2'
             );
           });

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -1,6 +1,5 @@
 import {
   get,
-  isEmpty,
 } from 'lodash';
 
 import { makeQueryFunction } from '@folio/stripes/smart-components';
@@ -14,7 +13,6 @@ import {
   getIsbnIssnTemplate,
 } from '../utils';
 import { getFilterConfig } from '../filterConfig';
-import facetsStore from '../stores/facetsStore';
 
 const INITIAL_RESULT_COUNT = 100;
 const DEFAULT_SORT = 'title';
@@ -120,71 +118,6 @@ export function buildQuery(queryParams, pathComponents, resourceData, logger, pr
   )(queryParams, pathComponents, resourceData, logger, props);
 }
 
-const memoizeGetFetch = (fn) => {
-  let prevLocationKey = '';
-  let prevResultOffset = '';
-  let prevResult = false;
-
-  return props => {
-    const {
-      location,
-      resources: {
-        resultOffset,
-      },
-    } = props;
-
-    if (
-      prevLocationKey === location.key &&
-      prevResultOffset === resultOffset
-    ) {
-      return prevResult;
-    } else {
-      const result = fn(props);
-      prevLocationKey = location.key;
-      prevResultOffset = resultOffset;
-      prevResult = result;
-      return result;
-    }
-  };
-};
-
-const getFetchProp = () => {
-  let prevQindex = null;
-  let prevQuery = null;
-
-  return memoizeGetFetch(props => {
-    const {
-      location,
-    } = props;
-    const params = new URLSearchParams(location.search);
-    const qindex = params.get('qindex');
-    const query = params.get('query');
-    const filters = params.get('filters');
-    const sort = params.get('sort');
-    const selectedBrowseResult = params.get('selectedBrowseResult');
-    const hasReset = (
-      !qindex &&
-      !query &&
-      !filters &&
-      (sort === DEFAULT_SORT || !sort) &&
-      isEmpty(facetsStore.getState().facetSettings)
-    );
-    let isFetch = true;
-
-    if (prevQindex !== qindex) {
-      isFetch = (
-        hasReset ||
-        prevQuery !== query ||
-        selectedBrowseResult === 'true'
-      );
-    }
-
-    prevQindex = qindex;
-    prevQuery = query;
-    return isFetch;
-  });
-};
-
 const buildRecordsManifest = (options = {}) => {
   const { path } = options;
 
@@ -196,8 +129,6 @@ const buildRecordsManifest = (options = {}) => {
     throwErrors: false,
     path: 'inventory/instances',
     resultDensity: 'sparse',
-    accumulate: 'true',
-    fetch: getFetchProp(),
     GET: {
       path,
       params: {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
- don't reset filters after changing a search option.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
- resetting filters was added in this PR [#1717](https://github.com/folio-org/ui-inventory/pull/1717) which is no longer relevant, Browse search is used on a separate page;
- removed `getFetchProp` from `buildManifestObject` due to we no longer fire search when selecting the search option.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Related PRs
https://github.com/folio-org/stripes-smart-components/pull/1393

## Refs
[UIIN-2566](https://issues.folio.org/browse/UIIN-2566)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots


https://github.com/folio-org/ui-inventory/assets/77053927/b1a9cdcb-4c96-4b98-9abb-13b834c09375




<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
