### PR TITLE
UIIN-2596  Staff suppress facet - use `No` as default value. Hide the facet when users don't have permissions to use it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Display the 'Holdings detail' page after saving the holding changes. Fixes UIIN-2734.
 * *BREAKING* Bump up okapi interfaces for `pieces` (3.0). Refs UIIN-2761.
 * Action when Set record for deletion option is invoked. Refs UIIN-2595.
+* Staff suppress facet - use `No` as default value. Hide the facet when users don't have permissions to use it. Refs UIIN-2596.
 
 ## [10.0.10](https://github.com/folio-org/ui-inventory/tree/v10.0.10) (2024-01-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.9...v10.0.10)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "handlerName": "eventHandler",
     "displayName": "ui-inventory.meta.title",
     "route": "/inventory",
-    "home": "/inventory?filters=&sort=title",
+    "home": "/inventory?filters=staffSuppress.false&sort=title",
     "queryResource": "query",
     "icons": [
       {

--- a/src/components/HoldingsRecordFilters/HoldingsRecordFilters.js
+++ b/src/components/HoldingsRecordFilters/HoldingsRecordFilters.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { reduce } from 'lodash';
@@ -18,6 +18,7 @@ import TagsFilter from '../TagsFilter';
 import CheckboxFacet from '../CheckboxFacet';
 import { useFacets } from '../../common/hooks';
 import HeldByFacet from '../HeldByFacet';
+import { useStaffSuppressInitialValue } from '../../hooks';
 import {
   getSourceOptions,
   getSharedOptions,
@@ -147,12 +148,7 @@ const HoldingsRecordFilters = (props) => {
     props.data
   );
 
-  useEffect(() => {
-    onChange({
-      name: FACETS.STAFF_SUPPRESS,
-      values: ['false'],
-    });
-  }, []);
+  useStaffSuppressInitialValue(onChange, props.data.query);
 
   const isUserInMemberTenant = checkIfUserInMemberTenant(stripes);
 

--- a/src/components/HoldingsRecordFilters/HoldingsRecordFilters.js
+++ b/src/components/HoldingsRecordFilters/HoldingsRecordFilters.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { reduce } from 'lodash';
@@ -146,6 +146,13 @@ const HoldingsRecordFilters = (props) => {
     getNewRecords,
     props.data
   );
+
+  useEffect(() => {
+    onChange({
+      name: FACETS.STAFF_SUPPRESS,
+      values: ['false'],
+    });
+  }, []);
 
   const isUserInMemberTenant = checkIfUserInMemberTenant(stripes);
 

--- a/src/components/HoldingsRecordFilters/HoldingsRecordFilters.test.js
+++ b/src/components/HoldingsRecordFilters/HoldingsRecordFilters.test.js
@@ -62,7 +62,9 @@ const data = {
   tagsRecords: [],
   natureOfContentTerms: [],
   consortiaTenants: [],
-  query: [],
+  query: {
+    filters: 'language.eng',
+  },
   onFetchFacets: jest.fn(),
   parentResources: resources,
 };

--- a/src/components/HoldingsRecordFilters/HoldingsRecordFilters.test.js
+++ b/src/components/HoldingsRecordFilters/HoldingsRecordFilters.test.js
@@ -99,7 +99,7 @@ describe('HoldingsRecordFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[1]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.SHARED);
+      expect(onClear).toHaveBeenCalledWith(FACETS.SHARED);
     });
   });
 
@@ -110,7 +110,7 @@ describe('HoldingsRecordFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[3]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.HELD_BY);
+      expect(onClear).toHaveBeenCalledWith(FACETS.HELD_BY);
     });
   });
 
@@ -121,7 +121,7 @@ describe('HoldingsRecordFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[5]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.EFFECTIVE_LOCATION);
+      expect(onClear).toHaveBeenCalledWith(FACETS.EFFECTIVE_LOCATION);
     });
   });
 
@@ -132,7 +132,7 @@ describe('HoldingsRecordFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[7]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.HOLDINGS_PERMANENT_LOCATION);
+      expect(onClear).toHaveBeenCalledWith(FACETS.HOLDINGS_PERMANENT_LOCATION);
     });
   });
 
@@ -143,7 +143,7 @@ describe('HoldingsRecordFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[9]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.HOLDINGS_TYPE);
+      expect(onClear).toHaveBeenCalledWith(FACETS.HOLDINGS_TYPE);
     });
   });
 
