### PR TITLE
UIIN-2559: The quantity of assigned tags to the instance is not displaying in the little tag icon after assigning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Inactive Holdings/items on Central tenant when user have affiliation for separate Member with 0 permissions. Fixes UIIN-2689.
 * Ignored hot key command on edit fields. Refs UIIN-2604.
 * Don't render Fast Add record modal in a `<Paneset>` to re-calculate other `<Pane>`'s widths after closing. Fixes UIIN-2690.
+* The quantity of assigned tags to the instance is not displaying in the little tag icon after assigning. Fixes UIIN-2559.
 
 ## [10.0.6] IN PROGRESS
 

--- a/src/Instance/InstanceDetails/InstanceDetails.js
+++ b/src/Instance/InstanceDetails/InstanceDetails.js
@@ -1,4 +1,9 @@
-import React, { useMemo, useState, useContext, forwardRef } from 'react';
+import React, {
+  useMemo,
+  useState,
+  useContext,
+  forwardRef,
+} from 'react';
 import { useIntl, FormattedMessage } from 'react-intl';
 import { useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
@@ -68,6 +73,7 @@ const InstanceDetails = forwardRef(({
   onClose,
   actionMenu,
   tagsEnabled,
+  mutateInstance,
   userTenantPermissions,
   isShared,
   ...rest
@@ -105,6 +111,8 @@ const InstanceDetails = forwardRef(({
       </PaneMenu>
     );
   }, [tagsEnabled, tags, intl]);
+
+  const getEntity = () => instance;
 
   const renderPaneTitle = () => {
     const isInstanceShared = Boolean(isShared || isInstanceShadowCopy(instance?.source));
@@ -268,7 +276,14 @@ const InstanceDetails = forwardRef(({
           </AccordionSet>
         </AccordionStatus>
       </Pane>
-      { helperApp && <HelperApp appName={helperApp} onClose={setHelperApp} />}
+      { helperApp &&
+        <HelperApp
+          getEntity={getEntity}
+          mutateEntity={mutateInstance}
+          appName={helperApp}
+          onClose={setHelperApp}
+        />
+      }
     </>
   );
 });
@@ -277,6 +292,7 @@ InstanceDetails.propTypes = {
   children: PropTypes.node,
   actionMenu: PropTypes.func,
   onClose: PropTypes.func.isRequired,
+  mutateInstance: PropTypes.func,
   instance: PropTypes.object,
   tagsToggle: PropTypes.func,
   tagsEnabled: PropTypes.bool,

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -1170,6 +1170,7 @@ ViewInstance.propTypes = {
   isLoading: PropTypes.bool,
   isError: PropTypes.bool,
   error: PropTypes.object,
+  mutateInstance: PropTypes.func,
 };
 
 export default flowRight(

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -884,6 +884,7 @@ class ViewInstance extends React.Component {
       okapi,
       onClose,
       tagsEnabled,
+      mutateInstance,
       isCentralTenantPermissionsLoading,
       isShared,
       isLoading,
@@ -931,6 +932,7 @@ class ViewInstance extends React.Component {
         ref={this.accordionStatusRef}
         userTenantPermissions={this.state.userTenantPermissions}
         isShared={isShared}
+        mutateInstance={mutateInstance}
       >
         {
           (!holdingsrecordid && !itemid) ?

--- a/src/ViewInstanceWrapper.js
+++ b/src/ViewInstanceWrapper.js
@@ -5,7 +5,10 @@ import { checkIfUserInMemberTenant } from '@folio/stripes/core';
 import { withTags } from '@folio/stripes/smart-components';
 
 import ViewInstance from './ViewInstance';
-import { useUserTenantPermissions } from './hooks';
+import {
+  useInstanceMutation,
+  useUserTenantPermissions,
+} from './hooks';
 import { useInstance } from './common';
 
 const ViewInstanceWrapper = (props) => {
@@ -28,6 +31,7 @@ const ViewInstanceWrapper = (props) => {
   const isShared = Boolean(instance?.shared);
   const tenantId = instance?.tenantId ?? stripes.okapi.tenant;
 
+  const { mutateInstance: mutateEntity } = useInstanceMutation({ tenantId });
   const {
     userPermissions: centralTenantPermissions,
     isFetching: isCentralTenantPermissionsLoading,
@@ -38,6 +42,10 @@ const ViewInstanceWrapper = (props) => {
     enabled: Boolean(isShared && checkIfUserInMemberTenant(stripes)),
   });
 
+  const mutateInstance = (entity, { onError }) => {
+    mutateEntity(entity, { onSuccess: refetch, onError });
+  }
+
   return (
     <ViewInstance
       {...props}
@@ -46,6 +54,7 @@ const ViewInstanceWrapper = (props) => {
       centralTenantId={centralTenantId}
       consortiumId={consortiumId}
       refetchInstance={refetch}
+      mutateInstance={mutateInstance}
       selectedInstance={instance}
       isLoading={isLoading}
       isError={isError}

--- a/src/ViewInstanceWrapper.js
+++ b/src/ViewInstanceWrapper.js
@@ -44,7 +44,7 @@ const ViewInstanceWrapper = (props) => {
 
   const mutateInstance = (entity, { onError }) => {
     mutateEntity(entity, { onSuccess: refetch, onError });
-  }
+  };
 
   return (
     <ViewInstance

--- a/src/ViewInstanceWrapper.test.js
+++ b/src/ViewInstanceWrapper.test.js
@@ -7,7 +7,10 @@ import buildStripes from '../test/jest/__mock__/stripesCore.mock';
 import { renderWithIntl, translationsProperties } from '../test/jest/helpers';
 import ViewInstanceWrapper from './ViewInstanceWrapper';
 import ViewInstance from './ViewInstance';
-import { useUserTenantPermissions } from './hooks';
+import {
+  useInstanceMutation,
+  useUserTenantPermissions,
+} from './hooks';
 import { useInstance } from './common';
 import {
   CONSORTIUM_PREFIX,
@@ -18,6 +21,7 @@ jest.mock('./ViewInstance', () => jest.fn(() => <div>ViewInstance</div>));
 
 jest.mock('./hooks', () => ({
   ...jest.requireActual('./hooks'),
+  useInstanceMutation: jest.fn(),
   useUserTenantPermissions: jest.fn(),
 }));
 jest.mock('./common', () => ({
@@ -46,6 +50,7 @@ const renderViewInstanceWrapper = (props = {}) => renderWithIntl(
 describe('ViewInstanceWrapper', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    useInstanceMutation.mockReturnValue({ mutateInstance: () => {} });
     useUserTenantPermissions.mockReturnValue({
       userPermissions: [],
       isFetching: false,

--- a/src/components/HelperApp/HelperApp.js
+++ b/src/components/HelperApp/HelperApp.js
@@ -11,13 +11,17 @@ function HelperApp({
   appName,
   match: { params },
   onClose,
+  mutateEntity,
+  getEntity,
 }) {
   const HelperAppComponent = HELPER_APPS[appName];
 
   return (
     <HelperAppComponent
+      mutateEntity={mutateEntity}
       link={`inventory/instances/${params.id}`}
       onToggle={onClose}
+      getEntity={getEntity}
     />
   );
 }
@@ -26,6 +30,8 @@ HelperApp.propTypes = {
   appName: PropTypes.string,
   match: PropTypes.object,
   onClose: PropTypes.func,
+  mutateEntity: PropTypes.func,
+  getEntity: PropTypes.func,
 };
 
 export default withRouter(HelperApp);


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
The quantity of assigned tags to the instance is not displaying in the a little tag icon after assigning.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Refetch instance after successful mutation. The bug was caused by refactoring the instance details pane to use `react-queries`.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://issues.folio.org/browse/UIIN-2559

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
