### PR TITLE
UIIN-2766: i18n item status in item edit view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Add Bound items accordion in item record. Refs UIIN-2760.
 * Edit Inventory Instances: Optimistic locking error displays in pop-up modal instead of banner in the header. Fixes UIIN-2940.
 * Make item barcode column narrower. Fixes UIIN-2925.
+* i18n item status in item edit view. Refs UIIN-2766.
 
 ## [11.0.4](https://github.com/folio-org/ui-inventory/tree/v11.0.4) (2024-04-30)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.3...v11.0.4)

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -37,6 +37,7 @@ import {
 } from '@folio/stripes/components';
 import {
   AppIcon,
+  IntlConsumer,
 } from '@folio/stripes/core';
 import stripesFinalForm from '@folio/stripes/final-form';
 import {
@@ -61,6 +62,7 @@ import StatisticalCodeFields from '../statisticalCodeFields';
 import NoteFields from '../noteFields';
 
 import styles from './ItemForm.css';
+import { itemStatusesMap } from '../../constants';
 
 function validate(values) {
   const errors = {};
@@ -123,6 +125,30 @@ function validateBarcode(props) {
     return '';
   });
 }
+
+const ITEM_STATUSES_TRANSLATIONS_ID_MAP = {
+  [itemStatusesMap.AGED_TO_LOST]: 'stripes-inventory-components.item.status.agedToLost',
+  [itemStatusesMap.AVAILABLE]: 'stripes-inventory-components.item.status.available',
+  [itemStatusesMap.AWAITING_PICKUP]: 'stripes-inventory-components.item.status.awaitingPickup',
+  [itemStatusesMap.AWAITING_DELIVERY]: 'stripes-inventory-components.item.status.awaitingDelivery',
+  [itemStatusesMap.CHECKED_OUT]: 'stripes-inventory-components.item.status.checkedOut',
+  [itemStatusesMap.CLAIMED_RETURNED]: 'stripes-inventory-components.item.status.claimedReturned',
+  [itemStatusesMap.DECLARED_LOST]: 'stripes-inventory-components.item.status.declaredLost',
+  [itemStatusesMap.IN_PROCESS]: 'stripes-inventory-components.item.status.inProcess',
+  [itemStatusesMap.IN_PROCESS_NON_REQUESTABLE]: 'stripes-inventory-components.item.status.inProcessNonRequestable',
+  [itemStatusesMap.IN_TRANSIT]: 'stripes-inventory-components.item.status.inTransit',
+  [itemStatusesMap.INTELLECTUAL_ITEM]: 'stripes-inventory-components.item.status.intellectualItem',
+  [itemStatusesMap.LONG_MISSING]: 'stripes-inventory-components.item.status.longMissing',
+  [itemStatusesMap.LOST_AND_PAID]: 'stripes-inventory-components.item.status.lostAndPaid',
+  [itemStatusesMap.MISSING]: 'stripes-inventory-components.item.status.missing',
+  [itemStatusesMap.ON_ORDER]: 'stripes-inventory-components.item.status.onOrder',
+  [itemStatusesMap.ORDER_CLOSED]: 'stripes-inventory-components.item.status.orderClosed',
+  [itemStatusesMap.PAGED]: 'stripes-inventory-components.item.status.paged',
+  [itemStatusesMap.RESTRICTED]: 'stripes-inventory-components.item.status.restricted',
+  [itemStatusesMap.UNAVAILABLE]: 'stripes-inventory-components.item.status.unavailable',
+  [itemStatusesMap.UNKNOWN]: 'stripes-inventory-components.item.status.unknown',
+  [itemStatusesMap.WITHDRAWN]: 'stripes-inventory-components.item.status.withdrawn',
+};
 
 class ItemForm extends React.Component {
   constructor(props) {
@@ -799,14 +825,20 @@ class ItemForm extends React.Component {
                     </Row>
                     <Row>
                       <Col sm={2}>
-                        <Field
-                          label={<FormattedMessage id="ui-inventory.status" />}
-                          name="status.name"
-                          id="additem_status"
-                          component={TextField}
-                          disabled
-                          fullWidth
-                        />
+                        <IntlConsumer>
+                          {intl => (
+                            <Field
+                              label={<FormattedMessage id="ui-inventory.status" />}
+                              name="status.name"
+                              id="additem_status"
+                              component={TextField}
+                              format={value => (ITEM_STATUSES_TRANSLATIONS_ID_MAP[value] ? intl.formatMessage({ id: ITEM_STATUSES_TRANSLATIONS_ID_MAP[value] }) : value)}
+                              parse={value => value}
+                              disabled
+                              fullWidth
+                            />
+                          )}
+                        </IntlConsumer>
                       </Col>
                     </Row>
                     <Row>


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
To make item status translatable in the item edit view.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Add item status translations from `stripes-inventory-components`

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-2766

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