@@ -154,7 +154,7 @@ describe('HoldingsRecordFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[11]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.HOLDINGS_DISCOVERY_SUPPRESS);
+      expect(onClear).toHaveBeenCalledWith(FACETS.HOLDINGS_DISCOVERY_SUPPRESS);
     });
   });
 
@@ -165,7 +165,7 @@ describe('HoldingsRecordFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[13]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.HOLDINGS_STATISTICAL_CODE_IDS);
+      expect(onClear).toHaveBeenCalledWith(FACETS.HOLDINGS_STATISTICAL_CODE_IDS);
     });
   });
 
@@ -176,7 +176,7 @@ describe('HoldingsRecordFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[15]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.HOLDINGS_CREATED_DATE);
+      expect(onClear).toHaveBeenCalledWith(FACETS.HOLDINGS_CREATED_DATE);
     });
   });
 
@@ -187,9 +187,10 @@ describe('HoldingsRecordFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[22]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.HOLDINGS_UPDATED_DATE);
+      expect(onClear).toHaveBeenCalledWith(FACETS.HOLDINGS_UPDATED_DATE);
     });
   });
+
   it('Should Render holdingsSource, Clear selectedfilters buttons', async () => {
     renderHoldingsRecordFilters();
     const holdingsSource = screen.getByRole('button', { name: /Source/i });
@@ -197,7 +198,16 @@ describe('HoldingsRecordFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[29]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.HOLDINGS_SOURCE);
+      expect(onClear).toHaveBeenCalledWith(FACETS.HOLDINGS_SOURCE);
+    });
+  });
+
+  it('should call onChange with default selected Staff suppress value', async () => {
+    renderHoldingsRecordFilters();
+
+    expect(onChange).toHaveBeenCalledWith({
+      name: FACETS.STAFF_SUPPRESS,
+      values: ['false'],
     });
   });
 });

--- a/src/components/InstanceFilters/InstanceFilters.js
+++ b/src/components/InstanceFilters/InstanceFilters.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
 import _ from 'lodash';
@@ -9,6 +9,7 @@ import {
   FilterAccordionHeader,
 } from '@folio/stripes/components';
 import {
+  IfPermission,
   checkIfUserInMemberTenant,
   useStripes,
 } from '@folio/stripes/core';
@@ -185,6 +186,15 @@ const InstanceFilters = props => {
     props.data
   );
 
