### PR TITLE
UIIN-2677 Fix misspelled Instance notes (all) advanced search query index.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * ECS: Show info message when user in member tenant tries to view shared instance details without permission. Refs UIIN-2590.
 * Show only local MARC Authorities when share local instance. Fixes UIIN-2647.
 * Single instance export - MARC files sent to central tenant from member tenant. Fixes UIIN-2613.
+* Fix misspelled Instance notes (all) advanced search query index. Fixes UIIN-2677.
 
 ## [10.0.2](https://github.com/folio-org/ui-inventory/tree/v10.0.2) (2023-11-07)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.1...v10.0.2)

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -132,7 +132,7 @@ export const advancedSearchIndexes = {
     { label: 'ui-inventory.isbn', value: 'isbn' },
     { label: 'ui-inventory.issn', value: 'issn' },
     { label: 'ui-inventory.search.oclc', value: 'oclc' },
-    { label: 'ui-inventory.search.instanceNotes', value: 'isntanceNotes' },
+    { label: 'ui-inventory.search.instanceNotes', value: 'instanceNotes' },
     { label: 'ui-inventory.search.instanceAdministrativeNotes', value: 'instanceAdministrativeNotes' },
     { label: 'ui-inventory.subject', value: 'subject' },
     { label: 'ui-inventory.effectiveCallNumberShelving', value: 'callNumber' },

--- a/src/hooks/useInstanceMutation/useInstanceMutation.test.js
+++ b/src/hooks/useInstanceMutation/useInstanceMutation.test.js
@@ -50,7 +50,7 @@ describe('useInstanceMutation', () => {
       { wrapper },
     );
 
-    await act(async () => { result.current.mutateInstance({ id: 'isntanceId' }); });
+    await act(async () => { result.current.mutateInstance({ id: 'instanceId' }); });
 
     expect(putMock).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Description
Fix misspelled Instance notes (all) advanced search query index.

## Screenshots

https://github.com/folio-org/ui-inventory/assets/19309423/63b06bd4-a650-4a2c-8aff-3874843b4d81

## Issues
[UIIN-2677](https://issues.folio.org/browse/UIIN-2677)