### PR TITLE
UIIN-2533: Show facet options, if they exist, after clicking the +More button.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-inventory
 
+## [10.0.1](IN PROGRESS)
+* Show facet options, if they exist, after clicking the +More button. Refs UIIN-2533.
+
 ## [10.0.0](https://github.com/folio-org/ui-inventory/tree/v10.0.0) (2023-10-13)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.12...v10.0.0)
 

--- a/src/components/CheckboxFacet/CheckboxFacetList.js
+++ b/src/components/CheckboxFacet/CheckboxFacetList.js
@@ -52,23 +52,25 @@ function CheckboxFacetList({
           <FormattedMessage id="ui-inventory.noMatchingOptions" />
         }
 
-        {!isPending && dataOptions.map(({ count, value, label, disabled, readOnly }) => {
-          const name = typeof label === 'string' ? label : value;
-          return (
-            <Checkbox
-              id={`clickable-filter-${fieldName}-${kebabCase(name)}`}
-              data-test-checkbox-filter-data-option={value}
-              key={value}
-              label={label}
-              labelInfo={count}
-              name={name}
-              disabled={disabled}
-              readOnly={readOnly}
-              checked={selectedValues.includes(value)}
-              onChange={onChange(value)}
-            />
-          );
-        })}
+        {!isPending && dataOptions
+          .filter(({ isDeleted }) => !isDeleted)
+          .map(({ count, value, label, disabled, readOnly }) => {
+            const name = typeof label === 'string' ? label : value;
+            return (
+              <Checkbox
+                id={`clickable-filter-${fieldName}-${kebabCase(name)}`}
+                data-test-checkbox-filter-data-option={value}
+                key={value}
+                label={label}
+                labelInfo={count}
+                name={name}
+                disabled={disabled}
+                readOnly={readOnly}
+                checked={selectedValues.includes(value)}
+                onChange={onChange(value)}
+              />
+            );
+          })}
       </div>
 
       {!isPending && showMore && (

--- a/src/components/CheckboxFacet/CheckboxFacetList.test.js
+++ b/src/components/CheckboxFacet/CheckboxFacetList.test.js
@@ -38,6 +38,7 @@ const dataOptions = [
     label: 'Check Box 2',
     value: 'checkBox2',
   },
+  { id: 'fakeId', isDeleted: true },
 ];
 const selectedValues = ['checkBox1'];
 const fieldName = 'testFacet';
@@ -122,5 +123,25 @@ describe('CheckboxFacetList', () => {
     );
     const checkBoxs = screen.findAllByRole('checkbox');
     expect(checkBoxs).toMatchObject({});
+  });
+
+  it('should not render deleted options', () => {
+    render(
+      <CheckboxFacetList
+        dataOptions={dataOptions}
+        selectedValues={selectedValues}
+        showMore={showMore}
+        showSearch={showSearch}
+        onMoreClick={onMoreClick}
+        onSearch={onSearch}
+        onChange={onChange}
+        fieldName={fieldName}
+        isPending={isPending}
+      />,
+    );
+
+    const allOptions = screen.getAllByRole('checkbox').length;
+
+    expect(allOptions).toBe(2);
   });
 });

--- a/src/components/InstanceFilters/InstanceFilters.js
+++ b/src/components/InstanceFilters/InstanceFilters.js
@@ -444,6 +444,9 @@ const InstanceFilters = props => {
           selectedValues={activeFilters[FACETS.STATUS]}
           isPending={getIsPending(FACETS.STATUS)}
           onChange={onChange}
+          isFilterable
+          onSearch={handleFilterSearch}
+          onFetch={handleFetchFacets}
         />
       </Accordion>
       <Accordion

--- a/src/facetUtils.js
+++ b/src/facetUtils.js
@@ -62,6 +62,11 @@ export const getFacetOptions = (selectedFiltersId, entries, facetData, key, pars
     if (facet) {
       const option = parse(facetDataMap.get(entry.id), entry.totalRecords);
       accum.push(option);
+    } else {
+      accum.push({
+        id: entry.id,
+        isDeleted: true,
+      });
     }
     return accum;
   }, []);

--- a/src/facetUtils.test.js
+++ b/src/facetUtils.test.js
@@ -43,6 +43,7 @@ describe('getFacetOptions', () => {
     const key = 'id';
     const expectedOptions = [
       { label: 'Filter 1', value: 'filter1', count: 2 },
+      { id: 'invalid', isDeleted: true },
       { label: 'Filter 2', value: 'filter2', count: 0 },
     ];
     expect(getFacetOptions(selectedFiltersId, entries, facetData, key)).toEqual(expectedOptions);


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Show facet options, if they exist, after clicking the `+More` button.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
BE currently returns 6 options for the facet, but some of them may have already been removed. There is no way to fix it on the BE side. The UI was now looking at these 6 options in the data and displaying a `+More` button if all 6 options existed. Because there are only 5 options, the `+More` button doesn't appear in the UI.

After this PR, if the BE returns 6 options for the facet and some of them cannot be found in the data (deleted), we display the `+More` button, just do not render the deleted options, which we mark as `isDeleted`.

Added `isFilterable`, `onSearch`, `onFetch` props to be able to filter options via the facet's input field.

<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-2533](https://issues.folio.org/browse/UIIN-2533)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots




https://github.com/folio-org/ui-inventory/assets/77053927/b1fc23d8-6ac2-4c48-844a-ce2edc894130






<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
