### PR TITLE
UIIN-2784: Set central tenant id in the request when Member tenant deletes a shared record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Staff suppress facet - use `No` as default value. Hide the facet when users don't have permissions to use it. Refs UIIN-2596.
 * Add a new search option for instances called `LCCN normalization`. Refs UIIN-2245.
 * Add and adjust collapse/expand buttons for consortial instances. Refs UIIN-2711.
+* Set central tenant id when Member tenant deletes a shared record. Fixes UIIN-2784.
 
 ## [10.0.10](https://github.com/folio-org/ui-inventory/tree/v10.0.10) (2024-01-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.9...v10.0.10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 * Staff suppress facet - use `No` as default value. Hide the facet when users don't have permissions to use it. Refs UIIN-2596.
 * Add a new search option for instances called `LCCN normalization`. Refs UIIN-2245.
 * Add and adjust collapse/expand buttons for consortial instances. Refs UIIN-2711.
-* Set central tenant id when Member tenant deletes a shared record. Fixes UIIN-2784.
+* Set central tenant id in the request when Member tenant deletes a shared record. Fixes UIIN-2784.
 
 ## [10.0.10](https://github.com/folio-org/ui-inventory/tree/v10.0.10) (2024-01-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.9...v10.0.10)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -38,6 +38,7 @@ import {
   isInstanceShadowCopy,
   isMARCSource,
   getLinkedAuthorityIds,
