### PR TITLE
UIIN-2612 The "Exact phrase" search gives incorrect results for all fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
 * Instance 3rd pane: Add consortial holdings/item accordion. Refs UIIN-2410.
 * Consortial Central Tenant: Handling Holdings and Item actions on the Instance detail view. Refs UIIN-2523.
 * Hide Held by facet in Inventory contributor and subject browse. Refs UIIN-2591.
+* Use `==` for exact phrase search in Advanced Search for all full-text and term fields. Refs UIIN-2612.
 
 ## [9.4.12](https://github.com/folio-org/ui-inventory/tree/v9.4.12) (2023-09-21)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.11...v9.4.12)

--- a/src/constants.js
+++ b/src/constants.js
@@ -507,17 +507,17 @@ export const SINGLE_ITEM_QUERY_TEMPLATES = {
 
 export const fieldSearchConfigurations = {
   keyword: {
-    exactPhrase: 'keyword==/string "%{query.query}"',
+    exactPhrase: 'keyword=="%{query.query}"',
     containsAll: 'keyword all "%{query.query}"',
     startsWith: 'keyword all "%{query.query}*"',
   },
   contributor: {
-    exactPhrase: 'contributors.name==/string "%{query.query}"',
+    exactPhrase: 'contributors.name=="%{query.query}"',
     containsAll: 'contributors.name="*%{query.query}*"',
     startsWith: 'contributors.name="%{query.query}*"',
   },
   title: {
-    exactPhrase: 'title==/string "%{query.query}"',
+    exactPhrase: 'title=="%{query.query}"',
     containsAll: 'title all "%{query.query}"',
     startsWith: 'title all "%{query.query}*"',
   },
@@ -542,24 +542,24 @@ export const fieldSearchConfigurations = {
     startsWith: 'oclc="%{query.query}*"',
   },
   instanceNotes: {
-    exactPhrase: 'notes.note==/string "%{query.query}" or administrativeNotes==/string "%{query.query}"',
+    exactPhrase: 'notes.note=="%{query.query}" or administrativeNotes=="%{query.query}"',
     containsAll: 'notes.note all "%{query.query}" or administrativeNotes all "%{query.query}"',
     startsWith: 'notes.note all "%{query.query}*" or administrativeNotes all "%{query.query}*"',
   },
   instanceAdministrativeNotes: {
-    exactPhrase: 'administrativeNotes==/string "%{query.query}"',
+    exactPhrase: 'administrativeNotes=="%{query.query}"',
     containsAll: 'administrativeNotes all "%{query.query}"',
     startsWith: 'administrativeNotes all "%{query.query}*"',
   },
   subject: {
-    exactPhrase: 'subjects.value==/string "%{query.query}"',
+    exactPhrase: 'subjects.value=="%{query.query}"',
     containsAll: 'subjects.value all "%{query.query}"',
-    startsWith: 'subjects.value==/string "%{query.query}*"',
+    startsWith: 'subjects.value=="%{query.query}*"',
   },
   callNumber: {
-    exactPhrase: 'itemEffectiveShelvingOrder==/string "%{query.query}"',
+    exactPhrase: 'itemEffectiveShelvingOrder=="%{query.query}"',
     containsAll: 'itemEffectiveShelvingOrder="*%{query.query}*"',
-    startsWith: 'itemEffectiveShelvingOrder==/string "%{query.query}*"',
+    startsWith: 'itemEffectiveShelvingOrder=="%{query.query}*"',
   },
   hrid: {
     exactPhrase: 'hrid=="%{query.query}"',
@@ -577,7 +577,7 @@ export const fieldSearchConfigurations = {
     startsWith: 'authorityId=="%{query.query}*"',
   },
   allFields: {
-    exactPhrase: 'cql.all==/string "%{query.query}"',
+    exactPhrase: 'cql.all=="%{query.query}"',
     containsAll: 'cql.all all "%{query.query}"',
     startsWith: 'cql.all all "%{query.query}*"',
   },
@@ -592,12 +592,12 @@ export const fieldSearchConfigurations = {
     startsWith: 'holdingsNormalizedCallNumbers="%{query.query}*"',
   },
   holdingsNotes: {
-    exactPhrase: 'holdings.notes.note==/string "%{query.query}" or holdings.administrativeNotes==/string "%{query.query}"',
+    exactPhrase: 'holdings.notes.note=="%{query.query}" or holdings.administrativeNotes=="%{query.query}"',
     containsAll: 'holdings.notes.note all "%{query.query}" or holdings.administrativeNotes all "%{query.query}"',
     startsWith: 'holdings.notes.note all "%{query.query}*" or holdings.administrativeNotes all "%{query.query}*"',
   },
   holdingsAdministrativeNotes: {
-    exactPhrase: 'holdings.administrativeNotes==/string "%{query.query}"',
+    exactPhrase: 'holdings.administrativeNotes=="%{query.query}"',
     containsAll: 'holdings.administrativeNotes all "%{query.query}"',
     startsWith: 'holdings.administrativeNotes all "%{query.query}*"',
   },
@@ -627,17 +627,17 @@ export const fieldSearchConfigurations = {
     startsWith: 'itemNormalizedCallNumbers="%{query.query}*"',
   },
   itemNotes: {
-    exactPhrase: 'item.notes.note==/string "%{query.query}" or item.administrativeNotes==/string "%{query.query}"',
+    exactPhrase: 'item.notes.note=="%{query.query}" or item.administrativeNotes=="%{query.query}"',
     containsAll: 'item.notes.note all "%{query.query}" or item.administrativeNotes all "%{query.query}"',
     startsWith: 'item.notes.note all "%{query.query}*" or item.administrativeNotes all "%{query.query}*"',
   },
   itemAdministrativeNotes: {
-    exactPhrase: 'item.administrativeNotes==/string "%{query.query}"',
+    exactPhrase: 'item.administrativeNotes=="%{query.query}"',
     containsAll: 'item.administrativeNotes all "%{query.query}"',
     startsWith: 'item.administrativeNotes all "%{query.query}*"',
   },
   itemCirculationNotes: {
-    exactPhrase: 'item.circulationNotes.note==/string "%{query.query}"',
+    exactPhrase: 'item.circulationNotes.note=="%{query.query}"',
     containsAll: 'item.circulationNotes.note all "%{query.query}"',
     startsWith: 'item.circulationNotes.note all "%{query.query}*"',
   },

--- a/src/routes/buildManifestObject.test.js
+++ b/src/routes/buildManifestObject.test.js
@@ -79,7 +79,7 @@ describe('buildQuery', () => {
         const cql = buildQuery(...getBuildQueryArgs({ queryParams }));
 
         expect(cql).toContain(
-          '(keyword all "test" or title==/string "hello")'
+          '(keyword all "test" or title=="hello")'
         );
       });
 

--- a/src/withFacets.test.js
+++ b/src/withFacets.test.js
@@ -170,7 +170,7 @@ describe('withFacets', () => {
       expect(mutator.facets.GET).toHaveBeenCalledWith(expect.objectContaining({
         params: {
           facet: 'source:6',
-          query: 'isbn="*test1*" or title==/string "test2" or keyword all "test3*"',
+          query: 'isbn="*test1*" or title=="test2" or keyword all "test3*"',
         },
       }));
     });


### PR DESCRIPTION
## Description
Use `==` for exact phrase search in Advanced Search for all full text and term fields

## Screenshots

https://github.com/folio-org/ui-inventory/assets/19309423/970f37d8-2418-432e-b51e-6b520232efb1


## Issues
[UIIN-2612](https://issues.folio.org/browse/UIIN-2612)