### PR TITLE
UIIN-2778: Display Holdings/Item Electronic Access URIs consistent with Instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Action when Set record for deletion option is invoked. Refs UIIN-2595.
 * Detail view not opened for non-local items when one shared record found using "Barcode" search on "Item" tab. Fixes UIIN-2698.
 * Jest/RTL: Cover CreateHoldings component with unit tests. Refs UIIN-2663.
+* Display Holdings/Item Electronic Access URIs consistent with Instances. Fixes UIIN-2778.
 
 ## [10.0.10](https://github.com/folio-org/ui-inventory/tree/v10.0.10) (2024-01-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.9...v10.0.10)

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -1075,15 +1075,22 @@ class ViewHoldingsRecord extends React.Component {
                           }}
                           formatter={{
                             'URL relationship': x => this.refLookup(referenceTables.electronicAccessRelationships, get(x, ['relationshipId'])).name || noValue,
-                            'URI': x => (get(x, ['uri'])
-                              ? (
-                                <a
-                                  href={get(x, ['uri'])}
-                                  style={wrappingCell}
-                                >
-                                  {get(x, ['uri'])}
-                                </a>)
-                              : noValue),
+                            'URI': x => {
+                              const uri = x?.uri;
+
+                              return uri
+                                ? (
+                                  <a
+                                    href={uri}
+                                    rel="noreferrer noopener"
+                                    target="_blank"
+                                    style={wrappingCell}
+                                  >
+                                    {uri}
+                                  </a>
+                                )
+                                : noValue;
+                            },
                             'Link text': x => get(x, ['linkText']) || noValue,
                             'Materials specified': x => get(x, ['materialsSpecification']) || noValue,
                             'URL public note': x => get(x, ['publicNote']) || noValue,

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -906,15 +906,22 @@ class ItemView extends React.Component {
     const electronicAccessFormatter = {
       'URL relationship': x => refLookup(referenceTables.electronicAccessRelationships,
         get(x, ['relationshipId'])).name || noValue,
-      'URI': x => (get(x, ['uri'])
-        ? (
-          <a
-            href={get(x, ['uri'])}
-            style={wrappingCell}
-          >
-            {get(x, ['uri'])}
-          </a>)
-        : noValue),
+      'URI': x => {
+        const uri = x?.uri;
+
+        return uri
+          ? (
+            <a
+              href={uri}
+              rel="noreferrer noopener"
+              target="_blank"
+              style={wrappingCell}
+            >
+              {uri}
+            </a>
+          )
+          : noValue;
+      },
       'Link text': x => get(x, ['linkText']) || noValue,
       'Materials specified': x => get(x, ['materialsSpecification']) || noValue,
       'URL public note': x => get(x, ['publicNote']) || noValue,


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
* There’s security vulnerability for holdings and items, but instances is fine.  The goal here is to adjust the code for holdings and items so it’s consistent with instances and therefore no longer a security risk.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Made Holdings/Item Electronic Access URIs consistent with Instances

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-2778](https://folio-org.atlassian.net/browse/UIIN-2778)
