### PR TITLE
UIIN-2477 Inventory search/browse: Do not retain checkbox selections when toggling search segment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,9 @@
 ## [11.0.0] IN PROGRESS
 
 * *BREAKING* Replace imports from quick-marc with stripes-marc-components. Refs UIIN-2636.
-
-## [10.1.0] IN PROGRESS
-
 * Make Inventory search and browse query boxes expandable. Refs UIIN-2493.
 * Added support for `containsAny` match option in Advanced search. Refs UIIN-2486.
+* Inventory search/browse: Do not retain checkbox selections when toggling search segment. Refs UIIN-2477.
 
 ## [10.0.1] IN PROGRESS
 

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -393,6 +393,11 @@ class InstancesList extends React.Component {
     document.getElementById('input-inventory-search').focus();
   }
 
+  handleSearchSegmentChange = (segment) => {
+    this.refocusOnInputSearch(segment);
+    this.setState({ selectedRows: {} });
+  }
+
   onSearchModeSwitch = () => {
     const {
       namespace,
@@ -415,7 +420,7 @@ class InstancesList extends React.Component {
       />
       <FilterNavigation
         segment={this.props.segment}
-        onChange={this.refocusOnInputSearch}
+        onChange={this.handleSearchSegmentChange}
       />
     </>
   );

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -221,6 +221,22 @@ describe('InstancesList', () => {
       });
     });
 
+    describe('when search segment is changed', () => {
+      it('should clear selected rows', () => {
+        const {
+          getAllByLabelText,
+          getByText,
+        } = renderInstancesList({
+          segment: 'instances',
+        });
+
+        fireEvent.click(getAllByLabelText('Select instance')[0]);
+        fireEvent.click(getByText('Holdings'));
+
+        expect(getAllByLabelText('Select instance')[0].checked).toBeFalsy();
+      });
+    });
+
     describe('when a user performs a search and clicks the `Next` button in the list of records', () => {
       describe('then clicks on the `Browse` lookup tab and then clicks `Search` lookup tab', () => {
         it('should avoid infinity loading by resetting the records on unmounting', () => {


### PR DESCRIPTION
## Description
Inventory search/browse: Do not retain checkbox selections when toggling search segment

## Screenshots

https://github.com/folio-org/ui-inventory/assets/19309423/1c452061-80a3-4964-8ca8-ec4af570a1d7

## Issues
[UIIN-2477](https://issues.folio.org/browse/UIIN-2477)