### PR TITLE
UIIN-2740 Add 'Display summary' field to item enumeration data accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Add Set record for deletion option in Actions menu with Confirmation modal. Refs UIIN-2594.
 * Use `onSave` prop for quickMARC to handle saving records separately. Refs UIIN-2743.
 * Set Inventory settings HTML page title this format - `<<App name>> settings - <<selected page name>> - FOLIO`. Refs UIIN-2713.
+* Add "Display summary" field to item enumeration data accordion. Refs UIIN-2740.
 
 ## [10.0.10](https://github.com/folio-org/ui-inventory/tree/v10.0.10) (2024-01-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.9...v10.0.10)

--- a/src/Holding/ViewHolding/HoldingReceivingHistory/HoldingReceivingHistory.js
+++ b/src/Holding/ViewHolding/HoldingReceivingHistory/HoldingReceivingHistory.js
@@ -17,7 +17,7 @@ import { SORT_DIRECTION } from '../../../constants';
 const { ASCENDING, DESCENDING } = SORT_DIRECTION;
 
 const columnMapping = {
-  'caption': <FormattedMessage id="ui-inventory.caption" />,
+  'displaySummary': <FormattedMessage id="ui-inventory.displaySummary" />,
   'copyNumber': <FormattedMessage id="ui-inventory.copyNumber" />,
   'enumeration': <FormattedMessage id="ui-inventory.enumeration" />,
   'chronology': <FormattedMessage id="ui-inventory.chronology" />,
@@ -25,9 +25,9 @@ const columnMapping = {
   'comment': <FormattedMessage id="ui-inventory.receivingHistory.comment" />,
   'source': <FormattedMessage id="ui-inventory.receivingHistory.source" />,
 };
-const visibleColumns = ['caption', 'copyNumber', 'enumeration', 'chronology', 'receivedDate', 'comment', 'source'];
+const visibleColumns = ['displaySummary', 'copyNumber', 'enumeration', 'chronology', 'receivedDate', 'comment', 'source'];
 const columnFormatter = {
-  'caption': i => i.caption || <NoValue />,
+  'displaySummary': i => i.displaySummary || <NoValue />,
   'copyNumber': i => i.copyNumber || <NoValue />,
   'enumeration': i => i.enumeration || <NoValue />,
   'chronology': i => i.chronology || <NoValue />,
@@ -36,7 +36,7 @@ const columnFormatter = {
   'source': i => <FormattedMessage id={`ui-inventory.receivingHistory.source.${i.source || 'user'}`} />,
 };
 const sorters = {
-  'caption': ({ caption }) => caption,
+  'displaySummary': ({ displaySummary }) => displaySummary,
   'copyNumber': ({ copyNumber }) => copyNumber,
   'chronology': ({ chronology }) => chronology,
   'enumeration': ({ enumeration }) => enumeration,

--- a/src/Holding/ViewHolding/HoldingReceivingHistory/HoldingReceivingHistory.test.js
+++ b/src/Holding/ViewHolding/HoldingReceivingHistory/HoldingReceivingHistory.test.js
@@ -33,13 +33,13 @@ describe('HoldingReceivingHistory', () => {
   it('should apply sort by a column', () => {
     renderHoldingReceivingHistory({ id: 'holdingUid' });
 
-    const captionHeader = screen.getAllByRole('columnheader')[0];
-    const btn = screen.getByRole('button', { name: 'ui-inventory.caption' });
+    const displaySummaryHeader = screen.getAllByRole('columnheader')[0];
+    const btn = screen.getByRole('button', { name: 'ui-inventory.displaySummary' });
 
     fireEvent.click(btn);
-    expect(captionHeader.getAttribute('aria-sort')).toBe(SORT_DIRECTION.ASCENDING);
+    expect(displaySummaryHeader.getAttribute('aria-sort')).toBe(SORT_DIRECTION.ASCENDING);
 
     fireEvent.click(btn);
-    expect(captionHeader.getAttribute('aria-sort')).toBe(SORT_DIRECTION.DESCENDING);
+    expect(displaySummaryHeader.getAttribute('aria-sort')).toBe(SORT_DIRECTION.DESCENDING);
   });
 });

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -593,6 +593,18 @@ class ItemForm extends React.Component {
                     <Row>
                       <Col sm={3}>
                         <Field
+                          label={<FormattedMessage id="ui-inventory.displaySummary" />}
+                          name="displaySummary"
+                          id="additem_displaySummary"
+                          component={TextField}
+                          rows={1}
+                          fullWidth
+                        />
+                      </Col>
+                    </Row>
+                    <Row>
+                      <Col sm={3}>
+                        <Field
                           label={<FormattedMessage id="ui-inventory.enumeration" />}
                           name="enumeration"
                           id="additem_enumeration"

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -805,6 +805,7 @@ class ItemView extends React.Component {
     };
 
     const enumerationData = {
+      displaySummary: get(item, 'displaySummary', '-'),
       enumeration: get(item, 'enumeration', '-'),
       chronology: get(item, 'chronology', '-'),
       volume: get(item, 'volume', '-'),
@@ -1320,6 +1321,17 @@ class ItemView extends React.Component {
                       id="acc03"
                       label={<FormattedMessage id="ui-inventory.enumerationData" />}
                     >
+                      <Row>
+                        <Col
+                          smOffset={0}
+                          sm={4}
+                        >
+                          <KeyValue
+                            label={<FormattedMessage id="ui-inventory.displaySummary" />}
+                            value={checkIfElementIsEmpty(enumerationData.displaySummary)}
+                          />
+                        </Col>
+                      </Row>
                       <Row>
                         <Col
                           smOffset={0}

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -287,6 +287,7 @@
   "status": "Status",
   "loanTypeTemporary": "Temporary loan type",
   "caption": "Caption",
+  "displaySummary": "Display summary",
   "enumeration": "Enumeration",
   "enumerationData": "Enumeration data",
   "volume": "Volume",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Ensure the synchronized data points between different UIs (basically receiving and inventory) are named consistently.

## Approach
Add a new field "Display summary" to the item view and form.
Update "Caption" to "Display summary" in the holding receiving history.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
UI Jira - https://issues.folio.org/browse/UIIN-2740
BE Jira - https://issues.folio.org/browse/MODORDERS-1000
## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-inventory/assets/88109087/eeb1fac0-7166-47cd-ad17-25201abb8cc9