+  const isStaffSuppressFilterAvailable = stripes.hasPerm('ui-inventory.instance.view-staff-suppressed-records');
+
+  useEffect(() => {
+    onChange({
+      name: FACETS.STAFF_SUPPRESS,
+      values: ['false'],
+    });
+  }, []);
+
   const isUserInMemberTenant = checkIfUserInMemberTenant(stripes);
 
   return (
@@ -339,23 +349,25 @@ const InstanceFilters = props => {
           onFetch={handleFetchFacets}
         />
       </Accordion>
-      <Accordion
-        label={<FormattedMessage id={`ui-inventory.${FACETS.STAFF_SUPPRESS}`} />}
-        id={FACETS.STAFF_SUPPRESS}
-        name={FACETS.STAFF_SUPPRESS}
-        closedByDefault
-        header={FilterAccordionHeader}
-        displayClearButton={activeFilters[FACETS.STAFF_SUPPRESS]?.length > 0}
-        onClearFilter={() => onClear(FACETS.STAFF_SUPPRESS)}
-      >
-        <CheckboxFacet
+      {isStaffSuppressFilterAvailable && (
+        <Accordion
+          label={<FormattedMessage id={`ui-inventory.${FACETS.STAFF_SUPPRESS}`} />}
+          id={FACETS.STAFF_SUPPRESS}
           name={FACETS.STAFF_SUPPRESS}
-          dataOptions={facetsOptions[FACETS_OPTIONS.SUPPRESSED_OPTIONS]}
-          selectedValues={activeFilters[FACETS.STAFF_SUPPRESS]}
-          isPending={getIsPending(FACETS.STAFF_SUPPRESS)}
-          onChange={onChange}
-        />
-      </Accordion>
+          closedByDefault
+          header={FilterAccordionHeader}
+          displayClearButton={activeFilters[FACETS.STAFF_SUPPRESS]?.length > 0}
+          onClearFilter={() => onClear(FACETS.STAFF_SUPPRESS)}
+        >
+          <CheckboxFacet
+            name={FACETS.STAFF_SUPPRESS}
+            dataOptions={facetsOptions[FACETS_OPTIONS.SUPPRESSED_OPTIONS]}
+            selectedValues={activeFilters[FACETS.STAFF_SUPPRESS]}
+            isPending={getIsPending(FACETS.STAFF_SUPPRESS)}
+            onChange={onChange}
+          />
+        </Accordion>
+      )}
       <Accordion
         label={<FormattedMessage id="ui-inventory.discoverySuppress" />}
         id={FACETS.INSTANCES_DISCOVERY_SUPPRESS}

--- a/src/components/InstanceFilters/InstanceFilters.js
+++ b/src/components/InstanceFilters/InstanceFilters.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
 import _ from 'lodash';
@@ -9,7 +9,6 @@ import {
   FilterAccordionHeader,
 } from '@folio/stripes/components';
 import {
-  IfPermission,
   checkIfUserInMemberTenant,
   useStripes,
 } from '@folio/stripes/core';
@@ -18,6 +17,7 @@ import TagsFilter from '../TagsFilter';
 import CheckboxFacet from '../CheckboxFacet';
 import HeldByFacet from '../HeldByFacet';
 import DateRangeFilter from '../DateRangeFilter';
+import { useStaffSuppressInitialValue } from '../../hooks';
 import {
   getSourceOptions,
   getSharedOptions,
@@ -188,12 +188,7 @@ const InstanceFilters = props => {
 
   const isStaffSuppressFilterAvailable = stripes.hasPerm('ui-inventory.instance.view-staff-suppressed-records');
 
-  useEffect(() => {
-    onChange({
-      name: FACETS.STAFF_SUPPRESS,
-      values: ['false'],
-    });
-  }, []);
+  useStaffSuppressInitialValue(onChange, props.data.query);
 
   const isUserInMemberTenant = checkIfUserInMemberTenant(stripes);
 

--- a/src/components/InstanceFilters/InstanceFilters.test.js
+++ b/src/components/InstanceFilters/InstanceFilters.test.js
@@ -1,15 +1,17 @@
 import React from 'react';
 import '../../../test/jest/__mock__';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
-import { ModuleHierarchyProvider } from '@folio/stripes/core';
 
+import { screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
 import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
-import renderWithIntl from '../../../test/jest/helpers/renderWithIntl';
 import {
-  FACETS
-} from '../../constants';
+  ModuleHierarchyProvider,
+  useStripes,
+} from '@folio/stripes/core';
+
+import { FACETS } from '../../constants';
 import InstanceFilters from './InstanceFilters';
+import renderWithIntl from '../../../test/jest/helpers/renderWithIntl';
 import translationsProperties from '../../../test/jest/helpers/translationsProperties';
 
 jest.mock('../CheckboxFacet/CheckboxFacet', () => jest.fn().mockReturnValue('CheckboxFacet'));
@@ -18,6 +20,13 @@ jest.mock('../../facetUtils', () => ({
   ...jest.requireActual('../../facetUtils'),
   getSourceOptions: jest.fn(),
   getSuppressedOptions: jest.fn(),
+}));
+
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  useStripes: jest.fn().mockReturnValue({
+    hasPerm: jest.fn().mockReturnValue(true),
+  }),
 }));
 
 const activeFilters = {
@@ -108,6 +117,7 @@ describe('InstanceFilters', () => {
       expect(onClear).toBeCalledWith(FACETS.SHARED);
     });
   });
+
   it('Should Clear selected filters for Held By', async () => {
     renderInstanceFilters();
     const Clearselectedfilters = screen.getAllByRole('button');
@@ -116,6 +126,7 @@ describe('InstanceFilters', () => {
       expect(onClear).toBeCalledWith(FACETS.HELD_BY);
     });
   });
+
   it('Should Clear selected filters for effective Location', async () => {
     renderInstanceFilters();
     const Clearselectedfilters = screen.getAllByRole('button');
@@ -124,6 +135,7 @@ describe('InstanceFilters', () => {
       expect(onClear).toBeCalledWith(FACETS.EFFECTIVE_LOCATION);
     });
   });
