### PR TITLE
UIIN-2695: "Something went wrong" error appears when user selects Shared Instance as "Child/Parent Instance" for Local Instance without permissions at Central tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Ignored hot key command on edit fields. Refs UIIN-2604.
 * Don't render Fast Add record modal in a `<Paneset>` to re-calculate other `<Pane>`'s widths after closing. Fixes UIIN-2690.
 * Don't include `sort` parameter in requests to facets. Fixes UIIN-2685.
+* "Something went wrong" error appears when user selects Shared Instance as "Child/Parent Instance" for Local Instance without permissions at Central tenant. Fixes UIIN-2695.
 
 ## [10.0.4](https://github.com/folio-org/ui-inventory/tree/v10.0.4) (2023-11-10)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.3...v10.0.4)

--- a/src/Instance/InstanceEdit/InstanceField/InstanceField.js
+++ b/src/Instance/InstanceEdit/InstanceField/InstanceField.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Field } from 'react-final-form';
+import { isEmpty } from 'lodash';
 
 import {
   KeyValue,
@@ -46,10 +47,12 @@ const InstanceField = ({
   const publicationDate = publication?.[0]?.dateOfPublication;
 
   const handleSelect = (inst) => {
-    update(index, {
-      ...inst,
-      [titleIdKey]: inst.id,
-    });
+    if (!isEmpty((inst))) {
+      update(index, {
+        ...inst,
+        [titleIdKey]: inst.id,
+      });
+    }
   };
 
   return (


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
When trying to link a shared instance to a local instance from a member tenant having a central tenant without permissions for viewing instances, the page crashes because of `inst` object is `undefined` so `id` cannot be found.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Check whether `inst` is empty or not, if not - set it to the form field.
- Handle errors during fetching instance is done in a separate [PR](https://github.com/folio-org/ui-plugin-find-instance/pull/188) in ui-plugin-find-instance

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://issues.folio.org/browse/UIIN-2695

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
