### PR TITLE
UIIN-2826 Add "Display to public" column to receiving history on Holdings

### DIFF
--- a/src/Holding/ViewHolding/HoldingReceivingHistory/HoldingReceivingHistory.js
+++ b/src/Holding/ViewHolding/HoldingReceivingHistory/HoldingReceivingHistory.js
@@ -35,7 +35,7 @@ const columnFormatter = {
   'chronology': i => i.chronology || <NoValue />,
   'receivedDate': i => (i.receivedDate ? <FormattedDate value={i.receivedDate} /> : <NoValue />),
   'comment': i => i.comment || <NoValue />,
-  'displayToPublic': i => <Checkbox checked={i.displayToPublic} disabled />,
+  'displayToPublic': i => <Checkbox checked={i.displayToPublic || i.publicDisplay} disabled />,
   'source': i => <FormattedMessage id={`ui-inventory.receivingHistory.source.${i.source || 'user'}`} />,
 };
 const sorters = {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
https://folio-org.atlassian.net/browse/UIIN-2826

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
use correct column from holding receiving history

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