+
   it('Should Clear selected filters for language', async () => {
     renderInstanceFilters();
     const Clearselectedfilters = screen.getAllByRole('button');
@@ -230,6 +242,30 @@ describe('InstanceFilters', () => {
     userEvent.click(Clearselectedfilters[39]);
     await waitFor(() => {
       expect(onClear).toBeCalledWith(FACETS.SOURCE);
+    });
+  });
+
+  it('should call onChange with default selected Staff suppress value', async () => {
+    renderInstanceFilters();
+
+    expect(onChange).toHaveBeenCalledWith({
+      name: FACETS.STAFF_SUPPRESS,
+      values: ['false'],
+    });
+  });
+
+  describe('when users do not have permissions to view Staff Suppress facet', () => {
+    beforeEach(() => {
+      useStripes.mockClear().mockReturnValue({
+        hasPerm: () => false,
+      });
+    });
+
+    it('should not render the facet', async () => {
+      renderInstanceFilters();
+      const staffSuppressFacet = screen.queryByRole('button', { name: 'Staff suppress filter list' });
+
+      expect(staffSuppressFacet).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/InstanceFilters/InstanceFilters.test.js
+++ b/src/components/InstanceFilters/InstanceFilters.test.js
@@ -81,7 +81,9 @@ const data = {
   consortiaTenants: [],
   tagsRecords: [],
   natureOfContentTerms: [],
-  query: [],
+  query: {
+    filters: 'language.eng',
+  },
   onFetchFacets: jest.fn(),
   parentResources: resources,
 };

--- a/src/components/ItemFilters/ItemFilters.js
+++ b/src/components/ItemFilters/ItemFilters.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -17,6 +17,7 @@ import DateRangeFilter from '../DateRangeFilter';
 import TagsFilter from '../TagsFilter';
 import CheckboxFacet from '../CheckboxFacet';
 import HeldByFacet from '../HeldByFacet';
+import { useStaffSuppressInitialValue } from '../../hooks';
 import { useFacets } from '../../common/hooks';
 import {
   getSourceOptions,
@@ -147,12 +148,7 @@ const ItemFilters = (props) => {
     props.data
   );
 
-  useEffect(() => {
-    onChange({
-      name: FACETS.STAFF_SUPPRESS,
-      values: ['false'],
-    });
-  }, []);
+  useStaffSuppressInitialValue(onChange, props.data.query);
 
   const isUserInMemberTenant = checkIfUserInMemberTenant(stripes);
 

--- a/src/components/ItemFilters/ItemFilters.js
+++ b/src/components/ItemFilters/ItemFilters.js
@@ -1,7 +1,8 @@
 import _ from 'lodash';
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
+
 import {
   Accordion,
   AccordionSet,
@@ -145,6 +146,13 @@ const ItemFilters = (props) => {
     getNewRecords,
     props.data
   );
+
+  useEffect(() => {
+    onChange({
+      name: FACETS.STAFF_SUPPRESS,
+      values: ['false'],
+    });
+  }, []);
 
   const isUserInMemberTenant = checkIfUserInMemberTenant(stripes);
 

--- a/src/components/ItemFilters/ItemFilters.test.js
+++ b/src/components/ItemFilters/ItemFilters.test.js
@@ -59,7 +59,9 @@ const data = {
   tagsRecords: [],
   natureOfContentTerms: [],
   consortiaTenants: [],
-  query: [],
+  query: {
+    filters: 'language.eng',
+  },
   onFetchFacets: jest.fn(),
   parentResources: resources,
 };

--- a/src/components/ItemFilters/ItemFilters.test.js
+++ b/src/components/ItemFilters/ItemFilters.test.js
@@ -93,7 +93,7 @@ describe('ItemFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[1]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.SHARED);
+      expect(onClear).toHaveBeenCalledWith(FACETS.SHARED);
     });
   });
 
@@ -102,7 +102,7 @@ describe('ItemFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[3]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.HELD_BY);
+      expect(onClear).toHaveBeenCalledWith(FACETS.HELD_BY);
     });
   });
 
@@ -111,7 +111,7 @@ describe('ItemFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[5]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.ITEM_STATUS);
+      expect(onClear).toHaveBeenCalledWith(FACETS.ITEM_STATUS);
     });
   });
 
@@ -120,7 +120,7 @@ describe('ItemFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[7]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.EFFECTIVE_LOCATION);
+      expect(onClear).toHaveBeenCalledWith(FACETS.EFFECTIVE_LOCATION);
     });
   });
 
