### PR TITLE
UIIN-2608: If Shared & Held by facets were selected in the Browse search, then retain them in the Search lookup after clicking the record.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-inventory
 
+## [10.0.1](IN PROGRESS)
+* If Shared & Held by facets were selected in the Browse search, then retain them in the Search lookup after clicking the record. Refs UIIN-2608.
+
 ## [10.0.0](https://github.com/folio-org/ui-inventory/tree/v10.0.0) (2023-10-13)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.12...v10.0.0)
 
@@ -107,7 +110,6 @@
 * Bump @folio/stripes-acq-components dependency version to 5.0.0. Refs UIIN-2620.
 * ECS: Check when sharing instance with source=MARC is complete before re-fetching it. Refs UIIN-2605.
 * Update all facets after changing a term or selecting a facet option. Refs UIIN-2610.
-* If Shared & Held by facets were selected in the Browse search, then retain them in the Search lookup after clicking the record. Refs UIIN-2608.
 
 ## [9.4.12](https://github.com/folio-org/ui-inventory/tree/v9.4.12) (2023-09-21)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.11...v9.4.12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@
 * Bump @folio/stripes-acq-components dependency version to 5.0.0. Refs UIIN-2620.
 * ECS: Check when sharing instance with source=MARC is complete before re-fetching it. Refs UIIN-2605.
 * Update all facets after changing a term or selecting a facet option. Refs UIIN-2610.
+* If Shared & Held by facets were selected in the Browse search, then retain them in the Search lookup after clicking the record. Refs UIIN-2608.
 
 ## [9.4.12](https://github.com/folio-org/ui-inventory/tree/v9.4.12) (2023-09-21)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.11...v9.4.12)

