### PR TITLE
UIIN-2795: Replace 'Mod' with 'Control' for the quick-marc shortcuts.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,12 +67,12 @@ const InventoryRouting = (props) => {
     {
       label: <FormattedMessage id="ui-inventory.shortcut.nextSubfield" />,
       name: 'NEXT_SUBFIELD',
-      shortcut: 'Mod + ]',
+      shortcut: 'Control + ]',
     },
     {
       label: <FormattedMessage id="ui-inventory.shortcut.prevSubfield" />,
       name: 'PREV_SUBFIELD',
-      shortcut: 'Mod + [',
+      shortcut: 'Control + [',
     },
     ...defaultKeyboardShortcuts.slice(9),
   ];

--- a/src/index.js
+++ b/src/index.js
@@ -67,12 +67,12 @@ const InventoryRouting = (props) => {
     {
       label: <FormattedMessage id="ui-inventory.shortcut.nextSubfield" />,
       name: 'NEXT_SUBFIELD',
-      shortcut: 'Control + ]',
+      shortcut: 'Ctrl + ]',
     },
     {
       label: <FormattedMessage id="ui-inventory.shortcut.prevSubfield" />,
       name: 'PREV_SUBFIELD',
-      shortcut: 'Control + [',
+      shortcut: 'Ctrl + [',
     },
     ...defaultKeyboardShortcuts.slice(9),
   ];


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Description
Follow-up PR.
~~Windows computers should see `Ctrl` for the `quick-marc` shortcuts.
MAC computers should see `Control` for the `quick-marc` shortcuts.~~

Requirement change: show `Ctrl` for both OS for prev/next subfield shortcuts ([details](https://folio-org.atlassian.net/browse/UIIN-2795?focusedCommentId=207160)).

<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Related PRs
~~https://github.com/folio-org/stripes-components/pull/2260~~

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-2795](https://folio-org.atlassian.net/browse/UIIN-2795)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots

For Windows
![image](https://github.com/folio-org/stripes-components/assets/77053927/6f9a8f1a-4029-4b95-a1df-fba1309ddc69)

For MAC
![image](https://github.com/folio-org/stripes-components/assets/77053927/33ce7dd4-2def-4fea-bb5b-f4d364914604)
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
