### PR TITLE
UIIN-2457 Edit Inventory Instances: Display a Save & keep editing button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Add classification browse types to facets requests when performing Browse. Fixes UIIN-2897.
 * Import `CheckboxFacet`, `CheckboxFacetList`, `HeldByFacet`, `withFacets`, facets constants, `fieldSearchConfigurations` constant, `queryIndexes` constants, `facetsStore`, and some of the utils from `stripes-inventory-components`. Refs UIIN-2781.
 * Import the new `useFacets` functionality from `stripes-inventory-components`. Refs UIIN-2910.
+* Edit Inventory Instances: Display a Save & keep editing button. Refs UIIN-2457.
 
 ## [11.0.4](https://github.com/folio-org/ui-inventory/tree/v11.0.4) (2024-04-30)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.3...v11.0.4)

--- a/src/Instance/InstanceEdit/InstanceEdit.js
+++ b/src/Instance/InstanceEdit/InstanceEdit.js
@@ -1,6 +1,7 @@
 import React, {
   useCallback,
   useEffect,
+  useRef,
   useState,
 } from 'react';
 import PropTypes from 'prop-types';
@@ -46,9 +47,14 @@ const InstanceEdit = ({
   const [httpError, setHttpError] = useState();
   const [initialValues, setInitialValues] = useState();
   const callout = useCallout();
-  const { instance, isLoading: isInstanceLoading } = useInstance(instanceId);
+  const keepEditing = useRef(false);
+  const { instance, isLoading: isInstanceLoading, refetch: refetchInstance } = useInstance(instanceId);
   const parentInstances = useLoadSubInstances(instance?.parentInstances, 'superInstanceId');
   const childInstances = useLoadSubInstances(instance?.childInstances, 'subInstanceId');
+
+  const setKeepEditing = useCallback((value) => {
+    keepEditing.current = value;
+  }, []);
 
   useEffect(() => {
     setInitialValues({
@@ -74,7 +80,12 @@ const InstanceEdit = ({
       type: 'success',
       message,
     });
-    goBack();
+
+    if (!keepEditing.current) {
+      goBack();
+    } else {
+      refetchInstance();
+    }
   }, [callout, goBack]);
 
   const onError = async error => {
@@ -122,6 +133,8 @@ const InstanceEdit = ({
         referenceTables={referenceData}
         stripes={stripes}
         onCancel={goBack}
+        setKeepEditing={setKeepEditing}
+        showKeepEditingButton
       />
       {httpError && !httpError?.errorType &&
         <ErrorModal

--- a/src/edit/InstanceForm.js
+++ b/src/edit/InstanceForm.js
@@ -236,13 +236,23 @@ class InstanceForm extends React.Component {
     );
   }
 
+  handleSaveClick = (e, keepEditing = false) => {
+    const {
+      handleSubmit,
+      setKeepEditing,
+    } = this.props;
+
+    setKeepEditing(keepEditing);
+    handleSubmit(e);
+  }
+
   getFooter = () => {
     const {
       onCancel,
-      handleSubmit,
       pristine,
       submitting,
       copy,
+      showKeepEditingButton,
     } = this.props;
 
     const cancelButton = (
@@ -254,13 +264,24 @@ class InstanceForm extends React.Component {
         <FormattedMessage id="ui-inventory.cancel" />
       </Button>
     );
+    const saveAndKeepEditingButton = (
+      <Button
+        id="clickable-save-and-keep-editing-instance"
+        buttonStyle="primary mega"
+        type="submit"
+        disabled={(pristine || submitting) && !copy}
+        onClick={(e) => this.handleSaveClick(e, true)}
+      >
+        <FormattedMessage id="stripes-components.saveAndKeepEditing" />
+      </Button>
+    );
     const saveButton = (
       <Button
         id="clickable-save-instance"
         buttonStyle="primary mega"
         type="submit"
         disabled={(pristine || submitting) && !copy}
-        onClick={handleSubmit}
+        onClick={(e) => this.handleSaveClick(e, false)}
       >
         <FormattedMessage id="stripes-components.saveAndClose" />
       </Button>
@@ -269,7 +290,12 @@ class InstanceForm extends React.Component {
     return (
       <PaneFooter
         renderStart={cancelButton}
-        renderEnd={saveButton}
+        renderEnd={(
+          <>
+            {showKeepEditingButton && saveAndKeepEditingButton}
+            {saveButton}
+          </>
+        )}
       />
     );
   };
@@ -813,6 +839,8 @@ InstanceForm.propTypes = {
   initialValues: PropTypes.object,
   referenceTables: PropTypes.object.isRequired,
   copy: PropTypes.bool,
+  setKeepEditing: PropTypes.func.isRequired,
+  showKeepEditingButton: PropTypes.bool,
   stripes: PropTypes.shape({
     connect: PropTypes.func.isRequired,
     locale: PropTypes.string.isRequired,
@@ -832,6 +860,7 @@ InstanceForm.defaultProps = {
   instanceSource: 'FOLIO',
   initialValues: {},
   id: 'instance-form',
+  showKeepEditingButton: false,
 };
 
 export default withRouter(stripesFinalForm({

--- a/src/edit/InstanceForm.test.js
+++ b/src/edit/InstanceForm.test.js
@@ -4,7 +4,7 @@ import {
   QueryClient,
   QueryClientProvider,
 } from 'react-query';
-import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import { fireEvent, screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import '../../test/jest/__mock__';
 
@@ -80,6 +80,7 @@ const mockGoTo = jest.fn();
 const mockOnSubmit = jest.fn();
 const mockOnCancel = jest.fn();
 const mockInstance = jest.fn();
+const mockSetKeepEditing = jest.fn();
 
 const queryClient = new QueryClient();
 
@@ -104,6 +105,7 @@ const InstanceFormSetUp = (props = {}) => (
           goTo={mockGoTo}
           isMARCRecord
           resources={mockResources}
+          setKeepEditing={mockSetKeepEditing}
           {...props}
         />
       </DataContext.Provider>
@@ -227,6 +229,39 @@ describe('InstanceForm', () => {
       const subheader = await findByText('test hrid • Last updated: 4/11/2019');
 
       expect(subheader).toBeInTheDocument();
+    });
+  });
+
+  it('should render Save & keep editing and Save & close buttons', () => {
+    const { getByRole } = renderInstanceForm({
+      showKeepEditingButton: true,
+    });
+
+    expect(getByRole('button', { name: 'Save & keep editing' })).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Save & close' })).toBeInTheDocument();
+  });
+
+  describe('when clicking Save & close', () => {
+    it('should call setKeepEditing with false', () => {
+      const { getByRole } = renderInstanceForm();
+
+      fireEvent.change(getByRole('textbox', { name: 'Resource title' }), { target: { value: 'new title' } });
+      fireEvent.click(getByRole('button', { name: 'Save & close' }));
+
+      expect(mockSetKeepEditing).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('when clicking Save & keep editing', () => {
+    it('should call setKeepEditing with true', () => {
+      const { getByRole } = renderInstanceForm({
+        showKeepEditingButton: true,
+      });
+
+      fireEvent.change(getByRole('textbox', { name: 'Resource title' }), { target: { value: 'new title' } });
+      fireEvent.click(getByRole('button', { name: 'Save & keep editing' }));
+
+      expect(mockSetKeepEditing).toHaveBeenCalledWith(true);
     });
   });
 });


### PR DESCRIPTION
## Description
Edit Inventory Instances: Display a Save & keep editing button

When user clicks "Save & keep editing" they should stay on the edit record page with updated data

## Screenshots

https://github.com/folio-org/ui-inventory/assets/19309423/b7d303e3-1139-4d5b-a528-6b9db74e3476


## Issues
[UIIN-2457](https://folio-org.atlassian.net/browse/UIIN-2457)

## Related PRs
https://github.com/folio-org/stripes-components/pull/2292