### PR TITLE
UIIN-2760: add modal title for removing piece

### DIFF
--- a/src/components/BoundPiecesList/BoundPiecesList.js
+++ b/src/components/BoundPiecesList/BoundPiecesList.js
@@ -92,9 +92,9 @@ const BoundPiecesList = ({ id, itemId }) => {
       <ConfirmationModal
         id="delete-confirmation-modal"
         open={open}
-        showHeader={false}
         onConfirm={handleRemove}
         onCancel={toggleOpen}
+        heading={<FormattedMessage id="ui-inventory.boundPieces.remove.heading" />}
         message={<FormattedMessage id="ui-inventory.boundPieces.remove.message" />}
         confirmLabel={<FormattedMessage id="ui-inventory.boundPieces.remove.button" />}
       />

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -807,6 +807,7 @@
 
   "boundPieces.remove.success": "Bound piece successfully removed",
   "boundPieces.remove.error": "Bound piece deletion failed",
+  "boundPieces.remove.heading": "Are you sure?",
   "boundPieces.remove.message": "Remove this piece from the bound item?",
   "boundPieces.remove.button": "Remove",
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
[UIIN-2760](https://folio-org.atlassian.net/browse/UIIN-2760): add modal title for removing piece
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
![Screenshot 2024-06-20 at 19 48 55](https://github.com/folio-org/ui-inventory/assets/116072773/2da4f7d3-c7e2-48d9-a6f2-0948c849ac35)

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
