### PR TITLE
UIIN-2593: Add permission for setting record for deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * ECS: id of member tenant is undefined when rendering consortial holdings. Fixes UIIN-2724.
 * Moving items between holdings records doesn't update correctly in UI. Fixes UIIN-2692.
 * Update permission for Staff suppressed facet. Refs UIIN-2705.
+* Add permission for setting record for deletion. Refs UIIN-2593.
 
 ## [10.0.9](https://github.com/folio-org/ui-inventory/tree/v10.0.9) (2023-12-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.8...v10.0.9)

--- a/package.json
+++ b/package.json
@@ -709,6 +709,15 @@
         "visible": true
       },
       {
+        "permissionName": "ui-inventory.instance.set-deletion-and-staff-suppress",
+        "displayName": "Inventory: Set records for deletion and staff suppress",
+        "subPermissions": [
+          "ui-inventory.instance.view",
+          "source-storage.records.update"
+        ],
+        "visible": true
+      },
+      {
         "permissionName": "ui-inventory.settings.list.view",
         "displayName": "Settings (Inventory): View list of settings pages",
         "subPermissions": [

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -733,6 +733,7 @@
   "permission.holdings.move": "Inventory: Move holdings",
   "permission.holdings.delete": "Inventory: View, create, edit, delete holdings",
   "permission.instance.view-staff-suppressed-records": "Inventory: Enable staff suppress facet",
+  "permission.instance.set-deletion-and-staff-suppress": "Inventory: Set records for deletion and staff suppress",
   "permission.settings.list.view": "Settings (Inventory): View list of settings pages",
   "permission.items.mark-items-withdrawn": "Inventory: Mark items withdrawn",
   "permission.items.mark-intellectual-item": "Inventory: Mark items intellectual item",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
* Add new permission to set FOLIO instance and MARC bib records for Deletion. 

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Added permission to `package.json`
* Added translation

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-2593](https://issues.folio.org/browse/UIIN-2593)
