### PR TITLE
UIIN-2814 Apply staffSuppress.false in Holdings/Items search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [10.0.1] (IN PROGRESS)
 
 * Keep query and results list when switching Browse options. Refs UIIN-2802.
+* Apply staff suppress filter for first search in Holdings/Items. Fixes UIIN-2814.
 
 ## [11.0.0](https://github.com/folio-org/ui-inventory/tree/v11.0.0) (2024-03-21)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.11...v11.0.0)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -60,6 +60,8 @@ import {
   buildSingleItemQuery,
   isUserInConsortiumMode,
   switchAffiliation,
+  addFilter,
+  replaceFilter,
 } from '../../utils';
 import {
   INSTANCES_ID_REPORT_TIMEOUT,
@@ -228,6 +230,10 @@ class InstancesList extends React.Component {
     } else if (prevId) {
       setItem(`${this.props.namespace}.${this.props.segment}.lastOpenRecord`, null);
     }
+
+    if (prevProps.segment !== this.props.segment) {
+      this.applyDefaultStaffSuppressFilter();
+    }
   }
 
   componentWillUnmount() {
@@ -250,11 +256,21 @@ class InstancesList extends React.Component {
     sessionStorage.setItem(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY, false);
   }
 
-  applyDefaultStaffSuppressFilter = () => {
+  redirectToSearchParams = (searchParams) => {
     const {
       history,
       location,
     } = this.props;
+
+    history.replace({
+      pathname: location.pathname,
+      search: searchParams.toString(),
+      state: location.state,
+    });
+  }
+
+  applyDefaultStaffSuppressFilter = () => {
+    const { location } = this.props;
 
     if (JSON.parse(sessionStorage.getItem(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY))) {
       return;
@@ -263,16 +279,26 @@ class InstancesList extends React.Component {
     const searchParams = new URLSearchParams(location.search);
     const filters = searchParams.get('filters');
 
+    const staffSuppressFalse = `${FACETS.STAFF_SUPPRESS}.false`;
+    const staffSuppressTrue = `${FACETS.STAFF_SUPPRESS}.true`;
+
     if (!filters?.includes(FACETS.STAFF_SUPPRESS)) {
-      const staffSuppressFalse = `${FACETS.STAFF_SUPPRESS}.false`;
-      const newFiltersValue = filters ? `${filters},${staffSuppressFalse}` : staffSuppressFalse;
+      const newFiltersValue = addFilter(filters, staffSuppressFalse);
 
       searchParams.set('filters', newFiltersValue);
-      history.replace({
-        pathname: location.pathname,
-        search: searchParams.toString(),
-        state: location.state,
-      });
+      this.redirectToSearchParams(searchParams);
+
+      return;
+    }
+
+    const isStaffSuppressFilterAvailable = this.props.stripes.hasPerm('ui-inventory.instance.view-staff-suppressed-records');
+    const isStaffSuppressTrueSelected = filters.includes(`${FACETS.STAFF_SUPPRESS}.true`);
+
+    if (!isStaffSuppressFilterAvailable && isStaffSuppressTrueSelected) {
+      const newFiltersValue = replaceFilter(filters, staffSuppressTrue, staffSuppressFalse);
+
+      searchParams.set('filters', newFiltersValue);
+      this.redirectToSearchParams(searchParams);
     }
   }
 

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -111,7 +111,7 @@ const openActionMenu = () => {
   fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
 };
 
-const getInstancesListTree = ({ segment, ...rest }, initialEntries) => {
+const getInstancesListTree = ({ segment, ...rest }) => {
   const {
     indexes,
     indexesES,
@@ -120,7 +120,7 @@ const getInstancesListTree = ({ segment, ...rest }, initialEntries) => {
 
   return (
     <Harness translations={translationsProperties}>
-      <Router history={history} initialEntries={initialEntries}>
+      <Router history={history}>
         <ModuleHierarchyProvider module="@folio/inventory">
           <InstancesList
             parentResources={resources}
@@ -158,7 +158,7 @@ const getInstancesListTree = ({ segment, ...rest }, initialEntries) => {
   );
 };
 
-const renderInstancesList = (props, initialEntries) => render(getInstancesListTree(props, initialEntries));
+const renderInstancesList = (props) => render(getInstancesListTree(props));
 
 describe('InstancesList', () => {
   describe('rendering InstancesList with instances segment', () => {
@@ -170,10 +170,7 @@ describe('InstancesList', () => {
       it('should replace history with selected facet value', async () => {
         jest.spyOn(history, 'replace');
 
-        renderInstancesList({ segment: 'instances' }, [{
-          pathname: '/',
-          search: 'filters=staffSuppress.true',
-        }]);
+        renderInstancesList({ segment: 'instances' });
 
         await waitFor(() => expect(history.replace).toHaveBeenCalledWith({
           pathname: '/',
@@ -188,6 +185,10 @@ describe('InstancesList', () => {
         it('should replace history with selected facet value', async () => {
           jest.spyOn(history, 'replace');
 
+          history.push({
+            pathname: '/',
+            search: 'filters=staffSuppress.true',
+          });
           renderInstancesList({
             segment: 'instances',
             stripes: {
@@ -211,8 +212,6 @@ describe('InstancesList', () => {
           jest.spyOn(history, 'replace');
 
           const { rerender } = renderInstancesList({ segment: 'instances' });
-
-          jest.clearAllMocks();
 
           history.push({
             pathname: '/',

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -55,7 +55,7 @@ const applyDefaultStaffSuppressFilter = (stripes, query) => {
   }
 
   const isStaffSuppressFilterAvailable = stripes.hasPerm('ui-inventory.instance.view-staff-suppressed-records');
-  const isStaffSuppressTrueSelected = query.filters.includes(`${FACETS.STAFF_SUPPRESS}.true`);
+  const isStaffSuppressTrueSelected = query.filters?.includes(`${FACETS.STAFF_SUPPRESS}.true`);
 
   if (!isStaffSuppressFilterAvailable && isStaffSuppressTrueSelected) {
     query.filters = replaceFilter(query.filters, staffSuppressTrue, staffSuppressFalse);

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -16,7 +16,6 @@ import {
 import {
   getQueryTemplate,
   getIsbnIssnTemplate,
-  removeFilter,
   replaceFilter,
 } from '../utils';
 import { getFilterConfig } from '../filterConfig';
@@ -49,7 +48,7 @@ const applyDefaultStaffSuppressFilter = (stripes, query) => {
   const staffSuppressTrue = `${FACETS.STAFF_SUPPRESS}.true`;
 
   if (!query.query && query.filters === staffSuppressFalse && !isUserTouchedStaffSuppress) {
-    // if query is empty and th~ only filter value is staffSuppress.false and search was not initiated by user action
+    // if query is empty and the only filter value is staffSuppress.false and search was not initiated by user action
     // then we need to clear the query.filters here to not automatically search when Inventory search is opened
     query.filters = undefined;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,7 +44,6 @@ import {
   OKAPI_TOKEN_HEADER,
   AUTHORITY_LINKED_FIELDS,
   segments,
-  FACETS,
 } from './constants';
 import { removeItem } from './storage';
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,6 +44,7 @@ import {
   OKAPI_TOKEN_HEADER,
   AUTHORITY_LINKED_FIELDS,
   segments,
+  FACETS,
 } from './constants';
 import { removeItem } from './storage';
 
@@ -885,4 +886,25 @@ export const clearStorage = () => {
   Object.values(segments).forEach((segment) => {
     removeItem(`${namespace}.${segment}.lastOpenRecord`);
   });
+};
+
+export const removeFilter = (filters, filterNameAndValue) => {
+  const filtersArray = filters.split(',');
+  return filtersArray.filter(_filter => _filter !== filterNameAndValue).join(',');
+};
+
+export const addFilter = (filters, filterNameAndValue) => {
+  return filters ? `${filters},${filterNameAndValue}` : filterNameAndValue;
+};
+
+export const replaceFilter = (filters, filterToReplace, filterToReplaceWith) => {
+  const filtersArray = filters.split(',');
+
+  return filtersArray.reduce((acc, _filter) => {
+    if (_filter === filterToReplace) {
+      return [...acc, filterToReplaceWith];
+    }
+
+    return [...acc, _filter];
+  }, []).join(',');
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -888,11 +888,6 @@ export const clearStorage = () => {
   });
 };
 
-export const removeFilter = (filters, filterNameAndValue) => {
-  const filtersArray = filters.split(',');
-  return filtersArray.filter(_filter => _filter !== filterNameAndValue).join(',');
-};
-
 export const addFilter = (filters, filterNameAndValue) => {
   return filters ? `${filters},${filterNameAndValue}` : filterNameAndValue;
 };

--- a/src/views/BrowseInventory/BrowseInventory.js
+++ b/src/views/BrowseInventory/BrowseInventory.js
@@ -163,7 +163,7 @@ const BrowseInventory = () => {
       as a work-around we can call `clearFilters` to clear filters only
     */
     changeSearchIndex(e);
-    //clearFilters();
+    clearFilters();
   }, [deleteItemToView, clearFilters, changeSearchIndex]);
 
   const onReset = useCallback(() => {

--- a/src/views/BrowseInventory/BrowseInventory.js
+++ b/src/views/BrowseInventory/BrowseInventory.js
@@ -163,7 +163,7 @@ const BrowseInventory = () => {
       as a work-around we can call `clearFilters` to clear filters only
     */
     changeSearchIndex(e);
-    clearFilters();
+    //clearFilters();
   }, [deleteItemToView, clearFilters, changeSearchIndex]);
 
   const onReset = useCallback(() => {


### PR DESCRIPTION
## Description
Apply staffSuppress.false when switching between Instance/Holdings/Items search
If a user doesn't have permissions to use Staff Suppress facet - when `staffSuppress.true` is present in the url then it should be changed to `staffSuppress.false`.

## Screenshots

https://github.com/folio-org/ui-inventory/assets/19309423/8209356c-8527-4670-9a65-13469f003b29


## Issues
[UIIN-2814](https://folio-org.atlassian.net/browse/UIIN-2814)