### PR TITLE
UIIN-2572: Consortial Central Tenant: Hide Instance Action Menu New Request option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 * Make the Move actions available regardless of how user navigated to the record. Refs UIIN-2518.
 * Sorting on the Instance's Holdings item table is not working, part 2. Fixes UIIN-2565.
 * Promote a local instance to become a shared instance. Refs UIIN-2460.
+* Consortial Central Tenant: Hide Instance Action Menu New Request option. Refs UIIN-2572.
 
 ## [9.4.11](https://github.com/folio-org/ui-inventory/tree/v9.4.11) (2023-08-02)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.10...v9.4.11)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -538,7 +538,7 @@ class ViewInstance extends React.Component {
     const numberOfRequests = instanceRequests.other?.totalRecords;
     const canReorderRequests = titleLevelRequestsFeatureEnabled && hasReorderPermissions && numberOfRequests && canReorder;
     const canViewRequests = !checkIfUserInCentralTenant(stripes) && !titleLevelRequestsFeatureEnabled;
-    const canCreateNewRequest = titleLevelRequestsFeatureEnabled && canCreateRequest;
+    const canCreateNewRequest = !checkIfUserInCentralTenant(stripes) && titleLevelRequestsFeatureEnabled && canCreateRequest;
     const identifier = this.getIdentifiers(data);
 
     const buildOnClickHandler = onClickHandler => {
@@ -700,7 +700,7 @@ class ViewInstance extends React.Component {
               )
             }
             <NewInstanceRequestButton
-              isTlrEnabled={!!titleLevelRequestsFeatureEnabled}
+              isTlrEnabled={canCreateNewRequest}
               instanceId={instance.id}
             />
           </MenuSection>


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
To suppress `New request` action item from Consortial Central Tenant

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Check if user is in central tenant and hide the action item when true

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://issues.folio.org/browse/UIIN-2572

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