+  setRecordForDeletion,
 } from './utils';
 import {
   CONSORTIUM_PREFIX,
@@ -168,14 +169,6 @@ class ViewInstance extends React.Component {
       path: 'consortia/!{consortiumId}/sharing/instances',
       accumulate: true,
       throwErrors: false,
-    },
-    setForDeletion: {
-      type: 'okapi',
-      throwErrors: false,
-      accumulate: true,
-      DELETE: {
-        path: 'inventory/instances/:{id}/mark-deleted',
-      },
     },
     authorities: {
       type: 'okapi',
@@ -587,15 +580,19 @@ class ViewInstance extends React.Component {
 
   handleSetForDeletion = () => {
     const {
-      mutator,
+      okapi,
+      isShared,
+      centralTenantId,
       refetchInstance,
       selectedInstance: {
         title: instanceTitle,
         id,
+        source,
       },
     } = this.props;
+    const tenantId = isShared && !isInstanceShadowCopy(source) ? centralTenantId : okapi.tenant;
 
-    mutator.setForDeletion.DELETE(id)
+    setRecordForDeletion(okapi, id, tenantId)
       .then(async () => {
         this.handleCloseSetForDeletionModal();
 
@@ -1206,9 +1203,6 @@ ViewInstance.propTypes = {
     shareInstance: PropTypes.shape({
       POST: PropTypes.func.isRequired,
       GET: PropTypes.func.isRequired,
-    }).isRequired,
-    setForDeletion: PropTypes.shape({
-      DELETE: PropTypes.func.isRequired,
     }).isRequired,
     authorities: PropTypes.shape({
       GET: PropTypes.func.isRequired,

--- a/src/ViewInstance.test.js
+++ b/src/ViewInstance.test.js
@@ -82,6 +82,7 @@ const spyOncollapseAllSections = jest.spyOn(require('@folio/stripes/components')
 const spyOnexpandAllSections = jest.spyOn(require('@folio/stripes/components'), 'expandAllSections');
 
 const spyOnGetUserTenantsPermissions = jest.spyOn(utils, 'getUserTenantsPermissions');
+const spyOnSetRecordForDeletion = jest.spyOn(utils, 'setRecordForDeletion');
 
 const location = {
   pathname: '/testPathName',
@@ -1117,20 +1118,28 @@ describe('ViewInstance', () => {
           fireEvent.click(screen.getByText('Set record for deletion'));
           fireEvent.click(screen.getByText('Confirm'));
 
-          expect(defaultProp.mutator.setForDeletion.DELETE).toHaveBeenCalledWith(defaultProp.selectedInstance.id);
+          expect(spyOnSetRecordForDeletion).toHaveBeenCalledWith(
+            { tenant: defaultProp.okapi.tenant },
+            defaultProp.selectedInstance.id,
+            defaultProp.okapi.tenant,
+          );
           expect(screen.queryByText(`${defaultProp.selectedInstance.title} has been set for deletion`)).toBeDefined();
         });
 
         describe('when there\'s an error', () => {
           it('should throw an error with id of the instance and show error message', async () => {
-            defaultProp.mutator.setForDeletion.DELETE.mockRejectedValueOnce();
+            global.fetch.mockRejectedValueOnce({ ok: false });
 
             renderViewInstance();
 
             fireEvent.click(screen.getByText('Set record for deletion'));
             fireEvent.click(screen.getByText('Confirm'));
 
-            expect(defaultProp.mutator.setForDeletion.DELETE).toHaveBeenCalledWith(defaultProp.selectedInstance.id);
+            expect(spyOnSetRecordForDeletion).toHaveBeenCalledWith(
+              { tenant: defaultProp.okapi.tenant },
+              defaultProp.selectedInstance.id,
+              defaultProp.okapi.tenant,
+            );
             expect(screen.queryByText(`${defaultProp.selectedInstance.title} was not set for deletion`)).toBeDefined();
           });
         });

--- a/src/utils.js
+++ b/src/utils.js
@@ -886,3 +886,33 @@ export const clearStorage = () => {
     removeItem(`${namespace}.${segment}.lastOpenRecord`);
   });
 };
+
+export const setRecordForDeletion = async (okapi, id, tenantId) => {
+  const {
+    url,
+    token,
+  } = okapi;
+
+  try {
+    const path = `${url}/inventory/instances/${id}/mark-deleted`;
+    const response = await fetch(path, {
+      method: 'DELETE',
+      headers: {
+        [OKAPI_TENANT_HEADER]: tenantId,
+        [CONTENT_TYPE_HEADER]: 'application/json',
+        ...(token && { [OKAPI_TOKEN_HEADER]: token }),
+      },
+      credentials: 'include',
+    });
+
+    if (!response.ok) {
+      throw new Error('Cannot set record for deletion');
+    }
+
+    return response;
+  } catch (error) {
+    console.error(error); // eslint-disable-line no-console
+
+    return error;
+  }
+};

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -13,8 +13,9 @@ import {
   validateAlphaNumericField,
   getQueryTemplate,
   switchAffiliation,
+  setRecordForDeletion,
 } from './utils';
-import { browseModeOptions } from './constants';
+import { CONTENT_TYPE_HEADER, OKAPI_TENANT_HEADER, OKAPI_TOKEN_HEADER, browseModeOptions } from './constants';
 
 describe('validateRequiredField', () => {
   const expectedResult = <FormattedMessage id="ui-inventory.hridHandling.validation.enterValue" />;
@@ -176,6 +177,69 @@ describe('switchAffiliation', () => {
       switchAffiliation(stripes, 'university', moveMock);
 
       expect(updateTenant).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('setRecordForDeletion', () => {
+  afterEach(() => {
+    global.fetch.mockClear();
+  });
+
+  afterAll(() => {
+    delete global.fetch;
+  });
+
+  const instanceId = 'testInstanceId';
+  const tenantId = 'testTenantId';
+  const okapi = {
+    token: 'token',
+    url: 'url/test',
+  };
+
+  describe('when the request was fulfilled successfuly', () => {
+    it('should return the appropriate response', () => {
+      global.fetch = jest.fn().mockReturnValue({ ok: true });
+
+      setRecordForDeletion(okapi, instanceId, tenantId);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${okapi.url}/inventory/instances/${instanceId}/mark-deleted`,
+        {
+          credentials: 'include',
+          headers: expect.objectContaining({
+            [OKAPI_TENANT_HEADER]: tenantId,
+            [OKAPI_TOKEN_HEADER]: okapi.token,
+            [CONTENT_TYPE_HEADER]: 'application/json',
+          }),
+          method: 'DELETE',
+        },
+      );
+
+      expect(global.fetch.mock.results[0].value.ok).toBe(true);
+    });
+  });
+
+  describe('when the request was fulfilled with an error', () => {
+    it('should the appropriate response', () => {
+      global.fetch = jest.fn().mockReturnValue({ ok: false });
+
+      setRecordForDeletion(okapi, instanceId, tenantId);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${okapi.url}/inventory/instances/${instanceId}/mark-deleted`,
+        {
+          credentials: 'include',
+          headers: expect.objectContaining({
+            [OKAPI_TENANT_HEADER]: tenantId,
+            [OKAPI_TOKEN_HEADER]: okapi.token,
+            [CONTENT_TYPE_HEADER]: 'application/json',
+          }),
+          method: 'DELETE',
+        },
+      );
+
+      expect(global.fetch.mock.results[0].value.ok).toBe(false);
     });
   });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
 * If user try to delete shared record from Member tenant, error message appeared. In DevTools he will see 404 error. The task is to remove this errror.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* When member tenant is setting shared instance for deletion, pass central tenant id in the request.
* Created separate function `setRecordForDeletion` which performs setting record for deletion using dynamically passed `tenantId`
* Updated unit tests

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-2784](https://folio-org.atlassian.net/browse/UIIN-2784)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-inventory/assets/85172747/bb85fe6a-3252-4599-807f-40ffbae35734


