### PR TITLE
UIIN-2818: Populate Acquisitions accordion on item when central ordering is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Jest/RTL: Cover ModalContent components with unit tests. Refs UIIN-2669.
 * Add callout noting user's active affiliation when it changes after selecting holding or item. Refs UIIN-2831, UIIN-2872.
 * Jest/RTL: Cover LocationSelectionWithCheck components with unit tests. Refs UIIN-2670.
+* Source record is local after instance is shared. Fixes UIIN-2900.
 
 ## [11.0.4](https://github.com/folio-org/ui-inventory/tree/v11.0.4) (2024-04-30)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.3...v11.0.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Add callout noting user's active affiliation when it changes after selecting holding or item. Refs UIIN-2831, UIIN-2872.
 * Jest/RTL: Cover LocationSelectionWithCheck components with unit tests. Refs UIIN-2670.
 * Populate Acquisitions accordion on instance when central ordering is active. Refs UIIN-2793.
+* Populate Acquisitions accordion on item when central ordering is active. Refs UIIN-2818.
 
 ## [11.0.4](https://github.com/folio-org/ui-inventory/tree/v11.0.4) (2024-04-30)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.3...v11.0.4)

--- a/src/Item/ViewItem/ItemAcquisition/useItemAcquisition.js
+++ b/src/Item/ViewItem/ItemAcquisition/useItemAcquisition.js
@@ -1,57 +1,82 @@
+import {
+  useState,
+  useEffect,
+} from 'react';
 import { useQuery } from 'react-query';
+import isEmpty from 'lodash/isEmpty';
 
-import { useOkapiKy, useNamespace, useStripes } from '@folio/stripes/core';
+import {
+  useOkapiKy,
+  useNamespace,
+  useStripes,
+  checkIfUserInMemberTenant,
+} from '@folio/stripes/core';
 
 const useItemAcquisition = (id) => {
-  const ky = useOkapiKy();
-  const namespace = useNamespace();
   const stripes = useStripes();
 
+  const centralTenant = stripes.user.user?.consortium?.centralTenantId;
+
+  const [activeTenant, setActiveTenant] = useState(stripes.okapi.tenant);
+
+  const ky = useOkapiKy({ tenant: activeTenant });
+  const namespace = useNamespace();
+
+  const fetchItemAcquisition = async () => {
+    const { pieces = [] } = await ky.get('orders/pieces', {
+      searchParams: { query: `itemId=${id}` },
+    }).json();
+
+    if (!pieces.length) return {};
+
+    const [piece] = pieces;
+    let orderLine;
+    let order;
+    let vendor;
+
+    try {
+      orderLine = await ky.get(`orders/order-lines/${piece.poLineId}`).json();
+    } catch {
+      orderLine = {};
+    }
+
+    try {
+      order = await ky.get(`orders/composite-orders/${orderLine.purchaseOrderId}`).json();
+    } catch {
+      order = {};
+    }
+
+    try {
+      vendor = await ky.get(`organizations/organizations/${order.vendor}`).json();
+    } catch {
+      vendor = {};
+    }
+
+    return {
+      order,
+      orderLine,
+      piece,
+      vendor,
+    };
+  };
+
   const { data = {}, isLoading } = useQuery(
-    [namespace, 'item-acquisition', id],
-    async () => {
-      const { pieces = [] } = await ky.get('orders/pieces', {
-        searchParams: { query: `itemId=${id}` },
-      }).json();
-
-      if (!pieces.length) return {};
-
-      const [piece] = pieces;
-      let orderLine;
-      let order;
-      let vendor;
-
-      try {
-        orderLine = await ky.get(`orders/order-lines/${piece.poLineId}`).json();
-      } catch {
-        orderLine = {};
-      }
-
-      try {
-        order = await ky.get(`orders/composite-orders/${orderLine.purchaseOrderId}`).json();
-      } catch {
-        order = {};
-      }
-
-      try {
-        vendor = await ky.get(`organizations/organizations/${order.vendor}`).json();
-      } catch {
-        vendor = {};
-      }
-
-      return {
-        order,
-        orderLine,
-        piece,
-        vendor,
-      };
-    },
-    { enabled: stripes.hasInterface('pieces') &&
-      stripes.hasInterface('order-lines') &&
-      stripes.hasInterface('orders') &&
-      stripes.hasInterface('organizations.organizations') &&
-      Boolean(id) },
+    [namespace, 'item-acquisition', id, activeTenant],
+    fetchItemAcquisition,
+    {
+      enabled: stripes.hasInterface('pieces') &&
+        stripes.hasInterface('order-lines') &&
+        stripes.hasInterface('orders') &&
+        stripes.hasInterface('organizations.organizations') &&
+        Boolean(id),
+    }
   );
+
+  useEffect(() => {
+    if (!isLoading && isEmpty(data) && checkIfUserInMemberTenant(stripes)) {
+      setActiveTenant(centralTenant);
+    }
+  }, [isLoading, data]);
 
   return {
     isLoading,

--- a/src/components/ViewSource/ViewSource.js
+++ b/src/components/ViewSource/ViewSource.js
@@ -18,7 +18,10 @@ import {
 
 import { useGoBack } from '../../common/hooks';
 
-import { isUserInConsortiumMode } from '../../utils';
+import {
+  isInstanceShadowCopy,
+  isUserInConsortiumMode,
+} from '../../utils';
 import MARC_TYPES from './marcTypes';
 
 import styles from './ViewSource.css';
@@ -88,7 +91,7 @@ const ViewSource = ({
     <FormattedMessage
       id={`ui-inventory.marcSourceRecord.${marcType}`}
       values={{
-        shared: isUserInConsortiumMode(stripes) ? instance.shared : null,
+        shared: isUserInConsortiumMode(stripes) ? (instance.shared || isInstanceShadowCopy(instance?.source)) : null,
       }}
     />
   );


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
 * Given user has active affiliation of non-central AND navigates to inventory AND selects an Item that is related to a central order (Piece). When acquisitions accordion is displayed, then it shows acquisition data from the related order in the central tenant

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* When user tries to view central tenant item, we replace `tenant` in `useOkapiKy` with central tenant id.
* Added unit tests.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-2818](https://folio-org.atlassian.net/browse/UIIN-2818)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-inventory/assets/85172747/c9d85abb-90de-4a57-9967-cd9071b90f18



