### PR TITLE
UIIN-2518: Make the Move actions available regardless of how user navigated to the record.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 * Don't reset filters after changing a search option. Fixes UIIN-2566.
 * Fix issue with 'Up' caret on default sort Holdings/Items segments. Refs UIIN-2553.
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs UIIN-2573.
+* Make the Move actions available regardless of how user navigated to the record. Refs UIIN-2518.
 
 ## [9.4.11](https://github.com/folio-org/ui-inventory/tree/v9.4.11) (2023-08-02)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.10...v9.4.11)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -460,7 +460,6 @@ class ViewInstance extends React.Component {
       onCopy,
       stripes,
       intl,
-      openedFromBrowse,
       resources: {
         instanceRequests,
       },
@@ -511,7 +510,7 @@ class ViewInstance extends React.Component {
     const showInventoryMenuSection = (
       canEditInstance
       || canViewSource
-      || (!openedFromBrowse && (canMoveItems || canMoveHoldings))
+      || (canMoveItems || canMoveHoldings)
       || canUseSingleRecordImport
       || canCreateInstance
       || canCreateOrder
@@ -927,7 +926,6 @@ ViewInstance.propTypes = {
   }),
   onClose: PropTypes.func,
   onCopy: PropTypes.func,
-  openedFromBrowse: PropTypes.bool,
   paneWidth: PropTypes.string.isRequired,
   resources: PropTypes.shape({
     allInstanceItems: PropTypes.object.isRequired,

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -561,31 +561,27 @@ class ViewInstance extends React.Component {
                 disabled={!marcRecord}
               />
             )}
-            {!openedFromBrowse && (
-              <>
-                {canMoveItems && (
-                  <ActionItem
-                    id="move-instance-items"
-                    icon="transfer"
-                    messageId={`ui-inventory.moveItems.instance.actionMenu.${this.state.isItemsMovement ? 'disable' : 'enable'}`}
-                    onClickHandler={() => {
-                      onToggle();
-                      this.toggleItemsMovement();
-                    }}
-                  />
-                )}
-                {(canMoveItems || canMoveHoldings) && (
-                  <ActionItem
-                    id="move-instance"
-                    icon="arrow-right"
-                    messageId="ui-inventory.moveItems"
-                    onClickHandler={() => {
-                      onToggle();
-                      this.toggleFindInstancePlugin();
-                    }}
-                  />
-                )}
-              </>
+            {canMoveItems && (
+              <ActionItem
+                id="move-instance-items"
+                icon="transfer"
+                messageId={`ui-inventory.moveItems.instance.actionMenu.${this.state.isItemsMovement ? 'disable' : 'enable'}`}
+                onClickHandler={() => {
+                  onToggle();
+                  this.toggleItemsMovement();
+                }}
+              />
+            )}
+            {(canMoveItems || canMoveHoldings) && (
+              <ActionItem
+                id="move-instance"
+                icon="arrow-right"
+                messageId="ui-inventory.moveItems"
+                onClickHandler={() => {
+                  onToggle();
+                  this.toggleFindInstancePlugin();
+                }}
+              />
             )}
             {canUseSingleRecordImport && (
               <ActionItem

--- a/src/ViewInstance.test.js
+++ b/src/ViewInstance.test.js
@@ -213,10 +213,10 @@ describe('ViewInstance', () => {
     expect(screen.getByText('Move items within an instance')).toBeInTheDocument();
     expect(screen.getByText('Move holdings/items to another instance')).toBeInTheDocument();
   });
-  it('should NOT display \'move\' action menu items when instance was opened from Browse page', () => {
+  it('should display \'move\' action menu items when instance was opened from Browse page', () => {
     renderViewInstance({ openedFromBrowse: true });
-    expect(screen.queryByText('Move items within an instance')).not.toBeInTheDocument();
-    expect(screen.queryByText('Move holdings/items to another instance')).not.toBeInTheDocument();
+    expect(screen.queryByText('Move items within an instance')).toBeInTheDocument();
+    expect(screen.queryByText('Move holdings/items to another instance')).toBeInTheDocument();
   });
   describe('instance header', () => {
     describe('for non-consortia users', () => {

--- a/src/ViewInstance.test.js
+++ b/src/ViewInstance.test.js
@@ -128,7 +128,6 @@ const defaultProp = {
   },
   onClose: mockonClose,
   onCopy: jest.fn(),
-  openedFromBrowse: false,
   paneWidth: '55%',
   resources: {
     allInstanceItems: {
@@ -214,7 +213,7 @@ describe('ViewInstance', () => {
     expect(screen.getByText('Move holdings/items to another instance')).toBeInTheDocument();
   });
   it('should display \'move\' action menu items when instance was opened from Browse page', () => {
-    renderViewInstance({ openedFromBrowse: true });
+    renderViewInstance();
     expect(screen.queryByText('Move items within an instance')).toBeInTheDocument();
     expect(screen.queryByText('Move holdings/items to another instance')).toBeInTheDocument();
   });

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -174,10 +174,8 @@ class InstancesList extends React.Component {
   componentDidMount() {
     const {
       history,
-      getParams,
       namespace,
     } = this.props;
-    const params = getParams();
 
     this.unlisten = history.listen((location) => {
       const hasReset = new URLSearchParams(location.search).get('reset');
@@ -192,10 +190,6 @@ class InstancesList extends React.Component {
     });
 
     this.processLastSearchTerms();
-
-    this.setState({
-      openedFromBrowse: params.selectedBrowseResult === 'true',
-    });
 
     registerLogoutListener(this.clearStorage, namespace, 'instances-list-logout', history);
   }
@@ -314,16 +308,11 @@ class InstancesList extends React.Component {
     const filtersStr = parseFiltersToStr(mergedFilters);
     const params = getParams();
 
-    this.setState({
-      openedFromBrowse: false,
-    });
-
     goTo(path, { ...params, filters: filtersStr });
   };
 
   onSubmitSearch = () => {
     this.setState({
-      openedFromBrowse: false,
       searchInProgress: true,
     });
   }
@@ -1029,7 +1018,6 @@ class InstancesList extends React.Component {
     const {
       isSelectedRecordsModalOpened,
       isImportRecordModalOpened,
-      openedFromBrowse,
       selectedRows,
       searchAndSortKey,
       isSingleResult
@@ -1216,7 +1204,6 @@ class InstancesList extends React.Component {
             detailProps={{
               referenceTables: data,
               onCopy: this.copyInstance,
-              openedFromBrowse,
             }}
             basePath={path}
             path={`${path}/(view|viewsource)/:id/:holdingsrecordid?/:itemid?`}


### PR DESCRIPTION

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Make the Move actions available regardless of how user navigated to the record.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Issue
[UIIN-2518](https://issues.folio.org/browse/UIIN-2518)

## Screencast


https://github.com/folio-org/ui-inventory/assets/77053927/1a6e9f98-0aca-46f3-81c0-fd6a3758bd2a




