### PR TITLE
UIIN-2699 Make browse result items that are not anchors and have no records not clickable, and show 0 in number of titles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Inactive Holdings/items on Central tenant when user have affiliation for separate Member with 0 permissions. Fixes UIIN-2689.
 * Ignored hot key command on edit fields. Refs UIIN-2604.
 * Don't render Fast Add record modal in a `<Paneset>` to re-calculate other `<Pane>`'s widths after closing. Fixes UIIN-2690.
+* Make browse result items that are not anchors and have no records not clickable, and show 0 in number of titles. Fixes UIIN-2699.
 
 ## [10.0.5](https://github.com/folio-org/ui-inventory/tree/v10.0.5) (2023-11-22)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.4...v10.0.5)

--- a/src/components/BrowseResultsList/getBrowseResultsFormatter.js
+++ b/src/components/BrowseResultsList/getBrowseResultsFormatter.js
@@ -104,15 +104,16 @@ const getBrowseResultsFormatter = ({
   return {
     title: r => getFullMatchRecord(r.instance?.title, r.isAnchor),
     subject: r => {
-      if (r?.totalRecords) {
-        const subject = getTargetRecord(r?.value, r, browseOption, filters);
-        if (browseOption === browseModeOptions.SUBJECTS && r.authorityId) {
-          return renderMarcAuthoritiesLink(r.authorityId, subject);
-        }
-
-        return subject;
+      if (!r?.totalRecords && r?.isAnchor) {
+        return <MissedMatchItem query={r?.value} />;
       }
-      return <MissedMatchItem query={r?.value} />;
+
+      const subject = getTargetRecord(r?.value, r, browseOption, filters);
+      if (browseOption === browseModeOptions.SUBJECTS && r.authorityId) {
+        return renderMarcAuthoritiesLink(r.authorityId, subject);
+      }
+
+      return subject;
     },
     callNumber: r => {
       if (r?.instance || r?.totalRecords) {
@@ -121,16 +122,17 @@ const getBrowseResultsFormatter = ({
       return <MissedMatchItem query={r.fullCallNumber} />;
     },
     contributor: r => {
-      if (r?.totalRecords) {
-        const fullMatchRecord = getTargetRecord(r.name, r, browseOption, filters);
-
-        if (browseOption === browseModeOptions.CONTRIBUTORS && r.authorityId) {
-          return renderMarcAuthoritiesLink(r.authorityId, fullMatchRecord);
-        }
-
-        return fullMatchRecord;
+      if (!r?.totalRecords && r?.isAnchor) {
+        return <MissedMatchItem query={r.name} />;
       }
-      return <MissedMatchItem query={r.name} />;
+
+      const fullMatchRecord = getTargetRecord(r.name, r, browseOption, filters);
+
+      if (browseOption === browseModeOptions.CONTRIBUTORS && r.authorityId) {
+        return renderMarcAuthoritiesLink(r.authorityId, fullMatchRecord);
+      }
+
+      return fullMatchRecord;
     },
     contributorType: r => data.contributorNameTypes.find(nameType => nameType.id === r.contributorNameTypeId)?.name || '',
     relatorTerm: r => {
@@ -142,7 +144,7 @@ const getBrowseResultsFormatter = ({
         return [...acc, data.contributorTypes.find(type => type.id === contributorTypeId)?.name || ''];
       }, []).filter(name => !!name).join(', ');
     },
-    numberOfTitles: r => ((r?.instance || r?.totalRecords) || (r?.value && r?.totalRecords > 0)) && getFullMatchRecord(r?.totalRecords, r.isAnchor),
+    numberOfTitles: r => ((r?.instance || r?.totalRecords) || (r?.value && !r?.isAnchor) || (r?.name && !r?.isAnchor)) && getFullMatchRecord(r?.totalRecords, r.isAnchor),
   };
 };
 

--- a/src/components/BrowseResultsList/getBrowseResultsFormatter.test.js
+++ b/src/components/BrowseResultsList/getBrowseResultsFormatter.test.js
@@ -151,9 +151,16 @@ describe('getBrowseResultsFormatter', () => {
         contributorTypeId: ['contributorTypeId'],
         contributorNameTypeId: 'contributorNameTypeId',
         totalRecords: 1,
+      },
+      {
+        name: 'Antoniou, Grigoris 2',
+        contributorTypeId: ['contributorTypeId'],
+        contributorNameTypeId: 'contributorNameTypeId',
+        totalRecords: 0,
+        isAnchor: false,
       }
     ];
-    const [anchorRecord, nonAnchorRecord] = contentData;
+    const [anchorRecord, nonAnchorRecord, notClickableRecord] = contentData;
 
     const renderContributorsList = (params = {}) => renderComponent({
       contentData,
@@ -171,6 +178,9 @@ describe('getBrowseResultsFormatter', () => {
       // Default row
       expect(screen.getByText(nonAnchorRecord.name).tagName.toLowerCase()).not.toBe('strong');
       expect(screen.getByText(nonAnchorRecord.totalRecords).tagName.toLowerCase()).not.toBe('strong');
+      // Non clickable row
+      expect(screen.getByText(notClickableRecord.name).tagName.toLowerCase()).not.toBe('strong');
+      expect(screen.getByText(notClickableRecord.totalRecords).tagName.toLowerCase()).not.toBe('strong');
     });
 
     it('should render \'Missed match item\' rows', () => {
@@ -188,6 +198,16 @@ describe('getBrowseResultsFormatter', () => {
       await act(async () => fireEvent.click(screen.getByText(anchorRecord.name)));
 
       expect(history.location.pathname).toEqual(INVENTORY_ROUTE);
+    });
+
+    it('should not navigate to instance "Search" page when not clickable target column was clicked', async () => {
+      renderContributorsList();
+
+      expect(history.location.pathname).toEqual(BROWSE_INVENTORY_ROUTE);
+
+      await act(async () => fireEvent.click(screen.getByText(notClickableRecord.name)));
+
+      expect(history.location.pathname).toEqual(BROWSE_INVENTORY_ROUTE);
     });
 
     it('should open the record in MARC authority app in new tab when "authority" icon was clicked', async () => {

--- a/src/components/BrowseResultsList/utils.js
+++ b/src/components/BrowseResultsList/utils.js
@@ -8,9 +8,17 @@ import {
 } from '../../constants';
 
 export const isRowPreventsClick = (row, browseOption) => {
-  const isMissedMatchItemRow = !!row.isAnchor && row.totalRecords === 0;
+  /**
+   * there is a special case when contributors and subject search can return shared records even with "Shared - No" in facets
+   * in this case there will be a non-anchor item with 0 total results. we need to show it as item with 0 results
+   * and make it not clickable
+   *
+   * items with isAnchor=false and totalRecords=0 should not appear in any other case,
+   * so we can safely just check for totalRecords here
+   */
+  const isItemHasNoRecords = row.totalRecords === 0;
 
-  return isMissedMatchItemRow || (
+  return isItemHasNoRecords || (
     (browseOption === browseModeOptions.CALL_NUMBERS && !row.shelfKey) ||
     (browseOption === browseModeOptions.CONTRIBUTORS && !row.contributorNameTypeId) ||
     (browseOption === browseModeOptions.SUBJECTS && !row.totalRecords)


### PR DESCRIPTION
## Description
Make browse result items that are not anchors and have no records not clickable, and show 0 in number of titles.

This is to fix a bug with Browsing contributors and subjects. In consortial environment, when browsing with `Shared: No` back-end returns items related to shared records. This is because search index does not differentiate between local and shared Instance records.
Since we can't remove the items from results without changing the index, the workaround for now is to identify such records (non-anchor and with 0 total results) and make them not clickable

## Screenshots

https://github.com/folio-org/ui-inventory/assets/19309423/c236a1f6-e0ff-4fd0-b9e0-338c39f1e4d5

## Issues
[UIIN-2699](https://issues.folio.org/browse/UIIN-2699)