### PR TITLE
UIIN-2698: Detail view not opened for non-local items when one shared record found using "Barcode" search on "Item" tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Display the 'Holdings detail' page after saving the holding changes. Fixes UIIN-2734.
 * *BREAKING* Bump up okapi interfaces for `pieces` (3.0). Refs UIIN-2761.
 * Action when Set record for deletion option is invoked. Refs UIIN-2595.
+* Detail view not opened for non-local items when one shared record found using "Barcode" search on "Item" tab. Fixes UIIN-2698.
 
 ## [10.0.10](https://github.com/folio-org/ui-inventory/tree/v10.0.10) (2024-01-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.9...v10.0.10)

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -105,6 +105,7 @@ const buildRecordsManifest = (options = {}) => {
     GET: {
       path,
       params: {
+        expandAll: true,
         query: buildQuery,
       },
     },

--- a/test/fixtures/instances.js
+++ b/test/fixtures/instances.js
@@ -191,6 +191,7 @@ export const instances = [
     'alternativeTitles': [],
     'editions': [],
     'series': [],
+    'items': [{ tenantId: 'college' }],
     'identifiers': [{
       'identifierTypeId': '913300b2-03ed-469a-8179-c1092c991227',
       'value': '0747-0088'


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Using a consortium environment when searching for an item using `barcode` and there is only one result with the item belonging to some other member tenant, the item details view is not opening.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Get items for a particular tenant
- Navigate to the details view when there is only one search result

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-2698

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