--- a/src/components/BrowseResultsList/BrowseResultsList.js
+++ b/src/components/BrowseResultsList/BrowseResultsList.js
@@ -49,6 +49,7 @@ const BrowseResultsList = ({
     onNeedMoreData,
   },
   totalRecords,
+  filters,
 }) => {
   const data = useContext(DataContext);
   const { search } = useLocation();
@@ -75,7 +76,7 @@ const BrowseResultsList = ({
       id={listId}
       totalCount={totalRecords}
       contentData={browseData}
-      formatter={getBrowseResultsFormatter({ data, browseOption })}
+      formatter={getBrowseResultsFormatter({ data, browseOption, filters })}
       visibleColumns={VISIBLE_COLUMNS_MAP[browseOption]}
       isEmptyMessage={isEmptyMessage}
       isSelected={isSelected}
@@ -101,6 +102,7 @@ const BrowseResultsList = ({
 
 BrowseResultsList.propTypes = {
   browseData: PropTypes.arrayOf(PropTypes.object),
+  filters: PropTypes.object.isRequired,
   isEmptyMessage: PropTypes.node.isRequired,
   isLoading: PropTypes.bool,
   pagination: PropTypes.shape({

--- a/src/components/BrowseResultsList/BrowseResultsList.test.js
+++ b/src/components/BrowseResultsList/BrowseResultsList.test.js
@@ -155,7 +155,7 @@ describe('BrowseResultsList', () => {
           },
         });
 
-        await act(async () => fireEvent.click(screen.getByText(defaultProps.browseData[2].fullCallNumber)));
+        fireEvent.click(screen.getByText(defaultProps.browseData[2].fullCallNumber))
 
         expect(history.location.search).toContain('?filters=shared.true%2Cshared.false%2CtenantId.college');
       });
@@ -181,7 +181,7 @@ describe('BrowseResultsList', () => {
           browseData: contributorsData,
         });
 
-        await act(async () => fireEvent.click(screen.getByText(contributorsData[0].name)));
+        fireEvent.click(screen.getByText(contributorsData[0].name))
 
         expect(history.location.search).toContain(
           '?filters=searchContributors.2b94c631-fca9-4892-a730-03ee529ffe2a%2Cshared.true%2Cshared.false%2CtenantId.college'
@@ -209,7 +209,7 @@ describe('BrowseResultsList', () => {
           browseData: subjectsData,
         });
 
-        await act(async () => fireEvent.click(screen.getByText(subjectsData[0].value)));
+        fireEvent.click(screen.getByText(subjectsData[0].value))
 
         expect(history.location.search).toContain('?filters=shared.true%2Cshared.false%2CtenantId.college');
       });

--- a/src/components/BrowseResultsList/BrowseResultsList.test.js
+++ b/src/components/BrowseResultsList/BrowseResultsList.test.js
@@ -15,6 +15,8 @@ import {
   browseModeOptions,
   BROWSE_INVENTORY_ROUTE,
   INVENTORY_ROUTE,
+  browseCallNumberOptions,
+  FACETS,
 } from '../../constants';
 import { DataContext } from '../../contexts';
 import BrowseResultsList from './BrowseResultsList';
@@ -59,13 +61,36 @@ const defaultProps = {
     pageConfig: [0, null, null],
   },
   totalRecords: 1,
+  filters: {},
 };
 
 const mockContext = {
   contributorNameTypes: [{
     id: '2b94c631-fca9-4892-a730-03ee529ffe2a',
   }],
+  contributorTypes: [{
+    id: '6e09d47d-95e2-4d8a-831b-f777b8ef6d81',
+    name: 'Author',
+  }],
 };
+
+const contributorsData = [
+  {
+    "name": "Toth, Josh",
+    "contributorTypeId": [
+      "6e09d47d-95e2-4d8a-831b-f777b8ef6d81"
+    ],
+    "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a",
+    "isAnchor": false,
+    "totalRecords": 1
+  },
+];
+const subjectsData = [
+  {
+    "value": "Trivia and miscellanea",
+    "totalRecords": 8
+  },
+];
 
 const renderBrowseResultsList = (props = {}) => renderWithIntl(
   <Router history={history}>
@@ -102,6 +127,94 @@ describe('BrowseResultsList', () => {
       )(defaultProps.browseData[2], browseModeOptions.CALL_NUMBERS)
     );
   });
+
+  describe.each([
+    { searchOption: browseCallNumberOptions.CALL_NUMBERS, shared: FACETS.SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY  },
+    { searchOption: browseCallNumberOptions.DEWEY, shared: FACETS.SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
+    { searchOption: browseCallNumberOptions.LIBRARY_OF_CONGRESS, shared: FACETS.SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
+    { searchOption: browseCallNumberOptions.LOCAL, shared: FACETS.SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
+    { searchOption: browseCallNumberOptions.NATIONAL_LIBRARY_OF_MEDICINE, shared: FACETS.SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
+    { searchOption: browseCallNumberOptions.OTHER, shared: FACETS.SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
+    { searchOption: browseCallNumberOptions.SUPERINTENDENT, shared: FACETS.SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
+  ])('when the search option is $searchOption and the Shared and/or HeldBy facets are selected', ({ searchOption, shared, heldBy }) => {
+    describe('and the user clicks on a record in the list', () => {
+      it('should be navigated to the Search lookup with those filters', async () => {
+        history = createMemoryHistory({
+          initialEntries: [{
+            pathname: BROWSE_INVENTORY_ROUTE,
+            search: `${heldBy}=college&qindex=${searchOption}&query=a&${shared}=true&${shared}=false`,
+          }],
+        });
+
+        renderBrowseResultsList({
+          filters: {
+            qindex: searchOption,
+            query: 'a',
+            [shared]: ['true', 'false'],
+            [heldBy]: ["college"],
+          },
+        });
+
+        await act(async () => fireEvent.click(screen.getByText(defaultProps.browseData[2].fullCallNumber)));
+
+        expect(history.location.search).toContain('?filters=shared.true%2Cshared.false%2CtenantId.college');
+      })
+    })
+  })
+
+  describe('when the search option is Contributors and the Shared and/or HeldBy facets are selected', () => {
+    describe('and the user clicks on a record in the list', () => {
+      it('should be navigated to the Search lookup with those filters', async () => {
+        history = createMemoryHistory({
+          initialEntries: [{
+            pathname: BROWSE_INVENTORY_ROUTE,
+            search: 'contributorsShared=true&contributorsShared=false&contributorsTenantId=college&qindex=contributors',
+          }],
+        });
+
+        renderBrowseResultsList({
+          filters: {
+            qindex: 'contributors',
+            contributorsShared: ['true', 'false'],
+            contributorsTenantId: ["college"],
+          },
+          browseData: contributorsData,
+        });
+
+        await act(async () => fireEvent.click(screen.getByText(contributorsData[0].name)));
+
+        expect(history.location.search).toContain(
+          '?filters=searchContributors.2b94c631-fca9-4892-a730-03ee529ffe2a%2Cshared.true%2Cshared.false%2CtenantId.college'
+        );
+      })
+    })
+  })
+
+  describe(`when the search option is Subjects and the Shared and/or HeldBy facets are selected`, () => {
+    describe('and the user clicks on a record in the list', () => {
+      it('should be navigated to the Search lookup with those filters', async () => {
+        history = createMemoryHistory({
+          initialEntries: [{
+            pathname: BROWSE_INVENTORY_ROUTE,
+            search: 'qindex=browseSubjects&subjectsShared=true&subjectsShared=false&subjectsTenantId=college',
+          }],
+        });
+
+        renderBrowseResultsList({
+          filters: {
+            qindex: 'browseSubjects',
+            subjectsShared: ['true', 'false'],
+            subjectsTenantId: ["college"],
+          },
+          browseData: subjectsData,
+        });
+
+        await act(async () => fireEvent.click(screen.getByText(subjectsData[0].value)));
+
+        expect(history.location.search).toContain('?filters=shared.true%2Cshared.false%2CtenantId.college');
+      })
+    })
+  })
 
   describe('when Instance record is linked to an authority record', () => {
     describe('by clicking on the icon of an authority app', () => {

--- a/src/components/BrowseResultsList/BrowseResultsList.test.js
+++ b/src/components/BrowseResultsList/BrowseResultsList.test.js
@@ -155,7 +155,7 @@ describe('BrowseResultsList', () => {
           },
         });
 
-        fireEvent.click(screen.getByText(defaultProps.browseData[2].fullCallNumber))
+        fireEvent.click(screen.getByText(defaultProps.browseData[2].fullCallNumber));
 
         expect(history.location.search).toContain('?filters=shared.true%2Cshared.false%2CtenantId.college');
       });
@@ -181,7 +181,7 @@ describe('BrowseResultsList', () => {
           browseData: contributorsData,
         });
 
-        fireEvent.click(screen.getByText(contributorsData[0].name))
+        fireEvent.click(screen.getByText(contributorsData[0].name));
 
         expect(history.location.search).toContain(
           '?filters=searchContributors.2b94c631-fca9-4892-a730-03ee529ffe2a%2Cshared.true%2Cshared.false%2CtenantId.college'
@@ -209,7 +209,7 @@ describe('BrowseResultsList', () => {
           browseData: subjectsData,
         });
 
-        fireEvent.click(screen.getByText(subjectsData[0].value))
+        fireEvent.click(screen.getByText(subjectsData[0].value));
 
         expect(history.location.search).toContain('?filters=shared.true%2Cshared.false%2CtenantId.college');
       });

--- a/src/components/BrowseResultsList/BrowseResultsList.test.js
+++ b/src/components/BrowseResultsList/BrowseResultsList.test.js
@@ -76,19 +76,19 @@ const mockContext = {
 
 const contributorsData = [
   {
-    "name": "Toth, Josh",
-    "contributorTypeId": [
-      "6e09d47d-95e2-4d8a-831b-f777b8ef6d81"
+    'name': 'Toth, Josh',
+    'contributorTypeId': [
+      '6e09d47d-95e2-4d8a-831b-f777b8ef6d81'
     ],
-    "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a",
-    "isAnchor": false,
-    "totalRecords": 1
+    'contributorNameTypeId': '2b94c631-fca9-4892-a730-03ee529ffe2a',
+    'isAnchor': false,
+    'totalRecords': 1
   },
 ];
 const subjectsData = [
   {
-    "value": "Trivia and miscellanea",
-    "totalRecords": 8
+    'value': 'Trivia and miscellanea',
+    'totalRecords': 8
   },
 ];
 
@@ -129,7 +129,7 @@ describe('BrowseResultsList', () => {
   });
 
   describe.each([
-    { searchOption: browseCallNumberOptions.CALL_NUMBERS, shared: FACETS.SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY  },
+    { searchOption: browseCallNumberOptions.CALL_NUMBERS, shared: FACETS.SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
     { searchOption: browseCallNumberOptions.DEWEY, shared: FACETS.SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
     { searchOption: browseCallNumberOptions.LIBRARY_OF_CONGRESS, shared: FACETS.SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
     { searchOption: browseCallNumberOptions.LOCAL, shared: FACETS.SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
@@ -151,16 +151,16 @@ describe('BrowseResultsList', () => {
             qindex: searchOption,
             query: 'a',
             [shared]: ['true', 'false'],
-            [heldBy]: ["college"],
+            [heldBy]: ['college'],
           },
         });
 
         await act(async () => fireEvent.click(screen.getByText(defaultProps.browseData[2].fullCallNumber)));
 
         expect(history.location.search).toContain('?filters=shared.true%2Cshared.false%2CtenantId.college');
-      })
-    })
-  })
+      });
+    });
+  });
 
   describe('when the search option is Contributors and the Shared and/or HeldBy facets are selected', () => {
     describe('and the user clicks on a record in the list', () => {
@@ -176,7 +176,7 @@ describe('BrowseResultsList', () => {
           filters: {
             qindex: 'contributors',
             contributorsShared: ['true', 'false'],
-            contributorsTenantId: ["college"],
+            contributorsTenantId: ['college'],
           },
           browseData: contributorsData,
         });
@@ -186,11 +186,11 @@ describe('BrowseResultsList', () => {
         expect(history.location.search).toContain(
           '?filters=searchContributors.2b94c631-fca9-4892-a730-03ee529ffe2a%2Cshared.true%2Cshared.false%2CtenantId.college'
         );
-      })
-    })
-  })
+      });
+    });
+  });
 
