### PR TITLE
Release v10.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-inventory
 
-## **10.0.15** (in progress)
+## [10.0.15](https://github.com/folio-org/ui-inventory/tree/v10.0.15) (2024-05-09)
+[Full Changelog](https://github.com/folio-org/ui-inventory/compare/v10.0.14...v10.0.15)
 
 * Use useTenantKy instead of useOkapiKy. Fixes UIIN-2886.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/inventory",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "description": "Inventory manager",
   "repository": "folio-org/ui-inventory",
   "publishConfig": {


### PR DESCRIPTION
Changes from `UIIN-2886` were pushed directly in `b10.0` because we don't need them neither in master nor in Q bugfix. It's only for CSP.