### PR TITLE
UIIN-2588: Edit instance success toast no longer shows the instance HRID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Instance 3rd pane: Adjust behavior when returning to instance from holdings/item full screen. Refs UIIN-2453.
 * Consortial holdings accordion is not appearing after the sharing of Instance. Fixes UIIN-2629.
+* Edit instance success toast no longer shows the instance HRID. Fixes UIIN-2588.
 
 ## [10.0.0](https://github.com/folio-org/ui-inventory/tree/v10.0.0) (2023-10-13)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.12...v10.0.0)

--- a/src/Instance/InstanceEdit/InstanceEdit.js
+++ b/src/Instance/InstanceEdit/InstanceEdit.js
@@ -54,13 +54,13 @@ const InstanceEdit = ({
 
   const goBack = useGoBack(`/inventory/view/${instanceId}`);
 
-  const onSuccess = useCallback((updatedInstance) => {
+  const onSuccess = useCallback(() => {
     const message = instance?.shared ? (
       <FormattedMessage id="ui-inventory.instance.shared.successfulySaved" />
     ) : (
       <FormattedMessage
         id="ui-inventory.instance.successfullySaved"
-        values={{ hrid: updatedInstance.hrid }}
+        values={{ hrid: instance.hrid }}
       />
     );
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Non-consortial tenant and consortial member tenant success toasts no longer show the Instance HRID.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Get instance hrid from a component state instead of from the response, because response contains no body

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://issues.folio.org/browse/UIIN-2588

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