@@ -129,7 +129,7 @@ describe('ItemFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[9]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.HOLDINGS_PERMANENT_LOCATION);
+      expect(onClear).toHaveBeenCalledWith(FACETS.HOLDINGS_PERMANENT_LOCATION);
     });
   });
 
@@ -138,7 +138,7 @@ describe('ItemFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[11]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.MATERIAL_TYPE);
+      expect(onClear).toHaveBeenCalledWith(FACETS.MATERIAL_TYPE);
     });
   });
 
@@ -147,7 +147,7 @@ describe('ItemFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[13]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.ITEMS_DISCOVERY_SUPPRESS);
+      expect(onClear).toHaveBeenCalledWith(FACETS.ITEMS_DISCOVERY_SUPPRESS);
     });
   });
 
@@ -156,7 +156,7 @@ describe('ItemFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[15]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.ITEMS_STATISTICAL_CODE_IDS);
+      expect(onClear).toHaveBeenCalledWith(FACETS.ITEMS_STATISTICAL_CODE_IDS);
     });
   });
 
@@ -165,7 +165,7 @@ describe('ItemFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[17]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.ITEMS_CREATED_DATE);
+      expect(onClear).toHaveBeenCalledWith(FACETS.ITEMS_CREATED_DATE);
     });
   });
 
@@ -174,7 +174,16 @@ describe('ItemFilters', () => {
     const Clearselectedfilters = screen.getAllByRole('button');
     userEvent.click(Clearselectedfilters[24]);
     await waitFor(() => {
-      expect(onClear).toBeCalledWith(FACETS.ITEMS_UPDATED_DATE);
+      expect(onClear).toHaveBeenCalledWith(FACETS.ITEMS_UPDATED_DATE);
+    });
+  });
+
+  it('should call onChange with default selected Staff suppress value', async () => {
+    renderItemFilters();
+
+    expect(onChange).toHaveBeenCalledWith({
+      name: FACETS.STAFF_SUPPRESS,
+      values: ['false'],
     });
   });
 });

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -346,6 +346,11 @@ export const holdingFilterConfig = [
     cql: FACETS_CQL.HOLDINGS_SOURCE,
     values: [],
   },
+  {
+    name: FACETS_CQL.STAFF_SUPPRESS, // this facet is not shown, but we need the config to apply default filter value
+    cql: FACETS_CQL.STAFF_SUPPRESS,
+    values: [],
+  },
 ];
 
 export const itemIndexes = [
@@ -427,6 +432,11 @@ export const itemFilterConfig = [
   {
     name: FACETS.ITEMS_TAGS,
     cql: FACETS_CQL.ITEMS_TAGS,
+    values: [],
+  },
+  {
+    name: FACETS_CQL.STAFF_SUPPRESS, // this facet is not shown, but we need the config to apply default filter value
+    cql: FACETS_CQL.STAFF_SUPPRESS,
     values: [],
   },
 ];

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -12,3 +12,4 @@ export { default as useLastSearchTerms } from './useLastSearchTerms';
 export { default as useSearchForShadowInstanceTenants } from './useSearchForShadowInstanceTenants';
 export { default as useUserTenantPermissions } from './useUserTenantPermissions';
 export { default as useLocationsForTenants } from './useLocationsForTenants';
+export { default as useStaffSuppressInitialValue } from './useStaffSuppressInitialValue';

--- a/src/hooks/useStaffSuppressInitialValue/index.js
+++ b/src/hooks/useStaffSuppressInitialValue/index.js
@@ -1,0 +1,1 @@
+export { default } from './useStaffSuppressInitialValue';

--- a/src/hooks/useStaffSuppressInitialValue/useStaffSuppressInitialValue.js
+++ b/src/hooks/useStaffSuppressInitialValue/useStaffSuppressInitialValue.js
@@ -1,17 +1,25 @@
-import { useEffect, useRef } from 'react';
+import {
+  useEffect,
+  useRef,
+} from 'react';
+import { useLocation } from 'react-router-dom';
 
 import { FACETS } from '../../constants';
 
 const useStaffSuppressInitialValue = (onChange, query) => {
-  const isFiltersFirstSet = useRef(Boolean(query.filters));
+  const location = useLocation();
+  const isQueryFiltersSet = Boolean(query.filters);
+  const isDefaultValueSet = useRef(false);
+
+  const hasFilters = new URLSearchParams(location.search).get('filters')?.length > 0;
 
   useEffect(() => {
-    isFiltersFirstSet.current = Boolean(query.filters);
-  }, [query.filters]);
+    if (isDefaultValueSet.current) {
+      return;
+    }
 
-  useEffect(() => {
     // need to wait until query.filters is set because calling onChange before that happens will override filters that are coming from location.search
-    if (!isFiltersFirstSet.current) {
+    if (!isQueryFiltersSet && hasFilters) {
       return;
     }
 
@@ -19,7 +27,8 @@ const useStaffSuppressInitialValue = (onChange, query) => {
       name: FACETS.STAFF_SUPPRESS,
       values: ['false'],
     });
-  }, [isFiltersFirstSet.current]);
+    isDefaultValueSet.current = true;
+  }, [isQueryFiltersSet]);
 };
 
 export default useStaffSuppressInitialValue;

