### PR TITLE
UIIN-2685 Remove sort parameter from requests to facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Inactive Holdings/items on Central tenant when user have affiliation for separate Member with 0 permissions. Fixes UIIN-2689.
 * Ignored hot key command on edit fields. Refs UIIN-2604.
 * Don't render Fast Add record modal in a `<Paneset>` to re-calculate other `<Pane>`'s widths after closing. Fixes UIIN-2690.
+* Don't include `sort` parameter in requests to facets. Fixes UIIN-2685.
 
 ## [10.0.4](https://github.com/folio-org/ui-inventory/tree/v10.0.4) (2023-11-10)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.3...v10.0.4)

--- a/src/withFacets.js
+++ b/src/withFacets.js
@@ -189,7 +189,7 @@ function withFacets(WrappedComponent) {
       } = mutator.facets;
 
       // Browse page does not use query resource: query params are stored in "activeFilters" of "useLocationFilters" hook
-      const query = resources.query || this.props.activeFilters;
+      const query = omit(resources.query || this.props.activeFilters, ['sort']);
 
       // temporary query value
       const params = { query: 'id = *' };

--- a/src/withFacets.test.js
+++ b/src/withFacets.test.js
@@ -42,6 +42,67 @@ describe('withFacets', () => {
     jest.clearAllMocks();
   });
 
+  describe('when query contains sort parameter', () => {
+    it('should remove the sort parameter from request', () => {
+      const resources = {
+        query: {
+          qindex: browseModeOptions.CONTRIBUTORS,
+          query: '',
+          sort: 'relevance',
+        },
+      };
+
+      const { getByText } = render(
+        <FacetsHoc
+          mutator={mutator}
+          resources={resources}
+          properties={{ facetToOpen: FACETS.CONTRIBUTORS_SHARED }}
+          isBrowseLookup
+        />
+      );
+
+      fireEvent.click(getByText('fetchFacetsButton'));
+
+      expect(mutator.facets.GET).toHaveBeenCalledWith(expect.objectContaining({
+        params: {
+          facet: `${FACETS_CQL.INSTANCES_SHARED}:6`,
+          query: '(cql.allRecords=1)',
+        },
+        path: 'search/contributors/facets',
+      }));
+    });
+  });
+
+  describe('when active filters contain sort parameter', () => {
+    it('should remove the sort parameter from request', () => {
+      const activeFilters = {
+        qindex: browseModeOptions.CONTRIBUTORS,
+        query: '',
+        sort: 'relevance',
+      };
+
+      const { getByText } = render(
+        <FacetsHoc
+          mutator={mutator}
+          resources={{}}
+          activeFilters={activeFilters}
+          properties={{ facetToOpen: FACETS.CONTRIBUTORS_SHARED }}
+          isBrowseLookup
+        />
+      );
+
+      fireEvent.click(getByText('fetchFacetsButton'));
+
+      expect(mutator.facets.GET).toHaveBeenCalledWith(expect.objectContaining({
+        params: {
+          facet: `${FACETS_CQL.INSTANCES_SHARED}:6`,
+          query: '(cql.allRecords=1)',
+        },
+        path: 'search/contributors/facets',
+      }));
+    });
+  });
+
   describe('when opening a contributots shared facet', () => {
     describe('and there are no selected options in other facets', () => {
       it('should make a request with correct request options', () => {


### PR DESCRIPTION
## Description
Remove unsupported `sort` parameter from requests to facets

## Screenshots

https://github.com/folio-org/ui-inventory/assets/19309423/500483dd-73b3-4276-a111-5f0b5ef69389

## Issues
[UIIN-2685](https://issues.folio.org/browse/UIIN-2685)