### PR TITLE
UIIN-2716 Refactor CSS away from postcss-color-function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Browse Lists | Focus updates. Fixes UIIN-2267.
 * Correctly display location data for holdings and items when tenant is changed. Fixes UIIN-2697.
 * Disable the "Share" button after clicking it once on "Are you sure you want to share this instance?" modal window. Refs UIIN-2704.
+* Refactor CSS away from `color()` function. Refs  UIIN-2716.
 
 ## [10.0.6](https://github.com/folio-org/ui-inventory/tree/v10.0.6) (2023-11-24)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.5...v10.0.6)

--- a/src/components/WarningMessage/WarningMessage.css
+++ b/src/components/WarningMessage/WarningMessage.css
@@ -3,7 +3,7 @@
 .fill {
   padding: 3px;
   border: 1px solid var(--error);
-  background-color: color(var(--error) alpha(-95%));
+  background-color: oklch(from var(--error) l c h / 5%);
 }
 
 .iconStart {

--- a/src/edit/items/BoundWithModal.css
+++ b/src/edit/items/BoundWithModal.css
@@ -1,5 +1,5 @@
 .itemData {
-    background-color: color(#fcfcfc contrast(100%) blend(#fcfcfc 90%));
+    background-color: color-mix(in oklch, oklch(from #fcfcfc calc(l - 0.7) c h) 10%, #fcfcfc);
     border-radius: 6px;
     padding: 10px 30px;
     margin-bottom: 16px;


### PR DESCRIPTION
https://issues.folio.org/browse/UIIN-2716

We're on a mission to remove an out-of-date dependency of our CSS pipeline, `postcss-color-function`. `color()` as we used it, was removed from its proposal and ultimately changed in native CSS API to convert color spaces rather than blend colors. 

The functionality has been replaced via the `color-mix()` function as well as the new relative-color-syntax. This PR uses both.

The colors are a very near match..
![image](https://github.com/folio-org/ui-inventory/assets/20704067/1a5b7036-611d-49d1-8ed3-dac6e060a13f)

This relates back, but is only blocked by https://github.com/folio-org/stripes-webpack/pull/133 for firefox support.