--- a/src/hooks/useStaffSuppressInitialValue/useStaffSuppressInitialValue.js
+++ b/src/hooks/useStaffSuppressInitialValue/useStaffSuppressInitialValue.js
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react';
+
+import { FACETS } from '../../constants';
+
+const useStaffSuppressInitialValue = (onChange, query) => {
+  const isFiltersFirstSet = useRef(Boolean(query.filters));
+
+  useEffect(() => {
+    isFiltersFirstSet.current = Boolean(query.filters);
+  }, [query.filters]);
+
+  useEffect(() => {
+    // need to wait until query.filters is set because calling onChange before that happens will override filters that are coming from location.search
+    if (!isFiltersFirstSet.current) {
+      return;
+    }
+
+    onChange({
+      name: FACETS.STAFF_SUPPRESS,
+      values: ['false'],
+    });
+  }, [isFiltersFirstSet.current]);
+};
+
+export default useStaffSuppressInitialValue;

--- a/src/hooks/useStaffSuppressInitialValue/useStaffSuppressInitialValue.test.js
+++ b/src/hooks/useStaffSuppressInitialValue/useStaffSuppressInitialValue.test.js
@@ -3,6 +3,12 @@ import { renderHook } from '@folio/jest-config-stripes/testing-library/react';
 import useStaffSuppressInitialValue from './useStaffSuppressInitialValue';
 import { FACETS } from '../../constants';
 
+jest.mock('react-router-dom', () => ({
+  useLocation: jest.fn().mockReturnValue({
+    search: 'filters=language.eng',
+  }),
+}));
+
 const mockOnChange = jest.fn();
 
 describe('useStaffSuppressInitialValue', () => {

--- a/src/hooks/useStaffSuppressInitialValue/useStaffSuppressInitialValue.test.js
+++ b/src/hooks/useStaffSuppressInitialValue/useStaffSuppressInitialValue.test.js
@@ -1,0 +1,50 @@
+import { renderHook } from '@folio/jest-config-stripes/testing-library/react';
+
+import useStaffSuppressInitialValue from './useStaffSuppressInitialValue';
+import { FACETS } from '../../constants';
+
+const mockOnChange = jest.fn();
+
+describe('useStaffSuppressInitialValue', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when query.filters is empty', () => {
+    it('should not call onChange', () => {
+      const query = { filters: '' };
+      renderHook(() => useStaffSuppressInitialValue(mockOnChange, query));
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
+
+    describe('when hook re-renders with set query.filters', () => {
+      it('should call onChange', () => {
+        const query = { filters: '' };
+        const { rerender } = renderHook(({ onChange, query: _query }) => useStaffSuppressInitialValue(onChange, _query), { initialProps: { onChange: mockOnChange, query } });
+
+        expect(mockOnChange).not.toHaveBeenCalled();
+
+        rerender({ onChange: mockOnChange, query: { filters: 'language.eng' } });
+        rerender({ onChange: mockOnChange, query: { filters: 'language.eng' } });
+
+        expect(mockOnChange).toHaveBeenCalledWith({
+          name: FACETS.STAFF_SUPPRESS,
+          values: ['false'],
+        });
+      });
+    });
+  });
+
+  describe('when query.filters is not empty', () => {
+    it('should call onChange', () => {
+      const query = { filters: 'language.eng' };
+      renderHook(() => useStaffSuppressInitialValue(mockOnChange, query));
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        name: FACETS.STAFF_SUPPRESS,
+        values: ['false'],
+      });
+    });
+  });
+});

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -9,7 +9,8 @@ import {
 import {
   CQL_FIND_ALL,
   fieldSearchConfigurations,
-  queryIndexes
+  queryIndexes,
+  FACETS,
 } from '../constants';
 import {
   getQueryTemplate,
@@ -36,6 +37,23 @@ export const getAdvancedSearchTemplate = (queryValue) => {
     const formattedRow = `${row.bool} ${rowQuery}`.trim();
     return `${acc} ${formattedRow}`;
   }, '').trim();
+};
+
+const applyDefaultStaffSuppressFilter = (query, isStaffSuppressFilterAvailable) => {
+  const staffSuppressFalse = `${FACETS.STAFF_SUPPRESS}.false`;
+
+  if (!query.query && query.filters === staffSuppressFalse) {
+    // if query is empty and the only filter value is staffSuppress.false - that means that search was not initiated by user action but by default applied
+    // staffSuppress filter. need to clear the query.filters here to not automatically search when Inventory search is opened
+    query.filters = undefined;
+  } else if (isStaffSuppressFilterAvailable) {
+    // if we have a query and/or filters and user has access to Staff Suppress filter - then do nothing - don't remove anything, don't add anything.
+    // let the user handle what Staff Suppress filter values they want selected
+  } else if ((query.query || query.filters) && !query.filters?.includes(staffSuppressFalse)) {
+    // if user doesn't have access to Staff Suppress filter and query and/or filters are not empty and don't already contain staffSuppress
+    // then add staffSuppress.false to filters
+    query.filters = `${query.filters},${staffSuppressFalse}`;
+  }
 };
 
 export function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
