### PR TITLE
UIIN-2624: Make classification column 50% width in the Browse results.

### DIFF
--- a/src/components/BrowseResultsList/constants.js
+++ b/src/components/BrowseResultsList/constants.js
@@ -35,6 +35,15 @@ export const COLUMNS_WIDTHS = {
     callNumber: '15%',
     title: '40%',
   },
+  [browseModeOptions.CLASSIFICATION_ALL]: {
+    classificationNumber: '50%',
+  },
+  [browseModeOptions.DEWEY_CLASSIFICATION]: {
+    classificationNumber: '50%',
+  },
+  [browseModeOptions.LC_CLASSIFICATION]: {
+    classificationNumber: '50%',
+  },
   [browseModeOptions.CONTRIBUTORS]: {
     contributor: '50%',
     contributorType: '15%',


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Follow-up pull request.
Make the classification column 50% width in the Browse results.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-2624](https://folio-org.atlassian.net/browse/UIIN-2624)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
![image](https://github.com/folio-org/ui-inventory/assets/77053927/ba8cbf10-05c4-4c2d-a28f-073309c78c48)

<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
