### PR TITLE
UIIN-2634: Remove error when search for an item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Instance. Series heading has vanished in detailed view. Fixes UIIN-2601.
 * Remove error message after switch from Instance Edit screen to another app. Fixes UIIN-2600.
 * Enable/disable consortial holdings/item actions based on User permissions. Refs UIIN-2452.
+* User receives an error when searching for an item in the Inventory app. Fixes UIIN-2634.
 
 ## [10.0.0](https://github.com/folio-org/ui-inventory/tree/v10.0.0) (2023-10-13)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v9.4.12...v10.0.0)

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -479,9 +479,10 @@ class ViewHoldingsRecord extends React.Component {
       referenceTables,
       goTo,
       stripes,
-      location: { state: { tenantFrom } },
+      location,
     } = this.props;
     const { instance } = this.state;
+    const tenantFrom = location?.state?.tenantFrom || stripes.okapi.tenant;
 
     if (this.isAwaitingResource()) return <LoadingView />;
 

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -16,6 +16,7 @@ import {
 import saveAs from 'file-saver';
 import moment from 'moment';
 import classnames from 'classnames';
+import { stringify } from 'query-string';
 
 import {
   Pluggable,
@@ -134,6 +135,7 @@ class InstancesList extends React.Component {
     }),
     stripes: PropTypes.object.isRequired,
     history: PropTypes.shape({
+      push: PropTypes.func,
       listen: PropTypes.func,
       replace: PropTypes.func,
     }),
@@ -956,8 +958,9 @@ class InstancesList extends React.Component {
     const {
       parentResources,
       parentMutator: { itemsByQuery },
-      goTo,
       getParams,
+      stripes,
+      history,
     } = this.props;
     const { query, qindex } = parentResources?.query ?? {};
     const { searchInProgress } = this.state;
@@ -973,7 +976,10 @@ class InstancesList extends React.Component {
     }
 
     itemsByQuery.reset();
-    const items = await itemsByQuery.GET({ params: { query: itemQuery } });
+    const items = await itemsByQuery.GET({
+      params: { query: itemQuery },
+      tenant: stripes.okapi.tenant,
+    });
 
     this.setState({ searchInProgress: false });
 
@@ -984,7 +990,13 @@ class InstancesList extends React.Component {
     }
 
     const { id, holdingsRecordId } = items[0];
-    goTo(`/inventory/view/${instance.id}/${holdingsRecordId}/${id}`, getParams());
+    const search = stringify(getParams());
+
+    history.push({
+      pathname: `/inventory/view/${instance.id}/${holdingsRecordId}/${id}`,
+      search,
+      state: { tenantTo: stripes.okapi.tenant },
+    });
 
     return null;
   }

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -559,6 +559,7 @@ describe('InstancesList', () => {
             params: {
               query: `${option}=="${_query}"`,
             },
+            tenant: 'diku',
           });
         });
       });

--- a/src/routes/ItemRoute.js
+++ b/src/routes/ItemRoute.js
@@ -174,8 +174,9 @@ class ItemRoute extends React.Component {
   onClose = () => {
     const {
       stripes,
-      location: { state: { tenantFrom } },
+      location,
     } = this.props;
+    const tenantFrom = location?.state?.tenantFrom || stripes.okapi.tenant;
 
     switchAffiliation(stripes, tenantFrom, this.goBack);
   }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
* User receives an error when searching for an item in the Inventory app.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Added `state` prop to `history.push` to allow reading `tenant: '!{location.state.tenantTo}',` in `ItemRoute`'s manifest
* Execute `itemsByQuery.GET` request with current tenant

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-2634](https://issues.folio.org/browse/UIIN-2634)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-inventory/assets/85172747/85bb0d38-e414-4738-a9b6-c2fcf68a4301

