### PR TITLE
UIIN-2938: Use namespace to store facets state separately for different modules (follow-up PR).

### DIFF
--- a/src/components/BrowseResultsList/BrowseResultsList.js
+++ b/src/components/BrowseResultsList/BrowseResultsList.js
@@ -9,6 +9,7 @@ import {
   useLocation,
 } from 'react-router-dom';
 
+import { useNamespace } from '@folio/stripes/core';
 import {
   MCLPagingTypes,
   MultiColumnList,
@@ -51,6 +52,7 @@ const BrowseResultsList = ({
   totalRecords,
   filters,
 }) => {
+  const [namespace] = useNamespace();
   const data = useContext(DataContext);
   const { search } = useLocation();
   const {
@@ -76,7 +78,7 @@ const BrowseResultsList = ({
       id={listId}
       totalCount={totalRecords}
       contentData={browseData}
-      formatter={getBrowseResultsFormatter({ data, browseOption, filters })}
+      formatter={getBrowseResultsFormatter({ data, browseOption, filters, namespace })}
       visibleColumns={VISIBLE_COLUMNS_MAP[browseOption]}
       isEmptyMessage={isEmptyMessage}
       isSelected={isSelected}

--- a/src/components/BrowseResultsList/getBrowseResultsFormatter.js
+++ b/src/components/BrowseResultsList/getBrowseResultsFormatter.js
@@ -35,6 +35,7 @@ const getTargetRecord = (
   row,
   browseOption,
   filters,
+  namespace,
 ) => {
   const record = getFullMatchRecord(item, row.isAnchor);
   const searchParams = getSearchParams(row, browseOption, filters);
@@ -51,7 +52,7 @@ const getTargetRecord = (
   };
 
   const handleClick = () => {
-    deleteFacetStates();
+    deleteFacetStates(namespace);
   };
 
   return (
@@ -110,6 +111,7 @@ const getBrowseResultsFormatter = ({
   data,
   browseOption,
   filters,
+  namespace,
 }) => {
   return {
     title: r => getFullMatchRecord(r.instance?.title, r.isAnchor),
@@ -118,7 +120,7 @@ const getBrowseResultsFormatter = ({
         return <MissedMatchItem query={r?.value} />;
       }
 
-      const subject = getTargetRecord(r?.value, r, browseOption, filters);
+      const subject = getTargetRecord(r?.value, r, browseOption, filters, namespace);
       if (browseOption === browseModeOptions.SUBJECTS && r.authorityId) {
         return renderMarcAuthoritiesLink(r.authorityId, subject);
       }
@@ -127,13 +129,13 @@ const getBrowseResultsFormatter = ({
     },
     callNumber: r => {
       if (r?.instance || r?.totalRecords) {
-        return getTargetRecord(r?.fullCallNumber, r, browseOption, filters);
+        return getTargetRecord(r?.fullCallNumber, r, browseOption, filters, namespace);
       }
       return <MissedMatchItem query={r.fullCallNumber} />;
     },
     classificationNumber: r => {
       if (r?.totalRecords) {
-        return getTargetRecord(r?.classificationNumber, r, browseOption, filters);
+        return getTargetRecord(r?.classificationNumber, r, browseOption, filters, namespace);
       }
       return <MissedMatchItem query={r.classificationNumber} />;
     },
@@ -142,7 +144,7 @@ const getBrowseResultsFormatter = ({
         return <MissedMatchItem query={r.name} />;
       }
 
-      const fullMatchRecord = getTargetRecord(r.name, r, browseOption, filters);
+      const fullMatchRecord = getTargetRecord(r.name, r, browseOption, filters, namespace);
 
       if (browseOption === browseModeOptions.CONTRIBUTORS && r.authorityId) {
         return renderMarcAuthoritiesLink(r.authorityId, fullMatchRecord);

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -474,7 +474,9 @@ class InstancesList extends React.Component {
   }
 
   handleSearchSegmentChange = (segment) => {
-    deleteFacetStates();
+    const { namespace } = this.props;
+
+    deleteFacetStates(namespace);
     this.refocusOnInputSearch(segment);
     this.setState({ selectedRows: {} });
     sessionStorage.setItem(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY, false);
@@ -997,11 +999,13 @@ class InstancesList extends React.Component {
   };
 
   handleResetAll = () => {
+    const { namespace } = this.props;
+
     this.setState({
       selectedRows: {},
     });
 
-    resetFacetStates();
+    resetFacetStates({ namespace });
     this.inputRef.current.focus();
     sessionStorage.setItem(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY, false);
   }

--- a/src/components/SearchModeNavigation/SearchModeNavigation.js
+++ b/src/components/SearchModeNavigation/SearchModeNavigation.js
@@ -13,6 +13,7 @@ import {
 } from '@folio/stripes/components';
 import { deleteFacetStates } from '@folio/stripes-inventory-components';
 
+import { useNamespace } from '@folio/stripes/core';
 import {
   searchModeRoutesMap,
   searchModeSegments,
@@ -25,6 +26,7 @@ const SearchModeNavigation = ({ search, state, onSearchModeSwitch }) => {
     pathname,
   } = useLocation();
   const history = useHistory();
+  const [namespace] = useNamespace();
 
   const checkIsButtonActive = useCallback((segment) => (
     path === searchModeRoutesMap[segment] ? 'primary' : 'default'
@@ -33,10 +35,10 @@ const SearchModeNavigation = ({ search, state, onSearchModeSwitch }) => {
   const onClick = useCallback((segment) => {
     const isCurrentSegment = path === searchModeRoutesMap[segment];
 
-    deleteFacetStates();
+    deleteFacetStates(namespace);
 
     if (onSearchModeSwitch) {
-      onSearchModeSwitch();
+      onSearchModeSwitch(namespace);
     }
 
     history.push({
@@ -44,7 +46,7 @@ const SearchModeNavigation = ({ search, state, onSearchModeSwitch }) => {
       search: isCurrentSegment ? currentSearch : search,
       state,
     });
-  }, [onSearchModeSwitch, history, path, currentSearch, search, state]);
+  }, [onSearchModeSwitch, history, path, currentSearch, search, state, namespace]);
 
   return (
     <ButtonGroup fullWidth>

--- a/src/routes/InstancesRoute.js
+++ b/src/routes/InstancesRoute.js
@@ -5,9 +5,7 @@ import { flowRight } from 'lodash';
 import { stripesConnect } from '@folio/stripes/core';
 import {
   filterConfig,
-  HoldingsRecordFilters,
-  InstanceFilters,
-  ItemFilters,
+  renderFilters,
   segments,
 } from '@folio/stripes-inventory-components';
 
@@ -16,12 +14,6 @@ import withLastSearchTerms from '../withLastSearchTerms';
 import { InstancesView } from '../views';
 import { buildManifestObject } from './buildManifestObject';
 import { DataContext } from '../contexts';
-
-const filterComponents = {
-  [segments.instances]: InstanceFilters,
-  [segments.holdings]: HoldingsRecordFilters,
-  [segments.items]: ItemFilters,
-};
 
 class InstancesRoute extends React.Component {
   static propTypes = {
@@ -43,18 +35,8 @@ class InstancesRoute extends React.Component {
 
   static manifest = Object.freeze(buildManifestObject());
 
-  renderFilters = ({ data, query }) => onChange => {
-    const { getParams } = this.props;
-    const { segment = segments.instances } = getParams(this.props);
-    const FiltersComponent = filterComponents[segment];
-
-    return (
-      <FiltersComponent
-        query={query}
-        data={data}
-        onChange={onChange}
-      />
-    );
+  handleFilterChange = (onChange) => ({ name, values }) => {
+    onChange({ name, values });
   };
 
   render() {
@@ -84,9 +66,10 @@ class InstancesRoute extends React.Component {
             data={{ ...data, query }}
             onSelectRow={onSelectRow}
             disableRecordCreation={disableRecordCreation}
-            renderFilters={this.renderFilters({
+            renderFilters={renderFilters({
               data,
               query,
+              onFilterChange: this.handleFilterChange,
             })}
             segment={segment}
             searchableIndexes={indexes}

--- a/src/views/BrowseInventory/BrowseInventory.js
+++ b/src/views/BrowseInventory/BrowseInventory.js
@@ -48,7 +48,7 @@ const BrowseInventory = () => {
   const location = useLocation();
   const intl = useIntl();
   const [namespace] = useNamespace();
-  const resetFacetStates = useResetFacetStates();
+  const resetFacetStates = useResetFacetStates(namespace);
   const {
     getLastSearch,
     getLastBrowseOffset,


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Description
- when both `ui-inventory` and `ui-plugin-find-instance` facets are visible, opening the plugin facet will also open the inventory facet. This is due to state being stored in one place for all modules. In the related PR the namespace is added for `facetsStore` to separate state for each module, all that's left is to pass the correct namespace;
- use `renderFilters` from `stripes-inventory-components` to reduce duplication.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Related PRs
https://github.com/folio-org/stripes-inventory-components/pull/50

## Refs
[UIIN-2938](https://folio-org.atlassian.net/browse/UIIN-2938)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
https://github.com/folio-org/ui-plugin-find-instance/assets/77053927/0a67cfba-107f-4c21-8143-442c835e3873
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
