### PR TITLE
UIIN-2855: Update Permission name for Inventory: Set records for deletion and staff suppress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Do not remove field from the form when its value is an empty string. Fixes UIIN-2787.
 * ECS: Shared instance cannot be edited from member tenant, even with permissions in both Central and member tenants. Fixes UIIN-2832.
 * Restricted status displays as Order Closed. Fixes UIIN-2821.
+* Update Permission name for Inventory: Set records for deletion and staff suppress. Refs UIIN-2855.
 
 ## [11.0.1](https://github.com/folio-org/ui-inventory/tree/v11.0.1) (2024-04-11)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.0...v11.0.1)

--- a/package.json
+++ b/package.json
@@ -722,7 +722,7 @@
       },
       {
         "permissionName": "ui-inventory.instance.set-deletion-and-staff-suppress",
-        "displayName": "Inventory: Set records for deletion and staff suppress",
+        "displayName": "Inventory: Set records for deletion",
         "subPermissions": [
           "ui-inventory.instance.view",
           "source-storage.records.update"

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -755,7 +755,7 @@
   "permission.holdings.move": "Inventory: Move holdings",
   "permission.holdings.delete": "Inventory: View, create, edit, delete holdings",
   "permission.instance.view-staff-suppressed-records": "Inventory: Enable staff suppress facet",
-  "permission.instance.set-deletion-and-staff-suppress": "Inventory: Set records for deletion and staff suppress",
+  "permission.instance.set-deletion-and-staff-suppress": "Inventory: Set records for deletion",
   "permission.settings.list.view": "Settings (Inventory): View list of settings pages",
   "permission.items.mark-items-withdrawn": "Inventory: Mark items withdrawn",
   "permission.items.mark-intellectual-item": "Inventory: Mark items intellectual item",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Upon review, we feel that the permission should specifically speak to the ‘set record for deletion’ action ability. Even though the action does apply staff suppressed field too, I fear the current language could be confusing.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Update permission name.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-2855

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
