### PR TITLE
UIIN-2735 do not use state right after calling setState in ViewHoldingsRecord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Update permission for Staff suppressed facet. Refs UIIN-2705.
 * Add permission for setting record for deletion. Refs UIIN-2593.
 * Mock ResizeObserver to fix failed tests. Refs UIIN-2738.
+* Fix "Edit in quickMARC" and "View source" options are disabled in the expanded dropdown on the holdings details view. Fixes UIIN-2735.
 
 ## [10.0.9](https://github.com/folio-org/ui-inventory/tree/v10.0.9) (2023-12-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.8...v10.0.9)

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -147,12 +147,15 @@ class ViewHoldingsRecord extends React.Component {
     Promise.all([holdingsRecordPromise, instances1Promise])
       .then(([, instances1Response]) => {
         this.setInstance(instances1Response);
-
-        if (this.state.instance?.source) {
-          if (this.isMARCSource() && !this.state.marcRecord) {
-            this.getMARCRecord();
-          }
+        if (!instances1Response.source) {
+          return;
         }
+
+        if (!this.isMARCSource() || this.state.marcRecord) {
+          return;
+        }
+
+        this.getMARCRecord();
       });
   }
 

--- a/src/ViewHoldingsRecord.test.js
+++ b/src/ViewHoldingsRecord.test.js
@@ -4,12 +4,14 @@ import {
   QueryClientProvider,
 } from 'react-query';
 import { MemoryRouter } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+
 import {
   screen,
   act,
   fireEvent,
+  waitFor,
 } from '@folio/jest-config-stripes/testing-library/react';
-import { createMemoryHistory } from 'history';
 
 import '../test/jest/__mock__';
 import buildStripes from '../test/jest/__mock__/stripesCore.mock';
@@ -119,64 +121,87 @@ describe('ViewHoldingsRecord actions', () => {
 
   it('should render Loading when awaiting resource', () => {
     const { getByText } = renderViewHoldingsRecord({ referenceTables: {} });
+
     expect(getByText('LoadingView')).toBeDefined();
   });
 
   it('should close view holding page', async () => {
     renderViewHoldingsRecord();
+
     fireEvent.click(await screen.findByRole('button', { name: 'confirm' }));
+
     expect(mockPush).toHaveBeenCalled();
   });
 
   it('should translate to edit holding form page', async () => {
     renderViewHoldingsRecord();
+
     const editHoldingBtn = await screen.findByTestId('edit-holding-btn');
     fireEvent.click(editHoldingBtn);
+
     expect(mockPush).toHaveBeenCalled();
   });
 
   it('should translate to duplicate holding form page', async () => {
     renderViewHoldingsRecord();
+
     const duplicatHoldingBtn = await screen.findByTestId('duplicate-holding-btn');
     fireEvent.click(duplicatHoldingBtn);
+
     expect(mockPush).toHaveBeenCalled();
   });
 
   it('should display "inactive" by an inactive temporary location', async () => {
     await act(async () => { renderViewHoldingsRecord(); });
+
     const tempLocation = document.querySelector('*[data-test-id=temporary-location]').innerHTML;
+
     expect(tempLocation).toContain('Inactive');
   });
 
   describe('Action menu', () => {
     describe('when user is in central tenant', () => {
-      it('should suppress action menu', () => {
+      it('should suppress action menu', async () => {
         const { queryByText } = renderViewHoldingsRecord({
           stripes: {
             ...buildStripes({ okapi: { tenant: 'consortia' } }),
           },
         });
 
-        expect(queryByText('Actions')).not.toBeInTheDocument();
+        await waitFor(() => expect(queryByText('Actions')).not.toBeInTheDocument());
+      });
+    });
+
+    describe('when user is in member tenant', () => {
+      it('should show action menu', async () => {
+        const { getByText } = renderViewHoldingsRecord({
+          stripes: {
+            ...buildStripes({ okapi: { tenant: 'member' } }),
+          },
+        });
+
+        await waitFor(() => expect(getByText('Actions')).toBeInTheDocument());
+      });
+    });
+
+    describe('when source is MARC', () => {
+      it('should enable View Source and Edit in quickMARC buttons', async () => {
+        const { getByText } = renderViewHoldingsRecord({
+          stripes: {
+            ...buildStripes({ okapi: { tenant: 'member' } }),
+          },
+        });
+
+        await waitFor(() => getByText('Actions'));
+
+        expect(getByText('View source')).toBeInTheDocument();
+        expect(getByText('Edit in quickMARC')).toBeInTheDocument();
       });
     });
   });
 
-  describe('Tests for shortcut of HasCommand', () => {
-    it('"onCopyHolding" function to be triggered on clicking "duplicateRecord" button', async () => {
-      const data = {
-        pathname: `/inventory/copy/${defaultProps.id}/${defaultProps.holdingsrecordid}`,
-        search: defaultProps.location.search,
-        state: {
-          backPathname: defaultProps.location.pathname,
-          tenantFrom: 'testTenantFromId',
-        },
-      };
-      renderViewHoldingsRecord();
-      fireEvent.click(await screen.findByRole('button', { name: 'duplicateRecord' }));
-      expect(mockPush).toBeCalledWith(data);
-    });
-    it('"onEditHolding" function to be triggered on clicking edit button', async () => {
+  describe('when clicking Edit button', () => {
+    it('should trigger "onEditHolding" function', async () => {
       const data = {
         pathname: `/inventory/edit/${defaultProps.id}/${defaultProps.holdingsrecordid}`,
         search: defaultProps.location.search,
@@ -186,23 +211,59 @@ describe('ViewHoldingsRecord actions', () => {
         },
       };
       renderViewHoldingsRecord();
+
       fireEvent.click(await screen.findByRole('button', { name: 'edit' }));
-      expect(mockPush).toBeCalledWith(data);
+
+      expect(mockPush).toHaveBeenCalledWith(data);
     });
-    it('"goTo" function to be triggered on clicking duplicateRecord button', async () => {
+  });
+
+  describe('when clicking Search button', () => {
+    it('should trigger "goTo" function', async () => {
       renderViewHoldingsRecord();
+
       fireEvent.click(await screen.findByRole('button', { name: 'search' }));
-      expect(defaultProps.goTo).toBeCalledWith('/inventory');
+
+      expect(defaultProps.goTo).toHaveBeenCalledWith('/inventory');
     });
-    it('collapseAllSections triggered on clicking collapseAllSections button', async () => {
+  });
+
+  describe('when clicking Duplicate record button', () => {
+    it('should call "onCopyHolding" function', async () => {
+      const data = {
+        pathname: `/inventory/copy/${defaultProps.id}/${defaultProps.holdingsrecordid}`,
+        search: defaultProps.location.search,
+        state: {
+          backPathname: defaultProps.location.pathname,
+          tenantFrom: 'testTenantFromId',
+        },
+      };
+
       renderViewHoldingsRecord();
-      fireEvent.click(await screen.findByRole('button', { name: 'collapseAllSections' }));
-      expect(spyOncollapseAllSections).toBeCalled();
+
+      fireEvent.click(await screen.findByRole('button', { name: 'duplicateRecord' }));
+
+      expect(mockPush).toHaveBeenCalledWith(data);
     });
+  });
+
+  describe('when clicking Collapse all sections button', () => {
+    it('should call collapseAllSections', async () => {
+      renderViewHoldingsRecord();
+
+      fireEvent.click(await screen.findByRole('button', { name: 'collapseAllSections' }));
+
+      expect(spyOncollapseAllSections).toHaveBeenCalled();
+    });
+  });
+
+  describe('when clicking Expand all sections button', () => {
     it('expandAllSections triggered on clicking expandAllSections button', async () => {
       await act(async () => { renderViewHoldingsRecord(); });
+
       fireEvent.click(await screen.findByRole('button', { name: 'expandAllSections' }));
-      expect(spyOnexpandAllSections).toBeCalled();
+
+      expect(spyOnexpandAllSections).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Description
Fix issue with disabled View source and Edit in quickMARC buttons after creating/opening a holding record for the first time

## Screenshots

https://github.com/folio-org/ui-inventory/assets/19309423/9a9e681f-20dc-4ddc-b7a1-fbd0d1b56970

## Issues
[UIIN-2735](https://issues.folio.org/browse/UIIN-2735)