### PR TITLE
UIIN-2896 Show callout when user doesn't have permissions to use edit MARC shortcut (follow-up)

### DIFF
--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -692,7 +692,15 @@ class ViewHoldingsRecord extends React.Component {
       {
         name: 'editMARC',
         handler: handleKeyCommand(() => {
-          if (!stripes.hasPerm('ui-quick-marc.quick-marc-editor.all') || !this.isMARCSource()) {
+          if (!this.isMARCSource()) {
+            return;
+          }
+
+          if (!stripes.hasPerm('ui-quick-marc.quick-marc-holdings-editor.all')) {
+            this.calloutRef.current.sendCallout({
+              type: 'error',
+              message: <FormattedMessage id="ui-inventory.shortcut.editMARC.noPermission" />,
+            });
             return;
           }
 

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -1062,7 +1062,15 @@ class ViewInstance extends React.Component {
       {
         name: 'editMARC',
         handler: handleKeyCommand(() => {
-          if (!stripes.hasPerm('ui-quick-marc.quick-marc-editor.all') || !isMARCSource(selectedInstance.source)) {
+          if (!isMARCSource(selectedInstance.source)) {
+            return;
+          }
+
+          if (!stripes.hasPerm('ui-quick-marc.quick-marc-editor.all')) {
+            this.calloutRef.current.sendCallout({
+              type: 'error',
+              message: <FormattedMessage id="ui-inventory.shortcut.editMARC.noPermission" />,
+            });
             return;
           }
 

--- a/src/components/ViewSource/ViewSource.js
+++ b/src/components/ViewSource/ViewSource.js
@@ -9,7 +9,10 @@ import {
   useHistory,
 } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import {
+  useIntl,
+  FormattedMessage,
+} from 'react-intl';
 
 import {
   Button,
@@ -17,7 +20,10 @@ import {
   HasCommand,
   checkScope,
 } from '@folio/stripes/components';
-import { useStripes } from '@folio/stripes/core';
+import {
+  useCallout,
+  useStripes,
+} from '@folio/stripes/core';
 import {
   MarcView,
   PrintPopup,
@@ -44,9 +50,11 @@ const ViewSource = ({
   tenantId,
   marcType,
 }) => {
+  const intl = useIntl();
   const stripes = useStripes();
   const location = useLocation();
   const history = useHistory();
+  const callout = useCallout();
   const [isShownPrintPopup, setIsShownPrintPopup] = useState(false);
   const openPrintPopup = () => setIsShownPrintPopup(true);
   const closePrintPopup = () => setIsShownPrintPopup(false);
@@ -76,7 +84,16 @@ const ViewSource = ({
     {
       name: 'editMARC',
       handler: handleKeyCommand(() => {
-        if (stripes.hasPerm('ui-quick-marc.quick-marc-editor.all')) redirectToMARCEdit();
+        if ((marcType === MARC_TYPES.BIB && !stripes.hasPerm('ui-quick-marc.quick-marc-editor.all'))
+        || (marcType === MARC_TYPES.HOLDINGS && !stripes.hasPerm('ui-quick-marc.quick-marc-holdings-editor.all'))) {
+          callout.sendCallout({
+            type: 'error',
+            message: intl.formatMessage({ id: 'ui-inventory.shortcut.editMARC.noPermission' }),
+          });
+          return;
+        }
+
+        redirectToMARCEdit();
       }),
     },
   ], [stripes, redirectToMARCEdit]);

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -877,5 +877,6 @@
 
   "shortcut.nextSubfield": "quickMARC only: Move to the next subfield in a text box",
   "shortcut.prevSubfield": "quickMARC only: Move to the previous subfield in a text box",
-  "shortcut.editMARC": "Edit MARC record"
+  "shortcut.editMARC": "Edit MARC record",
+  "shortcut.editMARC.noPermission": "You do not have permission to edit the record."
 }


### PR DESCRIPTION
## Description
Show callout when user doesn't have permissions to use edit MARC shortcut (follow-up)
Check for correct permissions in View Holdings and View Source pages

## Screenshots

https://github.com/folio-org/ui-inventory/assets/19309423/898a7769-2d50-4819-becf-54e7e83e96a2



## Issues
[UIIN-2896](https://folio-org.atlassian.net/browse/UIIN-2896)