### PR TITLE
UIIN-2811 Use consolidated locations endpoint to fetch all locations when in central tenant context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Jest/RTL: Cover InstancePlugin component with unit tests. Refs UIIN-2668.
 * Jest/RTL: Cover ImportRecord component with unit test. Refs UIIN-2667.
 * Jest/RTL: Cover MoveHoldingContext component with unit tests. Refs UIIN-2664.
+* Use consolidated locations endpoint to fetch all locations when in central tenant context. Refs UIIN-2811.
 
 ## [11.0.3](https://github.com/folio-org/ui-inventory/tree/v11.0.3) (2024-04-26)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.2...v11.0.3)

--- a/package.json
+++ b/package.json
@@ -569,7 +569,8 @@
           "browse.subjects.instances.collection.get",
           "browse.classification-numbers.instances.collection.get",
           "perms.users.get",
-          "inventory-storage.bound-with-parts.collection.get"
+          "inventory-storage.bound-with-parts.collection.get",
+          "consortium-search.locations.collection.get"
         ],
         "visible": true
       },

--- a/src/hooks/useLocationsForTenants/useLocationsForTenants.test.js
+++ b/src/hooks/useLocationsForTenants/useLocationsForTenants.test.js
@@ -3,7 +3,10 @@ import {
   QueryClientProvider,
 } from 'react-query';
 
-import { useOkapiKy } from '@folio/stripes/core';
+import {
+  useOkapiKy,
+  checkIfUserInCentralTenant,
+} from '@folio/stripes/core';
 
 import {
   renderHook,
@@ -37,22 +40,60 @@ describe('useLocationsForTenants', () => {
 
   const tenantIds = ['cs00000int', 'cs00000int_0002'];
 
-  it('should fetch locations of all tenants', async () => {
-    const { result } = renderHook(() => useLocationsForTenants({ tenantIds }), { wrapper });
+  describe('when user is in a member tenant', () => {
+    it('should fetch locations of all tenants via multiple requests', async () => {
+      const { result } = renderHook(() => useLocationsForTenants({ tenantIds }), { wrapper });
 
-    await act(() => !result.current.isLoading);
+      await act(() => !result.current.isLoading);
 
-    expect(result.current.data).toEqual([
-      { id: 'location-id' },
-      { id: 'location-id' },
-    ]);
+      expect(mockGet.mock.calls[0][0]).toBe('locations');
+      expect(mockGet.mock.calls[1][0]).toBe('locations');
+      expect(result.current.data).toEqual([
+        { id: 'location-id' },
+        { id: 'location-id' },
+      ]);
+    });
+
+    it('should not call consolidated locations endpoint', async () => {
+      const { result } = renderHook(() => useLocationsForTenants({ tenantIds }), { wrapper });
+
+      await act(() => !result.current.isLoading);
+
+      expect(mockGet).not.toHaveBeenCalledWith('search/consortium/locations');
+    });
+
+    describe('when tenantIds is empty', () => {
+      it('should not make a request', () => {
+        renderHook(() => useLocationsForTenants({ tenantIds: [] }), { wrapper });
+
+        expect(mockGet).not.toHaveBeenCalled();
+      });
+    });
   });
 
-  describe('when tenantIds is empty', () => {
-    it('should not make a request', () => {
-      renderHook(() => useLocationsForTenants({ tenantIds: [] }), { wrapper });
+  describe('when user is in a central tenant', () => {
+    beforeEach(() => {
+      checkIfUserInCentralTenant.mockClear().mockReturnValue(true);
+    });
 
-      expect(mockGet).not.toHaveBeenCalled();
+    it('should fetch locations of all tenants via consolidated endpoint', async () => {
+      const { result } = renderHook(() => useLocationsForTenants({ tenantIds }), { wrapper });
+
+      await act(() => !result.current.isLoading);
+
+      expect(mockGet).toHaveBeenCalledWith('search/consortium/locations');
+
+      expect(result.current.data).toEqual([
+        { id: 'location-id' },
+      ]);
+    });
+
+    it('should not call multiple locations endpoints', async () => {
+      const { result } = renderHook(() => useLocationsForTenants({ tenantIds }), { wrapper });
+
+      await act(() => !result.current.isLoading);
+
+      expect(mockGet).not.toHaveBeenCalledWith('locations');
     });
   });
 });

--- a/src/providers/DataProvider.js
+++ b/src/providers/DataProvider.js
@@ -47,6 +47,10 @@ const DataProvider = ({
   const { data: locationsOfAllTenants } = useLocationsForTenants({ tenantIds });
 
   useEffect(() => {
+    if (isUserInConsortiumMode(stripes)) {
+      return;
+    }
+
     mutator.locations.GET({ tenant: stripes.okapi.tenant });
   }, [stripes.okapi.tenant]);
 


### PR DESCRIPTION
## Description
 Use consolidated locations endpoint to fetch all locations when in central tenant context.

## Screenshots

https://github.com/folio-org/ui-inventory/assets/19309423/5118de48-895f-4413-919f-351a20b2a151



## Issues
[UIIN-2811](https://folio-org.atlassian.net/browse/UIIN-2811)