### PR TITLE
UIIN-2601: Instance. Series heading has vanished in detailed view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Reset CheckboxFacet state.more when user resets search form and fewer facet options are loaded. Fixes UIIN-2531.
 * Edit instance success toast no longer shows the instance HRID. Fixes UIIN-2588.
 * Show facet options, if they exist, after clicking the +More button. Refs UIIN-2533.
+* Instance. Series heading has vanished in detailed view. Fixes UIIN-2601.
 
 ## [10.0.0](https://github.com/folio-org/ui-inventory/tree/v10.0.0) (2023-10-13)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.12...v10.0.0)

--- a/src/Instance/InstanceDetails/InstanceTitleData/InstanceTitleData.js
+++ b/src/Instance/InstanceDetails/InstanceTitleData/InstanceTitleData.js
@@ -29,10 +29,13 @@ const InstanceTitleData = ({
 }) => {
   const precedingTitles = useMemo(() => {
     return checkIfArrayIsEmpty(instance.precedingTitles);
-  }, [instance]);
+  }, [instance.precedingTitles]);
   const succeedingTitles = useMemo(() => {
     return checkIfArrayIsEmpty(instance.succeedingTitles);
-  }, [instance]);
+  }, [instance.succeedingTitles]);
+  const seriesStatements = useMemo(() => {
+    return checkIfArrayIsEmpty(instance.series);
+  }, [instance.series]);
 
   return (
     <Accordion
@@ -67,7 +70,7 @@ const InstanceTitleData = ({
       </Row>
 
       <TitleSeriesStatements
-        seriesStatements={instance.series}
+        seriesStatements={seriesStatements}
         source={instance.source}
         segment={segment}
       />


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
In Nolana the Series heading is displaying as expected, but in Orchid Bugfest environment the Series heading has vanished from the detailed view. It was broken after [UIIN-2311](https://issues.folio.org/browse/UIIN-2311).

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- use `checkIfArrayIsEmpty` to check whether there is some series info or not

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://issues.folio.org/browse/UIIN-2601

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
<img width="550" alt="image" src="https://github.com/folio-org/ui-inventory/assets/55138456/774a1c32-44fb-47af-b119-91c1518b69aa">
