### PR TITLE
UIIN-2635: Create new instance success toast no longer shows the instance HRID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Instance. Series heading has vanished in detailed view. Fixes UIIN-2601.
 * Remove error message after switch from Instance Edit screen to another app. Fixes UIIN-2600.
 * Enable/disable consortial holdings/item actions based on User permissions. Refs UIIN-2452.
+* Create new instance success toast no longer shows the instance HRID. Fixes UIIN-2635.
 
 ## [10.0.0](https://github.com/folio-org/ui-inventory/tree/v10.0.0) (2023-10-13)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.12...v10.0.0)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -960,9 +960,9 @@ class ViewInstance extends React.Component {
 
             <Callout ref={this.calloutRef} />
 
-            {this.state.afterCreate &&
+            {this.state.afterCreate && !isEmpty(instance) &&
               <CalloutRenderer
-                message={<FormattedMessage id="ui-inventory.instance.successfullySaved" values={{ hrid: instance?.hrid }} />}
+                message={<FormattedMessage id="ui-inventory.instance.successfullySaved" values={{ hrid: instance.hrid }} />}
               />
             }
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
 When creating a new instance then success toast does not contain HRID info.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Wait until the instance is fetched before displaying the success toast.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://issues.folio.org/browse/UIIN-2635

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
