### PR TITLE
UIIN-2595: Action when `Set record for deletion` option is invoked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Add "Display summary" field to item enumeration data accordion. Refs UIIN-2740.
 * Display the 'Holdings detail' page after saving the holding changes. Fixes UIIN-2734.
 * *BREAKING* Bump up okapi interfaces for `pieces` (3.0). Refs UIIN-2761.
+* Action when Set record for deletion option is invoked. Refs UIIN-2595.
 
 ## [10.0.10](https://github.com/folio-org/ui-inventory/tree/v10.0.10) (2024-01-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.9...v10.0.10)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -594,6 +594,7 @@ class ViewInstance extends React.Component {
         id,
       },
     } = this.props;
+
     mutator.setForDeletion.DELETE(id)
       .then(async () => {
         this.handleCloseSetForDeletionModal();

--- a/src/ViewInstance.test.js
+++ b/src/ViewInstance.test.js
@@ -196,6 +196,9 @@ const defaultProp = {
       POST: jest.fn(),
       GET: jest.fn(() => Promise.resolve({ sharingInstances: [{ status: 'COMPLETE' }] })),
     },
+    setForDeletion: {
+      DELETE: jest.fn(),
+    },
     authorities: {
       GET: jest.fn(),
     }
@@ -1102,6 +1105,33 @@ describe('ViewInstance', () => {
           });
 
           expect(screen.queryByText('button', { name: 'Set record for deletion' })).not.toBeInTheDocument();
+        });
+      });
+
+      describe('when click "Set record for deletion" action item', () => {
+        it('should invoke function for setting record for deletion', () => {
+          defaultProp.mutator.setForDeletion.DELETE.mockResolvedValue({});
+
+          renderViewInstance();
+
+          fireEvent.click(screen.getByText('Set record for deletion'));
+          fireEvent.click(screen.getByText('Confirm'));
+
+          expect(defaultProp.mutator.setForDeletion.DELETE).toHaveBeenCalled();
+        });
+
+        describe('when there\'s an error', () => {
+          it('should throw an error with id of the instance', () => {
+            defaultProp.mutator.setForDeletion.DELETE.mockRejectedValueOnce();
+
+            renderViewInstance();
+
+            fireEvent.click(screen.getByText('Set record for deletion'));
+            fireEvent.click(screen.getByText('Confirm'));
+
+            expect(defaultProp.mutator.setForDeletion.DELETE).toHaveBeenCalled();
+            expect(defaultProp.mutator.setForDeletion.DELETE).toHaveBeenCalledWith(defaultProp.selectedInstance.id);
+          });
         });
       });
     });

--- a/src/ViewInstance.test.js
+++ b/src/ViewInstance.test.js
@@ -1109,7 +1109,7 @@ describe('ViewInstance', () => {
       });
 
       describe('when click "Set record for deletion" action item', () => {
-        it('should invoke function for setting record for deletion', () => {
+        it('should invoke function for setting record for deletion and show successful message', () => {
           defaultProp.mutator.setForDeletion.DELETE.mockResolvedValue({});
 
           renderViewInstance();
@@ -1117,11 +1117,12 @@ describe('ViewInstance', () => {
           fireEvent.click(screen.getByText('Set record for deletion'));
           fireEvent.click(screen.getByText('Confirm'));
 
-          expect(defaultProp.mutator.setForDeletion.DELETE).toHaveBeenCalled();
+          expect(defaultProp.mutator.setForDeletion.DELETE).toHaveBeenCalledWith(defaultProp.selectedInstance.id);
+          expect(screen.queryByText(`${defaultProp.selectedInstance.title} has been set for deletion`)).toBeDefined();
         });
 
         describe('when there\'s an error', () => {
-          it('should throw an error with id of the instance', () => {
+          it('should throw an error with id of the instance and show error message', async () => {
             defaultProp.mutator.setForDeletion.DELETE.mockRejectedValueOnce();
 
             renderViewInstance();
@@ -1129,8 +1130,8 @@ describe('ViewInstance', () => {
             fireEvent.click(screen.getByText('Set record for deletion'));
             fireEvent.click(screen.getByText('Confirm'));
 
-            expect(defaultProp.mutator.setForDeletion.DELETE).toHaveBeenCalled();
             expect(defaultProp.mutator.setForDeletion.DELETE).toHaveBeenCalledWith(defaultProp.selectedInstance.id);
+            expect(screen.queryByText(`${defaultProp.selectedInstance.title} was not set for deletion`)).toBeDefined();
           });
         });
       });

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -621,6 +621,8 @@
   "exportInstancesInMARC": "Export instances (MARC)",
   "exportInstanceInMARC": "Export instance (MARC)",
   "setRecordForDeletion": "Set record for deletion",
+  "setForDeletion.toast.successful": "<b>{instanceTitle}</b> has been set for deletion",
+  "setForDeletion.toast.unsuccessful": "<b>{instanceTitle}</b> was not set for deletion",
   "exportInstancesInMARCLimitExceeded": "Selected record limit of {count, number} exceeded",
   "exportInstancesInJSON": "Export instances (JSON)",
   "reports.inTransitItem.barcode": "Item barcode",


### PR DESCRIPTION
## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
* This story covers invoking the **Set record for deletion** option from the Actions menu.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Once the changes are saved a success message banner is displayed: **[Instance title] has been set for deletion**
* If an error occurs the error message banner is displayed: **[Instance title] was not set for deletion**
* Added unit tests

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-2595](https://issues.folio.org/browse/UIIN-2595)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-inventory/assets/85172747/baec97b7-149d-4136-a79b-44ad258c2adf


