### PR TITLE
UIIN-2776: Add a new "Inventory: Create and download In transit items report" permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Change history for ui-inventory
 
-## [10.1.0] (IN PROGRESS)
+## [11.1.0] (IN PROGRESS)
 
 * Remove unused code related to auto-open record detail view. Refs UIIN-2819.
-* Replace `all` with the `=` operator to get correct results when using the `All` search option.
+* Replace `all` with the `=` operator to get correct results when using the `All` search option. Refs UIIN-2816.
 
-## [10.0.1] (IN PROGRESS)
+## [11.0.1] (IN PROGRESS)
 
 * Keep query and results list when switching Browse options. Refs UIIN-2802.
 * Set central tenant id in the request when Member tenant deletes a shared record. Fixes UIIN-2784.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Apply staff suppress filter for first search in Holdings/Items. Fixes UIIN-2814.
 * Pass tenantId when open holding details during moving holdings/items. Fixes UIIN-2815.
 * Do not remove field from the form when its value is an empty string. Fixes UIIN-2787.
+* Add a new "Inventory: Create and download In transit items report" permission. Fixes UIIN-2776.
 
 ## [11.0.0](https://github.com/folio-org/ui-inventory/tree/v11.0.0) (2024-03-21)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.11...v11.0.0)

--- a/package.json
+++ b/package.json
@@ -835,6 +835,14 @@
         "visible": true
       },
       {
+        "permissionName": "ui-inventory.items.create-in-transit-report",
+        "displayName": "Inventory: Create and download In transit items report",
+        "subPermissions": [
+          "circulation.inventory.items-in-transit-report.get"
+        ],
+        "visible": true
+      },
+      {
         "permissionName": "ui-inventory.single-record-import",
         "displayName": "Inventory: Import single bibliographic records",
         "subPermissions": [

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -751,6 +751,7 @@ class InstancesList extends React.Component {
     const visibleColumns = this.getVisibleColumns();
     const columnMapping = this.getColumnMapping();
     const canExportMarc = stripes.hasPerm('ui-data-export.app.enabled');
+    const canCreateItemsInTransitReport = stripes.hasPerm('ui-inventory.items.create-in-transit-report');
 
     const buildOnClickHandler = onClickHandler => {
       return () => {
@@ -841,7 +842,7 @@ class InstancesList extends React.Component {
               icon: 'report',
               messageId: 'ui-inventory.exportInProgress',
             }) :
-            !checkIfUserInCentralTenant(stripes) && this.getActionItem({
+            canCreateItemsInTransitReport && !checkIfUserInCentralTenant(stripes) && this.getActionItem({
               id: 'dropdown-clickable-get-report',
               icon: 'report',
               messageId: 'ui-inventory.inTransitReport',

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -752,6 +752,7 @@
   "permission.items.mark-long-missing": "Inventory: Mark items long missing",
   "permission.items.mark-in-process-non-requestable": "Inventory: Mark items in process (non-requestable)",
   "permission.consortia.inventory.share.local.instance": "Inventory: Share local instance with consortium",
+  "permission.items.create-in-transit-report": "Inventory: Create and download In transit items report",
 
   "moveItems.moveButton": "Move to",
   "moveItems.selectAll": "Select/unselect all items for movement",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Douglas College got an error message while trying to generate the “In Transit Items Report” in the Inventory module because of missed permission. It is required to create a separate UI permission for “In Transit Items Report” generating.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Added a new **"Inventory: Create and download In transit items report"** UI permission
- Hidden `In transit items report (CSV)` action item for users without permission.
- Fix versions in CHANGELOG (`11.0.1` - Quesnelia Bugfix, `11.1.0` - Ramsons)

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-2776

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
**UI permission**
<img width="878" alt="new_perm" src="https://github.com/folio-org/ui-inventory/assets/55138456/8c43b3ff-4daa-4fd9-9422-0c99f400c713">

**Actions menu with permission**
<img width="1508" alt="with_perm" src="https://github.com/folio-org/ui-inventory/assets/55138456/48a9c22e-8edd-46a4-84ef-fe74963539ca">

**Actions menu without permission**
<img width="1512" alt="without_perm" src="https://github.com/folio-org/ui-inventory/assets/55138456/d6ac8359-5da9-49c1-ae19-9a628054e096">
