### PR TITLE
UIIN-2606: Item barcode redirects to the broken page in circ log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 * Add Browse facet for members with holdings on Instances in Contributors & Subject Browse. Refs UIIN-2415.
 * Add permission to promote a local instance to shared. Refs UIIN-2571.
 * Add `Held By` facet in Call number browse. Refs UIIN-2416.
+* Item barcode redirects to the broken page in circ log. Fixes UIIN-2606.
 
 ## [9.4.12](https://github.com/folio-org/ui-inventory/tree/v9.4.12) (2023-09-21)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.11...v9.4.12)

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -659,7 +659,7 @@ class ItemView extends React.Component {
       },
       effectiveLocation: {
         name: get(item, ['effectiveLocation', 'name'], '-'),
-        isActive: locationsById[item.effectiveLocation.id].isActive,
+        isActive: locationsById[item.effectiveLocation.id]?.isActive,
       },
     };
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Sometimes a user gets an error when navigating to Item details view from Circulation log app.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Add the optional chainig operator to `locationsById[item.effectiveLocation.id]`

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://issues.folio.org/browse/UIIN-2606

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
