### PR TITLE
UIIN-2724: ECS: id of member tenant is undefined when rendering consortial holdings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Always highlight the first list row after pagination is clicked. Refs UIIN-2708.
 * The quantity of assigned tags to the instance is not displaying in the little tag icon after assigning. Fixes UIIN-2559.
 * Reset search/browse query when user switches affiliation. Refs UIIN-2715.
+* ECS: id of member tenant is undefined when rendering consortial holdings. Fixes UIIN-2724.
 
 ## [10.0.8](https://github.com/folio-org/ui-inventory/tree/v10.0.8) (2023-12-06)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.7...v10.0.8)

--- a/src/Instance/InstanceDetails/ConsortialHoldings/ConsortialHoldings.js
+++ b/src/Instance/InstanceDetails/ConsortialHoldings/ConsortialHoldings.js
@@ -46,7 +46,7 @@ const ConsortialHoldings = ({
 
   const memberTenants = tenants
     .map(tenant => consortiaTenantsById[tenant.id])
-    .filter(tenant => !tenant?.isCentral && (tenant?.id !== stripes.okapi.tenant))
+    .filter(tenant => !!tenant && !tenant?.isCentral && (tenant?.id !== stripes.okapi.tenant))
     .sort((a, b) => a.name.localeCompare(b.name));
 
   return (

--- a/src/providers/DataProvider.js
+++ b/src/providers/DataProvider.js
@@ -29,7 +29,7 @@ const DataProvider = ({
     }
 
     mutator.consortiaTenants.GET({
-      path: `consortia/${consortium?.id}/tenants`,
+      path: `consortia/${consortium?.id}/tenants?limit=1000`,
       headers: {
         [OKAPI_TENANT_HEADER]: consortium?.centralTenantId,
       },


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
ECS: when viewing instances with more than one holding record there is a UX error.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Filter member tenants correctly
- Add limit param for tenants request

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://issues.folio.org/browse/UIIN-2724

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