@@ -74,7 +92,14 @@ export function buildQuery(queryParams, pathComponents, resourceData, logger, pr
     query.sort = DEFAULT_SORT;
   }
 
-  resourceData.query = { ...query, qindex: '' };
+  const isStaffSuppressFilterAvailable = props.stripes.hasPerm('ui-inventory.instance.view-staff-suppressed-records');
+
+  applyDefaultStaffSuppressFilter(query, isStaffSuppressFilterAvailable);
+
+  resourceData.query = {
+    ...query,
+    qindex: '',
+  };
 
   // makeQueryFunction escapes quote and backslash characters by default,
   // but when submitting a raw CQL query (i.e. when queryIndex === 'querySearch')

--- a/src/routes/buildManifestObject.test.js
+++ b/src/routes/buildManifestObject.test.js
@@ -98,6 +98,43 @@ describe('buildQuery', () => {
         );
       });
     });
+
+    describe('when user has staff suppress facet permission', () => {
+      it('should not apply staffSuppress.false facet by default', () => {
+        const qindex = queryIndexes.SUBJECT;
+        const queryParams = { ...defaultQueryParamsMap[qindex] };
+        const cql = buildQuery(...getBuildQueryArgs({ queryParams }));
+
+        expect(cql).toEqual('(subjects.value==/string "Some \\"subject\\" query") sortby title');
+      });
+
+      describe('when staff suppress is already selected', () => {
+        it('should not apply staffSuppress.false facet again ', () => {
+          const qindex = queryIndexes.SUBJECT;
+          const queryParams = { ...defaultQueryParamsMap[qindex], filters: 'staffSuppress.false' };
+          const cql = buildQuery(...getBuildQueryArgs({ queryParams }));
+
+          expect(cql).toEqual('((subjects.value==/string "Some \\"subject\\" query") and staffSuppress=="false") sortby title');
+        });
+      });
+    });
+
+    describe('when user does not have staff suppress facet permission', () => {
+      it('should apply staffSuppress.false facet by default', () => {
+        const qindex = queryIndexes.SUBJECT;
+        const queryParams = { ...defaultQueryParamsMap[qindex] };
+        const cql = buildQuery(...getBuildQueryArgs({
+          queryParams,
+          props: {
+            stripes: buildStripes({
+              hasPerm: () => false,
+            }),
+          },
+        }));
+
+        expect(cql).toEqual('((subjects.value==/string "Some \\"subject\\" query") and staffSuppress=="false") sortby title');
+      });
+    });
   });
 
   describe('build query based on selected browse record', () => {

--- a/src/routes/buildManifestObject.test.js
+++ b/src/routes/buildManifestObject.test.js
@@ -3,6 +3,7 @@ import '../../test/jest/__mock__';
 import { queryIndexes } from '../constants';
 import { instanceIndexes } from '../filterConfig';
 import { buildQuery } from './buildManifestObject';
+import buildStripes from '../../test/jest/__mock__/stripesCore.mock';
 
 const getQueryTemplate = (qindex) => instanceIndexes.find(({ value }) => value === qindex).queryTemplate;
 
@@ -11,10 +12,11 @@ const getBuildQueryArgs = ({
   pathComponents = {},
   resourceData = {},
   logger = { log: jest.fn() },
+  props = { stripes: buildStripes() }
 } = {}) => {
   const resData = { query: { ...queryParams }, ...resourceData };
 
-  return [queryParams, pathComponents, resData, logger];
+  return [queryParams, pathComponents, resData, logger, props];
 };
 
 const defaultQueryParamsMap = {

--- a/src/withFacets.js
+++ b/src/withFacets.js
@@ -180,7 +180,7 @@ function withFacets(WrappedComponent) {
 
       if (isStaffSuppressFilterAvailable) {
         // do nothing - don't remove anything, don't add anything.
-        // let the user handle what Staff Suppress filter values they want selected
+        // default value is added in filters components
       } else if (!query.filters) {
         query.filters = staffSuppressFalse;
       } else if (!query.filters?.includes(staffSuppressFalse)) {

--- a/src/withFacets.test.js
+++ b/src/withFacets.test.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {
   render,
   fireEvent,
@@ -103,7 +105,7 @@ describe('withFacets', () => {
     });
   });
 
-  describe('when opening a contributots shared facet', () => {
+  describe('when opening a contributors shared facet', () => {
     describe('and there are no selected options in other facets', () => {
       it('should make a request with correct request options', () => {
         const resources = {
@@ -690,6 +692,32 @@ describe('withFacets', () => {
           },
         }));
       });
+    });
+  });
+
+  describe('when user has staff suppress facet permission', () => {
+    it('should not apply staffSuppress.false facet by default', () => {
+      const resources = {
+        query: {},
+      };
+
+      const { getByText } = render(
+        <FacetsHoc
+          mutator={mutator}
+          resources={resources}
+          properties={{ facetToOpen: FACETS.SHARED }}
+        />
+      );
+
+      fireEvent.click(getByText('fetchFacetsButton'));
+
+      expect(mutator.facets.GET).toHaveBeenCalledWith(expect.objectContaining({
+        params: {
+          facet: `${FACETS_CQL.SHARED}:6`,
+          query: 'id = *',
+        },
+        path: 'search/instances/facets',
+      }));
     });
   });
 });

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -46,7 +46,7 @@ const STRIPES = buildStripes();
 
 const mockStripesCore = {
   stripesConnect: Component => ({ mutator, resources, stripes, ...rest }) => {
-    const fakeMutator = mutator || Object.keys(Component.manifest).reduce((acc, mutatorName) => {
+    const fakeMutator = mutator || Object.keys(Component.manifest || {}).reduce((acc, mutatorName) => {
       const returnValue = Component.manifest[mutatorName].records ? [] : {};
 
       acc[mutatorName] = {
@@ -62,7 +62,7 @@ const mockStripesCore = {
       return acc;
     }, {});
 
-    const fakeResources = resources || Object.keys(Component.manifest).reduce((acc, resourceName) => {
+    const fakeResources = resources || Object.keys(Component.manifest || {}).reduce((acc, resourceName) => {
       acc[resourceName] = {
         records: [],
       };


### PR DESCRIPTION
## Description
Apply `staffSuppress.false` filter to all search and facet requests by default.
Users without `Inventory: Enable staff suppress facet` permissions don't have the ability to search for staff suppressed records and to change selected Staff Suppress facet value.
Users with the permission can see and change facet values.

## Screenshots
**User with Staff Suppress facet permissions**

https://github.com/folio-org/ui-inventory/assets/19309423/f14fa8f4-ed04-4a19-971e-cb0520aac151



**User without Staff Suppress facet permissions**

https://github.com/folio-org/ui-inventory/assets/19309423/8282d79c-ed2f-41af-8687-145e596a87b7



## Issues
[UIIN-2596](https://folio-org.atlassian.net/browse/UIIN-2596)