### PR TITLE
UIIN-2628: Optimistic locking message not working for instances in non-consortial tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Show facet options, if they exist, after clicking the +More button. Refs UIIN-2533.
 * If Shared & Held by facets were selected in the Browse search, then retain them in the Search lookup after clicking the record. Refs UIIN-2608.
 * Instance. Series heading has vanished in detailed view. Fixes UIIN-2601.
+* Optimistic locking message not working for instances in non-consortial tenant. Fixes UIIN-2628.
 
 ## [10.0.0](https://github.com/folio-org/ui-inventory/tree/v10.0.0) (2023-10-13)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.12...v10.0.0)

--- a/src/Instance/InstanceEdit/InstanceEdit.js
+++ b/src/Instance/InstanceEdit/InstanceEdit.js
@@ -72,22 +72,20 @@ const InstanceEdit = ({
   }, [callout, goBack]);
 
   const onError = async error => {
-    const parsedError = await parseHttpError(error);
+    const response = await error.response;
+    const parsedError = await parseHttpError(response);
     setHttpError(parsedError);
   };
 
   const isMemberTenant = checkIfUserInMemberTenant(stripes);
   const tenantId = (isMemberTenant && instance?.shared) ? stripes.user.user.consortium.centralTenantId : stripes.okapi.tenant;
 
-  const { mutateInstance } = useInstanceMutation({
-    options: { onSuccess, onError },
-    tenantId,
-  });
+  const { mutateInstance } = useInstanceMutation({ tenantId });
 
   const onSubmit = useCallback((initialInstance) => {
     const updatedInstance = marshalInstance(initialInstance, identifierTypesByName);
 
-    return mutateInstance(updatedInstance);
+    return mutateInstance(updatedInstance, { onSuccess, onError });
   }, [mutateInstance]);
 
   if (isInstanceLoading) return <LoadingView />;

--- a/src/hooks/useInstanceMutation/useInstanceMutation.js
+++ b/src/hooks/useInstanceMutation/useInstanceMutation.js
@@ -5,18 +5,18 @@ import { useTenantKy } from '../../common';
 const useInstanceMutation = ({ tenantId, options = {} }) => {
   const ky = useTenantKy({ tenantId });
 
-  const { mutateAsync } = useMutation({
+  const { mutate } = useMutation({
     mutationFn: (instance) => {
       const kyMethod = instance.id ? 'put' : 'post';
       const kyPath = instance.id ? `inventory/instances/${instance.id}` : 'inventory/instances';
 
-      return ky[kyMethod](kyPath, { json: instance });
+      return ky[kyMethod](kyPath, { json: instance }).json();
     },
     ...options,
   });
 
   return {
-    mutateInstance: mutateAsync,
+    mutateInstance: mutate,
   };
 };
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Optimistic locking message for an instance in a non-consortial tenant is not displaying properly.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Use `mutate` func instead of `mutateAsync` to mutate Instance
- Fix handling errors during instance mutation

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://issues.folio.org/browse/UIIN-2628

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-inventory/assets/55138456/58511b86-1214-4958-b878-a80780a32b14

