### PR TITLE
UIIN-2604 Ignored hot key command on edit fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Search box/Browse box- Reset all should shift focus back to search box. Refs UIIN-2514.
 * Updated translations for adding new Instance records. Refs UIIN-2630.
 * Inactive Holdings/items on Central tenant when user have affiliation for separate Member with 0 permissions. Fixes UIIN-2689.
+* Ignored hot key command on edit fields. Refs UIIN-2604.
 
 ## [10.0.4](https://github.com/folio-org/ui-inventory/tree/v10.0.4) (2023-11-10)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.3...v10.0.4)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -56,7 +56,6 @@ import {
   marshalInstance,
   omitFromArray,
   isTestEnv,
-  handleKeyCommand,
   buildSingleItemQuery,
   isUserInConsortiumMode,
 } from '../../utils';
@@ -1174,11 +1173,15 @@ class InstancesList extends React.Component {
     const shortcuts = [
       {
         name: 'new',
-        handler: handleKeyCommand(() => {
+        handler: (e) => {
+          const nodeName = e.target?.nodeName || '';
+          const editTextField = (nodeName === 'TEXTAREA') || (nodeName === 'INPUT');
+          if (editTextField) return;
+
           if (stripes.hasPerm('ui-inventory.instance.create')) {
             this.openCreateInstance();
           }
-        }),
+        },
       },
     ];
 

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -34,7 +34,6 @@ import {
   Checkbox,
   MenuSection,
   Select,
-  checkScope,
   HasCommand,
   MCLPagingTypes,
   TextLink,
@@ -56,6 +55,7 @@ import {
   marshalInstance,
   omitFromArray,
   isTestEnv,
+  handleKeyCommand,
   buildSingleItemQuery,
   isUserInConsortiumMode,
 } from '../../utils';
@@ -1173,17 +1173,19 @@ class InstancesList extends React.Component {
     const shortcuts = [
       {
         name: 'new',
-        handler: (e) => {
-          const nodeName = e.target?.nodeName || '';
-          const isEditTextField = (nodeName === 'TEXTAREA') || (nodeName === 'INPUT');
-          if (isEditTextField) return;
-
+        handler: handleKeyCommand(() => {
           if (stripes.hasPerm('ui-inventory.instance.create')) {
             this.openCreateInstance();
           }
-        },
+        }),
       },
     ];
+
+    const checkScope = () => {
+      const ignoreElements = ['TEXTAREA', 'INPUT'];
+
+      return !ignoreElements.includes(document.activeElement.tagName);
+    };
 
     return (
       <HasCommand

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -1175,8 +1175,8 @@ class InstancesList extends React.Component {
         name: 'new',
         handler: (e) => {
           const nodeName = e.target?.nodeName || '';
-          const editTextField = (nodeName === 'TEXTAREA') || (nodeName === 'INPUT');
-          if (editTextField) return;
+          const isEditTextField = (nodeName === 'TEXTAREA') || (nodeName === 'INPUT');
+          if (isEditTextField) return;
 
           if (stripes.hasPerm('ui-inventory.instance.create')) {
             this.openCreateInstance();


### PR DESCRIPTION
Ignored hot key command  (ALT + n) on edit fields.

## Purpose
Prevent execute hot key command on edit fields to able input special characters like polish "ń" 

## Approach
By detect target event is edit field 

## Refs
[UIIN-2604](https://issues.folio.org/browse/UIIN-2604)

## Screenshots

![Inventory_polish_special_charakter_alt_n](https://github.com/folio-org/ui-inventory/assets/128044179/1400d528-ce42-4964-b720-9eeca60c46b7)
