### PR TITLE
UIIN-2686: "Saving instance failed" modal does not show error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Ignored hot key command on edit fields. Refs UIIN-2604.
 * Don't render Fast Add record modal in a `<Paneset>` to re-calculate other `<Pane>`'s widths after closing. Fixes UIIN-2690.
 * Don't include `sort` parameter in requests to facets. Fixes UIIN-2685.
+* "Saving instance failed" modal does not show error message. Fixes UIIN-2686.
 
 ## [10.0.4](https://github.com/folio-org/ui-inventory/tree/v10.0.4) (2023-11-10)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.3...v10.0.4)

--- a/src/Instance/InstanceEdit/InstanceEdit.css
+++ b/src/Instance/InstanceEdit/InstanceEdit.css
@@ -1,0 +1,4 @@
+.errorModalContent {
+    overflow-wrap: break-word;
+    hyphens: auto;
+}

--- a/src/Instance/InstanceEdit/InstanceEdit.js
+++ b/src/Instance/InstanceEdit/InstanceEdit.js
@@ -74,7 +74,20 @@ const InstanceEdit = ({
   const onError = async error => {
     const response = await error.response;
     const parsedError = await parseHttpError(response);
-    setHttpError(parsedError);
+    const err = {
+      message: parsedError?.errors[0]?.message,
+      status: response.status,
+    }
+
+    setHttpError(err);
+  };
+
+  const getErrorModalContent = () => {
+    return (
+      <div style={{ overflowWrap: "break-word", hyphens: "auto" }}>
+        {httpError?.status ? `${httpError.status}: ${httpError.message}` : httpError.message}
+      </div>
+    );
   };
 
   const isMemberTenant = checkIfUserInMemberTenant(stripes);
@@ -107,7 +120,7 @@ const InstanceEdit = ({
         <ErrorModal
           open
           label={<FormattedMessage id="ui-inventory.instance.saveError" />}
-          content={httpError?.status ? `${httpError.status}: ${httpError.message}` : httpError.message}
+          content={getErrorModalContent()}
           onClose={() => setHttpError()}
         />
       }

--- a/src/Instance/InstanceEdit/InstanceEdit.js
+++ b/src/Instance/InstanceEdit/InstanceEdit.js
@@ -79,7 +79,7 @@ const InstanceEdit = ({
     const err = {
       message: parsedError?.errors[0]?.message,
       status: response.status,
-    }
+    };
 
     setHttpError(err);
   };

--- a/src/Instance/InstanceEdit/InstanceEdit.js
+++ b/src/Instance/InstanceEdit/InstanceEdit.js
@@ -31,6 +31,8 @@ import useLoadSubInstances from '../../hooks/useLoadSubInstances';
 import useCallout from '../../hooks/useCallout';
 import { useInstanceMutation } from '../../hooks';
 
+import css from './InstanceEdit.css';
+
 const InstanceEdit = ({
   instanceId,
   referenceData,
@@ -84,7 +86,7 @@ const InstanceEdit = ({
 
   const getErrorModalContent = () => {
     return (
-      <div style={{ overflowWrap: "break-word", hyphens: "auto" }}>
+      <div className={css.errorModalContent}>
         {httpError?.status ? `${httpError.status}: ${httpError.message}` : httpError.message}
       </div>
     );

--- a/src/utils.js
+++ b/src/utils.js
@@ -757,7 +757,7 @@ export const parseHttpError = async httpError => {
 
     // Optimistic locking error is currently returned as a plain text
     // https://issues.folio.org/browse/UIIN-1872?focusedCommentId=125438&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-125438
-    if (jsonError.message.match(/optimistic locking/i)) {
+    if (jsonError.message?.match(/optimistic locking/i)) {
       jsonError.errorType = ERROR_TYPES.OPTIMISTIC_LOCKING;
     }
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
When there is an error while saving the edited instance, the confirmation modal shows "undefined" instead of an error message.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- To parse error correctly

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://issues.folio.org/browse/UIIN-2686

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
<img width="614" alt="Screenshot 2023-11-21 at 15 58 03" src="https://github.com/folio-org/ui-inventory/assets/55138456/be2287e9-8106-401f-9568-da2bfe0a89d1">
