### PR TITLE
UIIN-2819: Remove unused code related to auto-open record detail view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [10.1.0] (IN PROGRESS)
 
+* Remove unused code related to auto-open record detail view. Refs UIIN-2819.
+
 ## [10.0.1] (IN PROGRESS)
 
 * Keep query and results list when switching Browse options. Refs UIIN-2802.

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -104,7 +104,6 @@ const VISIBLE_COLUMNS_STORAGE_KEY = 'inventory-visible-columns';
 class InstancesList extends React.Component {
   static defaultProps = {
     canUseSingleRecordImport: false,
-    showSingleResult: true,
     segment: segments.instances,
   };
 
@@ -113,7 +112,6 @@ class InstancesList extends React.Component {
     data: PropTypes.object,
     parentResources: PropTypes.object,
     parentMutator: PropTypes.object,
-    showSingleResult: PropTypes.bool,
     disableRecordCreation: PropTypes.bool,
     updateLocation: PropTypes.func.isRequired,
     goTo: PropTypes.func.isRequired,
@@ -175,7 +173,6 @@ class InstancesList extends React.Component {
       isImportRecordModalOpened: false,
       searchAndSortKey: 0,
       segmentsSortBy: this.getInitialSegmentsSortBy(),
-      isSingleResult: this.props.showSingleResult,
       searchInProgress: false,
     };
   }
@@ -1125,7 +1122,6 @@ class InstancesList extends React.Component {
       isImportRecordModalOpened,
       selectedRows,
       searchAndSortKey,
-      isSingleResult
     } = this.state;
 
     const itemToView = getItem(`${namespace}.position`);
@@ -1208,10 +1204,6 @@ class InstancesList extends React.Component {
     const visibleColumns = this.getVisibleColumns();
     const columnMapping = this.getColumnMapping();
 
-    const onChangeIndex = () => {
-      this.setState({ isSingleResult: true });
-    };
-
     const formattedSearchableIndexes = searchableIndexes.map(this.formatSearchableIndex);
 
     const advancedSearchOptions = advancedSearchIndexes[segment].map(this.formatSearchableIndex);
@@ -1281,7 +1273,6 @@ class InstancesList extends React.Component {
             resultCountIncrement={RESULT_COUNT_INCREMENT}
             viewRecordComponent={ViewInstanceWrapper}
             editRecordComponent={InstanceForm}
-            onChangeIndex={onChangeIndex}
             onSelectRow={this.onSelectRow}
             paneTitleRef={this.paneTitleRef}
             newRecordInitialValues={(this.state && this.state.copiedInstance) ? this.state.copiedInstance : {
@@ -1323,7 +1314,7 @@ class InstancesList extends React.Component {
             }}
             basePath={path}
             path={`${path}/(view|viewsource)/:id/:holdingsrecordid?/:itemid?`}
-            showSingleResult={isSingleResult}
+            showSingleResult
             renderFilters={renderFilters}
             onFilterChange={this.onFilterChangeHandler}
             onSubmitSearch={this.onSubmitSearch}

--- a/src/routes/InstancesRoute.js
+++ b/src/routes/InstancesRoute.js
@@ -16,7 +16,6 @@ class InstancesRoute extends React.Component {
   static propTypes = {
     resources: PropTypes.object.isRequired,
     mutator: PropTypes.object.isRequired,
-    showSingleResult: PropTypes.bool,
     disableRecordCreation: PropTypes.bool,
     onSelectRow: PropTypes.func,
     getParams: PropTypes.func,
@@ -29,7 +28,6 @@ class InstancesRoute extends React.Component {
   };
 
   static defaultProps = {
-    showSingleResult: true,
     disableRecordCreation: false,
   };
 
@@ -37,7 +35,6 @@ class InstancesRoute extends React.Component {
 
   render() {
     const {
-      showSingleResult,
       onSelectRow,
       disableRecordCreation,
       resources,
@@ -62,7 +59,6 @@ class InstancesRoute extends React.Component {
             parentResources={parentResources}
             parentMutator={mutator}
             data={{ ...data, query }}
-            showSingleResult={showSingleResult}
             onSelectRow={onSelectRow}
             disableRecordCreation={disableRecordCreation}
             renderFilters={renderer({


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Remove unused code related to auto-open record detail view (third pane).
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Description
The `showSingleResult` prop is passed from `InstancesRoute` and is always `true`. This prop should always be true for `SearchAndSort` because we are using the auto-opening feature, and there is no need to pass it from the route component.

This code snippet is from a time when `Search` and `Browse` searches were not separated. It is no longer needed.
```
const onChangeIndex = () => {
  this.setState({ isSingleResult: true });
};
```

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-2819](https://folio-org.atlassian.net/browse/UIIN-2819)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
