### PR TITLE
UIIN-2514: Search box/Browse box- Reset all should shift focus back to search box 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Make Inventory search and browse query boxes expandable. Refs UIIN-2493.
 * Added support for `containsAny` match option in Advanced search. Refs UIIN-2486.
 * Inventory search/browse: Do not retain checkbox selections when toggling search segment. Refs UIIN-2477.
+* Search box/Browse box- Reset all should shift focus back to search box. Refs UIIN-2514.
 
 ## [10.0.3] IN PROGRESS
 

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -173,6 +173,7 @@ class InstancesList extends React.Component {
     };
   }
 
+
   componentDidMount() {
     const {
       history,
@@ -185,7 +186,7 @@ class InstancesList extends React.Component {
       if (hasReset) {
         // imperative way is used because it's no option in SearchAndSort reset/focus filters from outside
         document.getElementById('clickable-reset-all')?.click();
-        document.getElementById('input-inventory-search')?.focus();
+        this.inputRef.current.focus();
 
         history.replace({ search: 'segment=instances' });
       }
@@ -221,6 +222,9 @@ class InstancesList extends React.Component {
     this.unlisten();
     parentMutator.records.reset();
   }
+
+  inputRef = React.createRef();
+  indexRef = React.createRef();
 
   extraParamsToReset = {
     selectedBrowseResult: false,
@@ -390,7 +394,7 @@ class InstancesList extends React.Component {
     // https://issues.folio.org/browse/UIIN-1358
     storeLastSegment(segment);
     facetsStore.getState().resetFacetSettings();
-    document.getElementById('input-inventory-search').focus();
+    this.inputRef.current.focus();
   }
 
   handleSearchSegmentChange = (segment) => {
@@ -903,6 +907,7 @@ class InstancesList extends React.Component {
     });
 
     facetsStore.getState().resetFacetSettings();
+    this.inputRef.current.focus();
   }
 
   handleSelectedRecordsModalSave = selectedRecords => {
@@ -1184,6 +1189,8 @@ class InstancesList extends React.Component {
             initialResultCount={INITIAL_RESULT_COUNT}
             initiallySelectedRecord={getItem(`${namespace}.${segment}.lastOpenRecord`)}
             inputType="textarea"
+            inputRef={this.inputRef}
+            indexRef={this.indexRef}
             resultCountIncrement={RESULT_COUNT_INCREMENT}
             viewRecordComponent={ViewInstanceWrapper}
             editRecordComponent={InstanceForm}

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -541,7 +541,7 @@ describe('InstancesList', () => {
           renderInstancesList({ segment: 'instances' });
 
           fireEvent.click(screen.getByRole('button', { name: 'Advanced search' }));
-          indexRef(screen.getAllByRole('textbox', { name: 'Search for' })[0], {
+          fireEvent.change(screen.getAllByRole('textbox', { name: 'Search for' })[0], {
             target: { value: 'test2' }
           });
           const advancedSearchSubmit = screen.getAllByRole('button', { name: 'Search' })[0];
@@ -566,7 +566,7 @@ describe('InstancesList', () => {
         renderInstancesList({ segment: 'instances' });
 
         fireEvent.click(screen.getByRole('button', { name: 'Advanced search' }));
-        indexRef(screen.getAllByRole('textbox', { name: 'Search for' })[0], {
+        fireEvent.change(screen.getAllByRole('textbox', { name: 'Search for' })[0], {
           target: { value: 'test' }
         });
 
@@ -582,7 +582,7 @@ describe('InstancesList', () => {
     it('should show Save Holdings UUIDs button', () => {
       renderInstancesList({ segment: 'holdings' });
 
-      indexRef(screen.getByRole('combobox'), {
+      fireEvent.change(screen.getByRole('combobox'), {
         target: { value: 'all' }
       });
 

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -221,6 +221,20 @@ describe('InstancesList', () => {
       });
     });
 
+    describe('when user clicks Reset all', () => {
+      it('should move focus to query input', () => {
+        renderInstancesList({
+          segment: 'instances',
+        });
+
+        fireEvent.change(screen.getByRole('textbox', { name: 'Search' }), { target: { value: 'test' } });
+        fireEvent.click(screen.getAllByRole('button', { name: 'Search' })[1]);
+        fireEvent.click(screen.getByRole('button', { name: 'Reset all' }));
+
+        expect(screen.getByRole('textbox', { name: 'Search' })).toHaveFocus();
+      });
+    });
+
     describe('when search segment is changed', () => {
       it('should clear selected rows', () => {
         const {
@@ -490,7 +504,7 @@ describe('InstancesList', () => {
           renderInstancesList({ segment: 'instances' });
 
           fireEvent.click(screen.getByRole('button', { name: 'Advanced search' }));
-          fireEvent.change(screen.getAllByRole('textbox', { name: 'Search for' })[0], {
+          indexRef(screen.getAllByRole('textbox', { name: 'Search for' })[0], {
             target: { value: 'test2' }
           });
           const advancedSearchSubmit = screen.getAllByRole('button', { name: 'Search' })[0];
@@ -515,7 +529,7 @@ describe('InstancesList', () => {
         renderInstancesList({ segment: 'instances' });
 
         fireEvent.click(screen.getByRole('button', { name: 'Advanced search' }));
-        fireEvent.change(screen.getAllByRole('textbox', { name: 'Search for' })[0], {
+        indexRef(screen.getAllByRole('textbox', { name: 'Search for' })[0], {
           target: { value: 'test' }
         });
 
@@ -531,7 +545,7 @@ describe('InstancesList', () => {
     it('should show Save Holdings UUIDs button', () => {
       renderInstancesList({ segment: 'holdings' });
 
-      fireEvent.change(screen.getByRole('combobox'), {
+      indexRef(screen.getByRole('combobox'), {
         target: { value: 'all' }
       });
 

--- a/src/views/BrowseInventory/BrowseInventory.js
+++ b/src/views/BrowseInventory/BrowseInventory.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect, useMemo } from 'react';
+import React, { useCallback, useState, useEffect, useMemo, useRef } from 'react';
 import { useIntl } from 'react-intl';
 import { useHistory, useLocation } from 'react-router-dom';
 
@@ -46,6 +46,8 @@ const BrowseInventory = () => {
   const { isFiltersOpened, toggleFilters } = useFiltersToogle(`${namespace}/filters`);
   const { deleteItemToView } = useItemToView('browse');
   const [pageConfig, setPageConfig] = useState(getLastBrowseOffset());
+  const inputRef = useRef();
+
   const { search } = location;
 
   useEffect(() => {
@@ -134,6 +136,11 @@ const BrowseInventory = () => {
     changeSearchIndex(e);
   }, []);
 
+  const onReset = useCallback(() => {
+    resetFilters();
+    inputRef.current.focus();
+  }, [inputRef.current]);
+
   return (
     <PersistedPaneset
       appId={namespace}
@@ -160,10 +167,11 @@ const BrowseInventory = () => {
             selectedIndex={searchIndex}
             searchableIndexesPlaceholder={searchableIndexesPlaceholder}
             inputType="textarea"
+            inputRef={inputRef}
           />
 
           <ResetButton
-            reset={resetFilters}
+            reset={onReset}
             disabled={isResetButtonDisabled}
           />
 

--- a/src/views/BrowseInventory/BrowseInventory.test.js
+++ b/src/views/BrowseInventory/BrowseInventory.test.js
@@ -222,7 +222,7 @@ describe('BrowseInventory', () => {
       renderBrowseInventory();
 
       fireEvent.change(screen.getByRole('combobox'), { target: { value: 'contributors' } });
-      userEvent.type(screen.getByRole('textbox'), 'test')
+      userEvent.type(screen.getByRole('textbox'), 'test');
       fireEvent.click(screen.getByRole('button', { name: 'Search' }));
       fireEvent.click(screen.getByRole('button', { name: 'Reset all' }));
 

--- a/src/views/BrowseInventory/BrowseInventory.test.js
+++ b/src/views/BrowseInventory/BrowseInventory.test.js
@@ -216,4 +216,17 @@ describe('BrowseInventory', () => {
     expect(getByText('Contributors')).toBeDefined();
     expect(getByText('Subjects')).toBeDefined();
   });
+
+  describe('when user clicks on Reset all', () => {
+    it('should move focus to query input', () => {
+      renderBrowseInventory();
+
+      fireEvent.change(screen.getByRole('combobox'), { target: { value: 'contributors' } });
+      userEvent.type(screen.getByRole('textbox'), 'test')
+      fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Reset all' }));
+
+      expect(screen.getByRole('textbox')).toHaveFocus();
+    });
+  });
 });


### PR DESCRIPTION
## Description
Search box/Browse box- Reset all should shift focus back to search box 

Pass refs to `<SearchAndSort>` and use them to focus search box after reset

## Screenshots

https://github.com/folio-org/ui-inventory/assets/19309423/f773b3f2-3103-48cf-90ea-daf70c266dfd



## Issues
[UIIN-2514](https://issues.folio.org/browse/UIIN-2514)

## Related PRs
https://github.com/folio-org/stripes-smart-components/pull/1413
https://github.com/folio-org/stripes-components/pull/2169
https://github.com/folio-org/stripes-acq-components/pull/727