### PR TITLE
UIIN-2886: Use useTenantKy instead of useOkapiKy for Poppy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## **10.0.15** (in progress)
+
+* Use useTenantKy instead of useOkapiKy. Fixes UIIN-2886.
+
 ## [10.0.14](https://github.com/folio-org/ui-inventory/tree/v10.0.14) (2024-04-25)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.13...v10.0.14)
 

--- a/src/hooks/useConsortiumHoldings/useConsortiumHoldings.js
+++ b/src/hooks/useConsortiumHoldings/useConsortiumHoldings.js
@@ -3,15 +3,16 @@ import { useQuery } from 'react-query';
 import {
   useNamespace,
   useStripes,
-  useOkapiKy,
 } from '@folio/stripes/core';
+
+import { useTenantKy } from '../../common';
 
 const useConsortiumHoldings = (instanceId, tenantId) => {
   const stripes = useStripes();
   const consortium = stripes.user?.user?.consortium;
   const centralTenantId = consortium?.centralTenantId;
 
-  const ky = useOkapiKy({ tenant: centralTenantId });
+  const ky = useTenantKy({ tenantId: centralTenantId });
   const [namespace] = useNamespace({ key: 'search-tenants-holdings-by-instance-id' });
 
   const { isLoading, data = {} } = useQuery({

--- a/src/hooks/useConsortiumHoldings/useConsortiumHoldings.test.js
+++ b/src/hooks/useConsortiumHoldings/useConsortiumHoldings.test.js
@@ -8,15 +8,15 @@ import {
   renderHook,
   act,
 } from '@folio/jest-config-stripes/testing-library/react';
-import { useOkapiKy } from '@folio/stripes/core';
 
 import '../../../test/jest/__mock__';
 
 import useConsortiumHoldings from './useConsortiumHoldings';
+import { useTenantKy } from '../../common';
 
-jest.mock('@folio/stripes/core', () => ({
-  ...jest.requireActual('@folio/stripes/core'),
-  useOkapiKy: jest.fn(),
+jest.mock('../../common', () => ({
+  ...jest.requireActual('../../common'),
+  useTenantKy: jest.fn(),
 }));
 
 const queryClient = new QueryClient();
@@ -28,7 +28,7 @@ const wrapper = ({ children }) => (
 
 describe('useConsortiumHoldings', () => {
   beforeEach(() => {
-    useOkapiKy.mockClear().mockReturnValue({
+    useTenantKy.mockClear().mockReturnValue({
       get: () => ({
         json: () => Promise.resolve({ holdings: [{ id: 'holdings-id' }] }),
       }),

--- a/src/hooks/useConsortiumItems/useConsortiumItems.js
+++ b/src/hooks/useConsortiumItems/useConsortiumItems.js
@@ -3,15 +3,16 @@ import { useQuery } from 'react-query';
 import {
   useNamespace,
   useStripes,
-  useOkapiKy,
 } from '@folio/stripes/core';
+
+import { useTenantKy } from '../../common';
 
 const useConsortiumItems = (instanceId, holdingsRecordId, tenant, { searchParams } = {}) => {
   const stripes = useStripes();
   const consortium = stripes.user?.user?.consortium;
   const centralTenantId = consortium?.centralTenantId;
 
-  const ky = useOkapiKy({ tenant: centralTenantId });
+  const ky = useTenantKy({ tenantId: centralTenantId });
   const [namespace] = useNamespace({ key: 'search-tenants-items-by-instance-and-holdings-id' });
 
   const { isLoading, isFetching, data = {} } = useQuery({

--- a/src/hooks/useConsortiumItems/useConsortiumItems.test.js
+++ b/src/hooks/useConsortiumItems/useConsortiumItems.test.js
@@ -8,15 +8,15 @@ import {
   renderHook,
   act,
 } from '@folio/jest-config-stripes/testing-library/react';
-import { useOkapiKy } from '@folio/stripes/core';
 
 import '../../../test/jest/__mock__';
 
 import useConsortiumItems from './useConsortiumItems';
+import { useTenantKy } from '../../common';
 
-jest.mock('@folio/stripes/core', () => ({
-  ...jest.requireActual('@folio/stripes/core'),
-  useOkapiKy: jest.fn(),
+jest.mock('../../common', () => ({
+  ...jest.requireActual('../../common'),
+  useTenantKy: jest.fn(),
 }));
 
 const queryClient = new QueryClient();
@@ -28,7 +28,7 @@ const wrapper = ({ children }) => (
 
 describe('useConsortiumItems', () => {
   beforeEach(() => {
-    useOkapiKy.mockClear().mockReturnValue({
+    useTenantKy.mockClear().mockReturnValue({
       get: () => ({
         json: () => Promise.resolve({ items: [{ id: 'items-id' }] }),
       }),


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
As far as `useOkapiKy` from `stripes-core` with the support of a custom tenant was introduced in Quesnelia it is necessary to use a custom `useTenantKy` hook to send requests in a proper context for Poppy.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Replace `useOkapiKy` with a custom `useTenantKy` hook for Poppy

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-2886

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
