### PR TITLE
UIIN-2814 Clear USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY flag when switching between search segments (follow-up)

### DIFF
--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -471,6 +471,7 @@ class InstancesList extends React.Component {
   handleSearchSegmentChange = (segment) => {
     this.refocusOnInputSearch(segment);
     this.setState({ selectedRows: {} });
+    sessionStorage.setItem(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY, false);
   }
 
   onSearchModeSwitch = () => {

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -207,6 +207,26 @@ describe('InstancesList', () => {
     });
 
     describe('when switching to Holdings tab', () => {
+      const mockSetItem = jest.fn();
+
+      beforeEach(() => {
+        global.Storage.prototype.setItem = mockSetItem;
+      });
+
+      afterEach(() => {
+        global.Storage.prototype.setItem.mockReset();
+      });
+
+      it ('should clear USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY', async () => {
+        renderInstancesList({ segment: 'instances' });
+
+        const search = '?segment=instances&sort=title';
+        act(() => { history.push({ search }); });
+        await act(async () => fireEvent.click(screen.getByRole('button', { name: /^holdings$/i })));
+
+        expect(mockSetItem).toHaveBeenCalledWith(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY, false);
+      });
+
       describe('when staffSuppress filter is not present', () => {
         it('should replace history with selected facet value', async () => {
           jest.spyOn(history, 'replace');


### PR DESCRIPTION
## Description
We need to clear `USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY ` when switching between search segments. If the flag is true we skip setting of default value for `staffSuppress` facet so we need to clear the flag.

## Screenshots

https://github.com/folio-org/ui-inventory/assets/19309423/1138cbc2-27c3-4905-9b2b-63759034583a



## Issues
[UIIN-2814](https://folio-org.atlassian.net/browse/UIIN-2814)