### PR TITLE
UIIN-2570: Disable View source button for Source = FOLIO instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 * Consortial Central Tenant: Suppress Item detail view Action menu. Refs UIIN-2525.
 * Consortial Central Tenant: Hide Instance Action Menu New Request option. Refs UIIN-2572.
 * Add facet for members with holdings on Instances in Inventory Instances/Holdings/Items search. Refs UIIN-2395.
+* Disable View source button for Source = FOLIO instances. Fixes UIIN-2570.
 
 ## [9.4.11](https://github.com/folio-org/ui-inventory/tree/v9.4.11) (2023-08-02)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.10...v9.4.11)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -603,7 +603,7 @@ class ViewInstance extends React.Component {
                   onToggle();
                   this.handleViewSource(e, instance);
                 }}
-                disabled={!marcRecord}
+                isDisabled={!marcRecord}
               />
             )}
             {canMoveItems && (


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
* Disable "View source" button for Source = FOLIO instances

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Changed prop name to `isDisabled` which is correct prop for `ActionItem` component

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-2570](https://issues.folio.org/browse/UIIN-2570)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-inventory/assets/85172747/4c582b39-492f-404c-91f1-4b1b66e5d17c

