### PR TITLE
UIIN-2682: Handle errors correctly when sharing local instances failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * Show Instance record after creating with Fast add option. Refs UIIN-2497.
 * Search box/Browse box- Reset all should shift focus back to search box. Refs UIIN-2514.
 
+## [10.0.4] IN PROGRESS
+
+* Fetch sharing of local instance status in the context of member tenant. Refs UIIN-2680.
+
 ## [10.0.3] IN PROGRESS
 
 * ECS: Show info message when user in member tenant tries to view shared instance details without permission. Refs UIIN-2590.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## [10.0.4] IN PROGRESS
 
 * Fetch sharing of local instance status in the context of member tenant. Refs UIIN-2680.
+* Handle errors when sharing local instances failed. Refs UIIN-2682.
 
 ## [10.0.3] IN PROGRESS
 

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -45,7 +45,6 @@ import {
   indentifierTypeNames,
   INSTANCE_SHARING_STATUSES,
   layers,
-  OKAPI_TENANT_HEADER,
   REQUEST_OPEN_STATUSES,
 } from './constants';
 import { DataContext } from './contexts';
@@ -447,11 +446,6 @@ class ViewInstance extends React.Component {
   checkInstanceSharingProgress = ({ sourceTenantId, instanceIdentifier }) => {
     return this.props.mutator.shareInstance.GET({
       params: { sourceTenantId, instanceIdentifier },
-      headers: {
-        [OKAPI_TENANT_HEADER]: this.props.centralTenantId,
-        'Content-Type': 'application/json',
-        ...(this.props.okapi.token && { 'X-Okapi-Token': this.props.okapi.token }),
-      },
     });
   }
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
- Adjust handling of failed requests

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Create `renderInstanceDetails` to render details conditionally and have only one `Callout` component in the tree
- Handle errors when fetching `MARC authorities`

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://issues.folio.org/browse/UIIN-2682

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
