### PR TITLE
UIIN-2614 Provide an instance `tenantId` to the PO line form when creating an order from the instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
 * Consortial Central Tenant: Handling Holdings and Item actions on the Instance detail view. Refs UIIN-2523.
 * Hide Held by facet in Inventory contributor and subject browse. Refs UIIN-2591.
 * Use `==` for exact phrase search in Advanced Search for all full-text and term fields. Refs UIIN-2612.
+* Provide an instance `tenantId` to the PO line form when creating an order from the instance. Refs UIIN-2614.
 
 ## [9.4.12](https://github.com/folio-org/ui-inventory/tree/v9.4.12) (2023-09-21)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.11...v9.4.12)

--- a/src/components/NewOrderModal/NewOrderModalContainer.js
+++ b/src/components/NewOrderModal/NewOrderModalContainer.js
@@ -9,8 +9,12 @@ import {
   useParams,
 } from 'react-router-dom';
 
-import { useOkapiKy } from '@folio/stripes/core';
+import {
+  useOkapiKy,
+  useStripes,
+} from '@folio/stripes/core';
 
+import { useInstance } from '../../common';
 import { ORDERS_API } from '../../constants';
 import NewOrderModal from './NewOrderModal';
 
@@ -20,7 +24,9 @@ const NewOrderModalContainer = ({
 }) => {
   const history = useHistory();
   const ky = useOkapiKy();
+  const stripes = useStripes();
   const { id } = useParams();
+  const { instance } = useInstance(id);
   const [orderId, setOrderId] = useState();
 
   const validatePONumber = useCallback(async (poNumber) => {
@@ -45,9 +51,10 @@ const NewOrderModalContainer = ({
 
   const onSubmit = useCallback(() => {
     const route = orderId ? `/orders/view/${orderId}/po-line/create` : '/orders/create';
+    const instanceTenantId = instance?.tenantId || stripes.okapi.tenant;
 
-    history.push(route, { instanceId: id });
-  }, [orderId]);
+    history.push(route, { instanceId: id, instanceTenantId });
+  }, [instance, orderId, stripes.okapi.tenant]);
 
   return (
     <NewOrderModal

--- a/src/components/NewOrderModal/NewOrderModalContainer.js
+++ b/src/components/NewOrderModal/NewOrderModalContainer.js
@@ -53,7 +53,7 @@ const NewOrderModalContainer = ({
     const route = orderId ? `/orders/view/${orderId}/po-line/create` : '/orders/create';
     const instanceTenantId = instance?.tenantId || stripes.okapi.tenant;
 
-    history.push(route, { instanceId: id, instanceTenantId });
+    history.push(route, { instanceId: instance?.id, instanceTenantId });
   }, [instance, orderId, stripes.okapi.tenant]);
 
   return (

--- a/src/components/NewOrderModal/NewOrderModalContainer.test.js
+++ b/src/components/NewOrderModal/NewOrderModalContainer.test.js
@@ -1,23 +1,30 @@
-import React from 'react';
 import {
   BrowserRouter as Router,
   useHistory,
 } from 'react-router-dom';
-import { act, render, screen, fireEvent } from '@folio/jest-config-stripes/testing-library/react';
+
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import { useOkapiKy } from '@folio/stripes/core';
 
 import '../../../test/jest/__mock__';
 
-// eslint-disable-next-line import/order
-import { useOkapiKy } from '@folio/stripes/core';
-
 import { translationsProperties } from '../../../test/jest/helpers';
 import Harness from '../../../test/jest/helpers/Harness';
+import { instance } from '../../../test/fixtures/instance';
+import { useInstance } from '../../common';
 import NewOrderModalContainer from './NewOrderModalContainer';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useHistory: jest.fn()
 }));
+jest.mock('../../common', () => ({
+  ...jest.requireActual('../../common'),
+  useInstance: jest.fn(),
+}));
+
+global.document.createRange = jest.fn(() => new Range());
 
 const defaultProps = {
   onCancel: jest.fn(),
@@ -44,18 +51,25 @@ describe('NewOrderModalContainer', () => {
   const historyMock = {
     push: jest.fn(),
   };
+  const order = {
+    id: 'orderId',
+  };
   const kyMock = {
     get: jest.fn(() => ({
       json: () => Promise.resolve({
-        purchaseOrders: [{ id: 'orderId' }],
+        purchaseOrders: [order],
       })
     }))
   };
 
   beforeEach(() => {
+    historyMock.push.mockClear();
     useHistory
       .mockClear()
       .mockReturnValue(historyMock);
+    useInstance
+      .mockClear()
+      .mockReturnValue({ instance });
     useOkapiKy
       .mockClear()
       .mockReturnValue(kyMock);
@@ -70,7 +84,7 @@ describe('NewOrderModalContainer', () => {
   it('should navigate to \'PO\' creation form when create btn was clicked and \'PO number\' field is empty', async () => {
     renderNewOrderModalContainer();
 
-    await act(async () => fireEvent.click(screen.getByText(/^Create$/)));
+    await userEvent.click(screen.getByText(/^Create$/));
 
     expect(historyMock.push).toHaveBeenCalledWith('/orders/create', expect.anything());
   });
@@ -78,9 +92,19 @@ describe('NewOrderModalContainer', () => {
   it('should navigate to \'PO Line\' creation form when create btn was clicked and PO is exist', async () => {
     renderNewOrderModalContainer();
 
-    await act(async () => fireEvent.change(screen.getByLabelText(/PO number/i), { target: { value: '123' } }));
-    await act(async () => fireEvent.click(screen.getByText(/^Create$/)));
+    await userEvent.type(screen.getByLabelText(/PO number/i), '123');
+    await userEvent.tab();
 
-    expect(historyMock.push).toHaveBeenCalledWith('/orders/create', { 'instanceId': undefined });
+    expect(screen.queryByText('ui-inventory.newOrder.modal.PONumber.doesNotExist')).not.toBeInTheDocument();
+
+    await userEvent.click(await screen.findByText(/^Create$/));
+
+    expect(historyMock.push).toHaveBeenCalledWith(
+      `/orders/view/${order.id}/po-line/create`,
+      {
+        instanceId: instance.id,
+        instanceTenantId: 'diku',
+      },
+    );
   });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
In order to support creating an order from an instance in the "consortium" mode, a PO line form must have the ability to fetch instance data in the specific tenant (actually the central tenant for shared instances).

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Provide instance tenant value (as `instanceTenantId` field) in the location state when navigating to the creating PO/PO Line.
## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://issues.folio.org/browse/UIIN-2614
https://issues.folio.org/browse/UIOR-1159

Required by https://github.com/folio-org/ui-orders/pull/1511

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-inventory/assets/88109087/f5893533-496b-4c2a-b524-6636d3971df2

