### PR TITLE
UIIN-2860: Include mod-search permissions to "Inventory: Module is enabled" UI permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * ECS: Shared instance cannot be edited from member tenant, even with permissions in both Central and member tenants. Fixes UIIN-2845.
 * Restricted status displays as Order Closed. Fixes UIIN-2821.
 * Update Permission name for Inventory: Set records for deletion and staff suppress. Refs UIIN-2855.
+* Include mod-search permissions to "Inventory: Module is enabled" UI permission. Refs UIIN-2860.
 
 ## [11.0.1](https://github.com/folio-org/ui-inventory/tree/v11.0.1) (2024-04-11)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.0...v11.0.1)

--- a/package.json
+++ b/package.json
@@ -119,7 +119,9 @@
           "search.config.languages.collection.get",
           "search.config.languages.item.delete",
           "search.index.inventory.reindex.post",
-          "search.facets.collection.get"
+          "search.facets.collection.get",
+          "consortium-search.holdings.collection.get",
+          "consortium-search.items.collection.get"
         ]
       },
       {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
[UIIN-2780](https://folio-org.atlassian.net/browse/UIIN-2780) requires to have `consortium-search.items.collection.get` and `consortium-search.holdings.collection.get` permissions assigned to a member tenant to be able to fetch limited info about holdings/items. These permissions should not be visible via UI but rather be assigned automatically that is why we decided to add these to the "Inventory: Module is enabled" sub-permissions.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Add missing perms to the "Inventory: Module is enabled" sub-permissions

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-2860

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