-  describe(`when the search option is Subjects and the Shared and/or HeldBy facets are selected`, () => {
+  describe('when the search option is Subjects and the Shared and/or HeldBy facets are selected', () => {
     describe('and the user clicks on a record in the list', () => {
       it('should be navigated to the Search lookup with those filters', async () => {
         history = createMemoryHistory({
@@ -204,7 +204,7 @@ describe('BrowseResultsList', () => {
           filters: {
             qindex: 'browseSubjects',
             subjectsShared: ['true', 'false'],
-            subjectsTenantId: ["college"],
+            subjectsTenantId: ['college'],
           },
           browseData: subjectsData,
         });
@@ -212,9 +212,9 @@ describe('BrowseResultsList', () => {
         await act(async () => fireEvent.click(screen.getByText(subjectsData[0].value)));
 
         expect(history.location.search).toContain('?filters=shared.true%2Cshared.false%2CtenantId.college');
-      })
-    })
-  })
+      });
+    });
+  });
 
   describe('when Instance record is linked to an authority record', () => {
     describe('by clicking on the icon of an authority app', () => {

--- a/src/components/BrowseResultsList/getBrowseResultsFormatter.js
+++ b/src/components/BrowseResultsList/getBrowseResultsFormatter.js
@@ -31,9 +31,10 @@ const getTargetRecord = (
   item,
   row,
   browseOption,
+  filters,
 ) => {
   const record = getFullMatchRecord(item, row.isAnchor);
-  const searchParams = getSearchParams(row, browseOption);
+  const searchParams = getSearchParams(row, browseOption, filters);
   const isNotClickable = isRowPreventsClick(row, browseOption);
 
   if (isNotClickable) return record;
@@ -98,12 +99,13 @@ const renderMarcAuthoritiesLink = (authorityId, content) => {
 const getBrowseResultsFormatter = ({
   data,
   browseOption,
+  filters,
 }) => {
   return {
     title: r => getFullMatchRecord(r.instance?.title, r.isAnchor),
     subject: r => {
       if (r?.totalRecords) {
-        const subject = getTargetRecord(r?.value, r, browseOption);
+        const subject = getTargetRecord(r?.value, r, browseOption, filters);
         if (browseOption === browseModeOptions.SUBJECTS && r.authorityId) {
           return renderMarcAuthoritiesLink(r.authorityId, subject);
         }
@@ -114,13 +116,13 @@ const getBrowseResultsFormatter = ({
     },
     callNumber: r => {
       if (r?.instance || r?.totalRecords) {
-        return getTargetRecord(r?.fullCallNumber, r, browseOption);
+        return getTargetRecord(r?.fullCallNumber, r, browseOption, filters);
       }
       return <MissedMatchItem query={r.fullCallNumber} />;
     },
     contributor: r => {
       if (r?.totalRecords) {
-        const fullMatchRecord = getTargetRecord(r.name, r, browseOption);
+        const fullMatchRecord = getTargetRecord(r.name, r, browseOption, filters);
 
         if (browseOption === browseModeOptions.CONTRIBUTORS && r.authorityId) {
           return renderMarcAuthoritiesLink(r.authorityId, fullMatchRecord);

--- a/src/components/BrowseResultsList/utils.js
+++ b/src/components/BrowseResultsList/utils.js
@@ -17,10 +17,9 @@ export const isRowPreventsClick = (row, browseOption) => {
   );
 };
 
-// [true, false] => 'shared.true,shared.false'
 const facetsToString = (filters, facetNameInBrowse, facetNameInSearch) => {
   return filters[facetNameInBrowse]?.map(value => `${facetNameInSearch}.${value}`).join(',');
-}
+};
 
 const getExtraFilters = (row, qindex, allFilters) => {
   const filtersOnly = omit(allFilters, 'qindex', 'query');
@@ -51,7 +50,7 @@ const getExtraFilters = (row, qindex, allFilters) => {
   const extraFacetsString = [...extraFacets, sharedExtraFacets, heldByExtraFacets].filter(Boolean).join(',');
 
   return extraFacetsString ? { filters: extraFacetsString } : {};
-}
+};
 
 export const getSearchParams = (row, qindex, allFilters) => {
   const filters = getExtraFilters(row, qindex, allFilters);

--- a/src/components/BrowseResultsList/utils.js
+++ b/src/components/BrowseResultsList/utils.js
@@ -1,4 +1,7 @@
+import omit from 'lodash/omit';
+
 import {
+  browseCallNumberOptions,
   browseModeOptions,
   FACETS,
   queryIndexes,
@@ -14,45 +17,90 @@ export const isRowPreventsClick = (row, browseOption) => {
   );
 };
 
-export const getSearchParams = (row, qindex) => {
+// [true, false] => 'shared.true,shared.false'
+const facetsToString = (filters, facetNameInBrowse, facetNameInSearch) => {
+  return filters[facetNameInBrowse]?.map(value => `${facetNameInSearch}.${value}`).join(',');
+}
+
+const getExtraFilters = (row, qindex, allFilters) => {
+  const filtersOnly = omit(allFilters, 'qindex', 'query');
+  const extraFacets = [];
+
+  let sharedFacetName;
+  let heldByFacetName;
+
+  if (qindex === browseModeOptions.SUBJECTS) {
+    sharedFacetName = FACETS.SUBJECTS_SHARED;
+    heldByFacetName = FACETS.SUBJECTS_HELD_BY;
+
+    if (row.authorityId) {
+      extraFacets.push(`${FACETS.AUTHORITY_ID}.${row.authorityId}`);
+    }
+  } else if (qindex === browseModeOptions.CONTRIBUTORS) {
+    sharedFacetName = FACETS.CONTRIBUTORS_SHARED;
+    heldByFacetName = FACETS.CONTRIBUTORS_HELD_BY;
+
+    extraFacets.push(`${FACETS.SEARCH_CONTRIBUTORS}.${row.contributorNameTypeId}`);
+  } else if (Object.values(browseCallNumberOptions).includes(qindex)) {
+    sharedFacetName = FACETS.SHARED;
+    heldByFacetName = FACETS.CALL_NUMBERS_HELD_BY;
+  }
+
+  const sharedExtraFacets = facetsToString(filtersOnly, sharedFacetName, FACETS.SHARED);
+  const heldByExtraFacets = facetsToString(filtersOnly, heldByFacetName, FACETS.HELD_BY);
+  const extraFacetsString = [...extraFacets, sharedExtraFacets, heldByExtraFacets].filter(Boolean).join(',');
+
+  return extraFacetsString ? { filters: extraFacetsString } : {};
+}
+
+export const getSearchParams = (row, qindex, allFilters) => {
+  const filters = getExtraFilters(row, qindex, allFilters);
+
   const optionsMap = {
     [browseModeOptions.CALL_NUMBERS]: {
       qindex: queryIndexes.CALL_NUMBER,
       query: row.shelfKey,
+      ...filters,
     },
     [browseModeOptions.DEWEY]: {
       qindex: queryIndexes.CALL_NUMBER,
       query: row.shelfKey,
+      ...filters,
     },
     [browseModeOptions.LIBRARY_OF_CONGRESS]: {
       qindex: queryIndexes.CALL_NUMBER,
       query: row.shelfKey,
+      ...filters,
     },
     [browseModeOptions.LOCAL]: {
       qindex: queryIndexes.CALL_NUMBER,
       query: row.shelfKey,
+      ...filters,
     },
     [browseModeOptions.NATIONAL_LIBRARY_OF_MEDICINE]: {
       qindex: queryIndexes.CALL_NUMBER,
       query: row.shelfKey,
+      ...filters,
     },
     [browseModeOptions.OTHER]: {
       qindex: queryIndexes.CALL_NUMBER,
       query: row.shelfKey,
+      ...filters,
     },
     [browseModeOptions.SUPERINTENDENT]: {
       qindex: queryIndexes.CALL_NUMBER,
       query: row.shelfKey,
+      ...filters,
     },
     [browseModeOptions.CONTRIBUTORS]: {
       qindex: queryIndexes.CONTRIBUTOR,
       query: row.name,
-      filters: `${FACETS.SEARCH_CONTRIBUTORS}.${row.contributorNameTypeId}`,
+      ...filters,
     },
     [browseModeOptions.SUBJECTS]: {
       qindex: queryIndexes.SUBJECT,
       query: row.value,
-      ...(row.authorityId && { filters: `${FACETS.AUTHORITY_ID}.${row.authorityId}` }),
+      ...filters,
     },
   };
 

--- a/src/components/BrowseResultsPane/BrowseResultsPane.js
+++ b/src/components/BrowseResultsPane/BrowseResultsPane.js
@@ -91,6 +91,7 @@ const BrowseResultsPane = ({
         isLoading={isFetching}
         pagination={pagination}
         totalRecords={totalRecords}
+        filters={filters}
       />
     </Pane>
   );


### PR DESCRIPTION

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
If Shared & Held by facets were selected in the Browse search, then retain them in the Search lookup after clicking the record.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-2608](https://issues.folio.org/browse/UIIN-2608)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots



https://github.com/folio-org/ui-inventory/assets/77053927/15837da1-a81e-46c8-b560-9fcf164b5263





<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
