### PR TITLE
UIIN-2493 Make Inventory search and browse query boxes expandable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## [10.1.0] IN PROGRESS
 
+* Make Inventory search and browse query boxes expandable. Refs UIIN-2493.
 
 ## [10.0.1] IN PROGRESS
 

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -1178,6 +1178,7 @@ class InstancesList extends React.Component {
             searchableIndexesPlaceholder={null}
             initialResultCount={INITIAL_RESULT_COUNT}
             initiallySelectedRecord={getItem(`${namespace}.${segment}.lastOpenRecord`)}
+            inputType="textarea"
             resultCountIncrement={RESULT_COUNT_INCREMENT}
             viewRecordComponent={ViewInstanceWrapper}
             editRecordComponent={InstanceForm}

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -458,10 +458,10 @@ describe('InstancesList', () => {
       it('should have query in search input', () => {
         renderInstancesList({ segment: 'instances' });
 
-        fireEvent.change(screen.getByRole('searchbox', { name: 'Search' }), { target: { value: 'search query' } });
+        fireEvent.change(screen.getByRole('textbox', { name: 'Search' }), { target: { value: 'search query' } });
         fireEvent.click(screen.getAllByRole('button', { name: 'Search' })[1]);
 
-        expect(screen.getByRole('searchbox', { name: 'Search' })).toHaveValue('search query');
+        expect(screen.getByRole('textbox', { name: 'Search' })).toHaveValue('search query');
       });
 
       describe('when the search option is changed', () => {
@@ -549,7 +549,7 @@ describe('InstancesList', () => {
 
           await act(async () => fireEvent.change(screen.getByLabelText('Search field index'), { target: { value: qindex } }));
 
-          fireEvent.change(screen.getByRole('searchbox', { name: 'Search' }), { target: { value: _query } });
+          fireEvent.change(screen.getByRole('textbox', { name: 'Search' }), { target: { value: _query } });
           fireEvent.click(screen.getAllByRole('button', { name: 'Search' })[1]);
 
           const row = screen.getAllByText('ABA Journal')[0];

--- a/src/views/BrowseInventory/BrowseInventory.js
+++ b/src/views/BrowseInventory/BrowseInventory.js
@@ -159,6 +159,7 @@ const BrowseInventory = () => {
             changeSearchIndex={onChangeSearchIndex}
             selectedIndex={searchIndex}
             searchableIndexesPlaceholder={searchableIndexesPlaceholder}
+            inputType="textarea"
           />
 
           <ResetButton

--- a/src/views/BrowseInventory/BrowseInventory.test.js
+++ b/src/views/BrowseInventory/BrowseInventory.test.js
@@ -163,7 +163,7 @@ describe('BrowseInventory', () => {
   it('should call "changeSearch" when search query was changed', async () => {
     const { container } = renderBrowseInventory();
 
-    await act(async () => userEvent.type(screen.getByRole('searchbox'), 'newQuery'));
+    await act(async () => userEvent.type(screen.getByRole('textbox'), 'newQuery'));
     await act(async () => userEvent.click(container.querySelector('[data-test-single-search-form-submit="true"]')));
 
     expect(applySearch).toHaveBeenCalled();


### PR DESCRIPTION
## Description
Make Inventory search and browse query boxes expandable

## Screenshots

https://github.com/folio-org/ui-inventory/assets/19309423/e8a4ffd2-92bb-404f-bf1a-30629155d452

## Issues
[UIIN-2493](https://issues.folio.org/browse/UIIN-2493)

## Related PRs
https://github.com/folio-org/stripes-smart-components/pull/1407