### PR TITLE
UIIN-2658: Switch from = to == operator when querying for holdings-storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 * Added support for `containsAny` match option in Advanced search. Refs UIIN-2486.
 * Inventory search/browse: Do not retain checkbox selections when toggling search segment. Refs UIIN-2477.
 
-
 ## [10.0.3] IN PROGRESS
 
 * ECS: Show info message when user in member tenant tries to view shared instance details without permission. Refs UIIN-2590.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Make Inventory search and browse query boxes expandable. Refs UIIN-2493.
 * Added support for `containsAny` match option in Advanced search. Refs UIIN-2486.
 * Inventory search/browse: Do not retain checkbox selections when toggling search segment. Refs UIIN-2477.
-* Switch from `=` to `==` operator when quering for `holdings-storage/holdings` by hrid. Fixes UIIN-2658.
+* Switch from `=` to `==` operator when querying for `holdings-storage/holdings` by hrid. Fixes UIIN-2658.
 
 ## [10.0.3] IN PROGRESS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Make Inventory search and browse query boxes expandable. Refs UIIN-2493.
 * Added support for `containsAny` match option in Advanced search. Refs UIIN-2486.
 * Inventory search/browse: Do not retain checkbox selections when toggling search segment. Refs UIIN-2477.
+* Switch from `=` to `==` operator when quering for `holdings-storage/holdings` by hrid. Fixes UIIN-2658.
 
 ## [10.0.3] IN PROGRESS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Make Inventory search and browse query boxes expandable. Refs UIIN-2493.
 * Added support for `containsAny` match option in Advanced search. Refs UIIN-2486.
 * Inventory search/browse: Do not retain checkbox selections when toggling search segment. Refs UIIN-2477.
-* Switch from `=` to `==` operator when querying for `holdings-storage/holdings` by hrid. Fixes UIIN-2658.
+
 
 ## [10.0.3] IN PROGRESS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Show only local MARC Authorities when share local instance. Fixes UIIN-2647.
 * Single instance export - MARC files sent to central tenant from member tenant. Fixes UIIN-2613.
 * Fix misspelled Instance notes (all) advanced search query index. Fixes UIIN-2677.
+* Switch from `=` to `==` operator when querying for `holdings-storage/holdings` by hrid. Fixes UIIN-2658.
 
 ## [10.0.2](https://github.com/folio-org/ui-inventory/tree/v10.0.2) (2023-11-07)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.1...v10.0.2)

--- a/src/hooks/useHoldingsQueryByHrids.js
+++ b/src/hooks/useHoldingsQueryByHrids.js
@@ -10,7 +10,7 @@ const useHoldingsQueryByHrids = (holdingsRecordHrids) => {
 
   const { isLoading, data } = useQuery(
     [namespace, queryHrids],
-    () => ky.get(`holdings-storage/holdings?query=hrid=(${queryHrids})`).json(),
+    () => ky.get(`holdings-storage/holdings?query=hrid==(${queryHrids})`).json(),
     { enabled: Boolean(queryHrids) },
   );
 


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-2658

The `=` operator was taking too long to finish in Poppy.

This PR switched from `=` to `==` operator when querying for `holdings-storage/holdings` by hrids. 