### PR TITLE
UIIN-2734: Display the 'Holdings detail' page after saving the holdings changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Add Set record for deletion option in Actions menu with Confirmation modal. Refs UIIN-2594.
 * Use `onSave` prop for quickMARC to handle saving records separately. Refs UIIN-2743.
 * Set Inventory settings HTML page title this format - `<<App name>> settings - <<selected page name>> - FOLIO`. Refs UIIN-2713.
+* Display the 'Holdings detail' page after saving the holding changes. Fixes UIIN-2734.
 
 ## [10.0.10](https://github.com/folio-org/ui-inventory/tree/v10.0.10) (2024-01-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.9...v10.0.10)

--- a/src/Holding/EditHolding/EditHolding.js
+++ b/src/Holding/EditHolding/EditHolding.js
@@ -53,10 +53,10 @@ const EditHolding = ({
 
   const goBack = useCallback(() => {
     history.push({
-      pathname: locationState?.backPathname ?? `/inventory/view/${instanceId}`,
+      pathname: locationState?.backPathname ?? `/inventory/view/${instanceId}/${holdingId}`,
       search,
     });
-  }, [search, instanceId]);
+  }, [search, instanceId, holdingId]);
 
   const onCancel = useCallback(async () => {
     await switchAffiliation(stripes, tenantFrom, goBack);


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
* The user should be redirected to the 'Holdings detail' page after clicking on the 'Save and close' button.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* When cancel editing or submitting changes, redirect user to Holdings detail page.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-2734](https://issues.folio.org/browse/UIIN-2734)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-inventory/assets/85172747/60be3eb3-e274-45c2-8f8f-e4feee651f83


