### PR TITLE
UIIN-2666 Jest/RTL: Cover ConnectedTitle component with unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Update Permission name for Inventory: Set records for deletion and staff suppress. Refs UIIN-2855.
 * ECS Member tenant - add `Shared` and `Held by` facets for the `Classification` browse. Refs UIIN-2813.
 * Jest/RTL: Cover CalloutRenderer component with unit tests. Refs UIIN-2665.
+* Jest/RTL: Cover ConnectedTitle component with unit tests. Refs UIIN-2666.
 
 ## [11.0.3] (IN PROGRESS)
 

--- a/src/Instance/InstanceDetails/SubInstanceList/SubInstanceList.test.js
+++ b/src/Instance/InstanceDetails/SubInstanceList/SubInstanceList.test.js
@@ -65,7 +65,7 @@ describe('render SubInstanceList', () => {
   it('NoValue should display when no title is present', () => {
     useLoadSubInstances.mockReturnValue([{}]);
     const { getAllByText } = renderSubInstanceList(defaultProps);
-    expect(getAllByText(/No value set/i).length).toBe(4);
+    expect(getAllByText(/No value set/i).length).toBe(6);
   });
   it('No link to be present when tittleKey is empty', () => {
     useLoadSubInstances.mockReturnValue(mockuseLoadSubInstancesVaues);
@@ -87,6 +87,6 @@ describe('render SubInstanceList', () => {
     useLoadSubInstances.mockReturnValue(mockuseLoadSubInstancesVaues);
     const { container, getByRole } = renderSubInstanceList(defaultProps);
     userEvent.click(getByRole('button', { name: 'Next' }));
-    expect(container.getElementsByClassName('sr-only').length).toBe(1);
+    expect(container.getElementsByClassName('sr-only').length).toBe(3);
   });
 });

--- a/src/components/ConnectedTitle/ConnectedTitle.test.js
+++ b/src/components/ConnectedTitle/ConnectedTitle.test.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { keyBy } from 'lodash';
+
+import { DataContext } from '../../contexts';
+import { identifierTypes, instanceRelationshipTypes } from '../../../test/fixtures';
+import ConnectedTitle from './ConnectedTitle';
+import renderWithIntl from '../../../test/jest/helpers/renderWithIntl';
+
+jest.mock('../InstancePlugin/InstancePlugin', () => ({ onSelect, onClose }) => {
+  return (
+    <div>
+      <div>InstancePlugin</div>
+      <button type="button" onClick={() => onSelect()}>onSelect</button>
+      <button type="button" onClick={() => onClose()}>onClose</button>
+    </div>
+  );
+});
+
+const renderConnectedTitle = (props = {}) => renderWithIntl(
+  <Router>
+    <DataContext.Provider value={{
+      contributorTypes: [],
+      identifierTypes,
+      identifierTypesById: keyBy(identifierTypes, 'id'),
+      identifierTypesByName: keyBy(identifierTypes, 'name'),
+      instanceRelationshipTypes,
+      instanceRelationshipTypesById: keyBy(identifierTypes, 'id'),
+      instanceFormats: [],
+      modesOfIssuance: [],
+      natureOfContentTerms: [],
+      tagsRecords: [],
+    }}
+    >
+      <ConnectedTitle
+        instance={{
+          title: '',
+          hrid: '',
+          identifiers: [],
+        }}
+        onSelect={() => {}}
+        titleIdKey="id"
+        {...props}
+      />
+    </DataContext.Provider>
+  </Router>
+);
+
+
+describe('ConnectedTitle', () => {
+  it('should render correct titles', () => {
+    const { queryByText } = renderConnectedTitle();
+
+    expect(queryByText('ui-inventory.precedingField.title')).toBeInTheDocument();
+    expect(queryByText('ui-inventory.precedingField.connected')).toBeInTheDocument();
+    expect(queryByText('ui-inventory.instanceHrid')).toBeInTheDocument();
+    expect(queryByText('ui-inventory.isbn')).toBeInTheDocument();
+    expect(queryByText('ui-inventory.issn')).toBeInTheDocument();
+  });
+
+  it('should render fallback data if props are not present', () => {
+    const { queryAllByText } = renderConnectedTitle();
+
+    // 3 - means for isbn, issn and hrid
+    expect(queryAllByText('ui-inventory.notAvailable').length).toBe(3);
+  });
+
+  it('should render correct data based on props', () => {
+    const { queryByText } = renderConnectedTitle({
+      instance: {
+        title: 'test-title',
+        hrid: 'test-hrid',
+        identifiers: [
+          { identifierTypeId: '8261054f-be78-422d-bd51-4ed9f33c3422', value: '1111' },
+          { identifierTypeId: 'c858e4f2-2b6b-4385-842b-60732ee14abb', value: '2222' },
+        ],
+      },
+    });
+
+    expect(queryByText('ui-inventory.notAvailable')).not.toBeInTheDocument();
+
+    expect(queryByText('test-title')).toBeInTheDocument();
+    expect(queryByText('test-hrid')).toBeInTheDocument();
+    expect(queryByText('1111')).toBeInTheDocument();
+    expect(queryByText('2222')).toBeInTheDocument();
+  });
+});

--- a/src/components/ConnectedTitle/ConnectedTitle.test.js
+++ b/src/components/ConnectedTitle/ConnectedTitle.test.js
@@ -6,6 +6,7 @@ import { DataContext } from '../../contexts';
 import { identifierTypes, instanceRelationshipTypes } from '../../../test/fixtures';
 import ConnectedTitle from './ConnectedTitle';
 import renderWithIntl from '../../../test/jest/helpers/renderWithIntl';
+import translationsProperties from '../../../test/jest/helpers/translationsProperties';
 
 jest.mock('../InstancePlugin/InstancePlugin', () => ({ onSelect, onClose }) => {
   return (
@@ -43,7 +44,8 @@ const renderConnectedTitle = (props = {}) => renderWithIntl(
         {...props}
       />
     </DataContext.Provider>
-  </Router>
+  </Router>,
+  translationsProperties
 );
 
 
@@ -51,18 +53,18 @@ describe('ConnectedTitle', () => {
   it('should render correct titles', () => {
     const { queryByText } = renderConnectedTitle();
 
-    expect(queryByText('ui-inventory.precedingField.title')).toBeInTheDocument();
-    expect(queryByText('ui-inventory.precedingField.connected')).toBeInTheDocument();
-    expect(queryByText('ui-inventory.instanceHrid')).toBeInTheDocument();
-    expect(queryByText('ui-inventory.isbn')).toBeInTheDocument();
-    expect(queryByText('ui-inventory.issn')).toBeInTheDocument();
+    expect(queryByText('Title')).toBeInTheDocument();
+    expect(queryByText('Connected')).toBeInTheDocument();
+    expect(queryByText('Instance HRID')).toBeInTheDocument();
+    expect(queryByText('ISBN')).toBeInTheDocument();
+    expect(queryByText('ISSN')).toBeInTheDocument();
   });
 
   it('should render fallback data if props are not present', () => {
     const { queryAllByText } = renderConnectedTitle();
 
     // 3 - means for isbn, issn and hrid
-    expect(queryAllByText('ui-inventory.notAvailable').length).toBe(3);
+    expect(queryAllByText('N/A').length).toBe(3);
   });
 
   it('should render correct data based on props', () => {
@@ -77,7 +79,7 @@ describe('ConnectedTitle', () => {
       },
     });
 
-    expect(queryByText('ui-inventory.notAvailable')).not.toBeInTheDocument();
+    expect(queryByText('N/A')).not.toBeInTheDocument();
 
     expect(queryByText('test-title')).toBeInTheDocument();
     expect(queryByText('test-hrid')).toBeInTheDocument();

--- a/src/utils.js
+++ b/src/utils.js
@@ -474,6 +474,8 @@ export const getIdentifiers = (identifiers = [], type, identifierTypesById) => {
     }
   });
 
+  if (!result.length) return null;
+
   return (
     <div>
       {result.map((value, index) => <div>{`${value}${index !== result.length - 1 ? ',' : ''}`}</div>)}


### PR DESCRIPTION
After this PR merged: 

- coverage for ConnectedTitle will be 100%
- fixed a condition that was never met

Ref: [UIIN-2666](https://folio-org.atlassian.net/browse/UIIN-2666)

![image](https://github.com/folio-org/ui-inventory/assets/86330150/c99179cf-af26-4536-a297-327b85ca9fb4)
