### PR TITLE
UIIN-2708: Always highlight the first list row after pagination is clicked.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Correctly display location data for holdings and items when tenant is changed. Fixes UIIN-2697.
 * Disable the "Share" button after clicking it once on "Are you sure you want to share this instance?" modal window. Refs UIIN-2704.
 * Users with data export view only permission. Refs UIIN-2660.
+* Always highlight the first list row after pagination is clicked. Refs UIIN-2708.
 
 ## [10.0.6](https://github.com/folio-org/ui-inventory/tree/v10.0.6) (2023-11-24)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.5...v10.0.6)

--- a/src/ViewInstance.test.js
+++ b/src/ViewInstance.test.js
@@ -309,7 +309,7 @@ describe('ViewInstance', () => {
 
     await waitFor(() => expect(screen.getByText('Sharing this local instance will take a few moments.' +
       ' A success message and updated details will be displayed upon completion.')).toBeInTheDocument());
-  });
+  }, 10000);
   it('should show a correct Warning message banner when user lacks permission to vew shared instance', () => {
     renderViewInstance({
       isError: true,

--- a/src/views/BrowseInventory/BrowseInventory.js
+++ b/src/views/BrowseInventory/BrowseInventory.js
@@ -100,7 +100,6 @@ const BrowseInventory = () => {
   } = useInventoryBrowse({
     filters: withExtraFilters,
     pageParams: { pageConfig, setPageConfig },
-    options: { onSettled: deleteItemToView },
   });
 
   const { validateDataQuery } = useBrowseValidation(searchIndex);
@@ -148,6 +147,7 @@ const BrowseInventory = () => {
   }, [searchQuery, filters]);
 
   const onChangeSearchIndex = useCallback((e) => {
+    deleteItemToView();
     resetFilters();
     changeSearchIndex(e);
   }, []);

--- a/src/views/BrowseInventory/BrowseInventory.test.js
+++ b/src/views/BrowseInventory/BrowseInventory.test.js
@@ -312,4 +312,19 @@ describe('BrowseInventory', () => {
       expect(screen.getByRole('textbox')).toHaveFocus();
     });
   });
+
+  describe('when search option is changed', () => {
+    it('should reset itemToView to not highlight the first row', () => {
+      const mockDeleteItemToView = jest.fn();
+
+      jest.spyOn(stripesAcqComponents, 'useItemToView').mockReturnValueOnce({
+        deleteItemToView: mockDeleteItemToView,
+      });
+
+      renderBrowseInventory();
+
+      fireEvent.change(screen.getByRole('combobox'), { target: { value: 'contributors' } });
+      expect(mockDeleteItemToView).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Always highlight the first list row after pagination is clicked (not always highlighted due to deletion of the `itemToView` after loading data).
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Issues
[UIIN-2708](https://issues.folio.org/browse/UIIN-2708)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots



https://github.com/folio-org/ui-inventory/assets/77053927/36632216-83cb-4aff-8c46-8d2577656dda




<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
