### PR TITLE
UIIN-2771: Enable `+ New` and `Edit` buttons when user has `Settings (Inventory): Configure single-record import` permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Add Bound items accordion in item record. Refs UIIN-2760.
 * Edit Inventory Instances: Optimistic locking error displays in pop-up modal instead of banner in the header. Fixes UIIN-2940.
 * Make item barcode column narrower. Fixes UIIN-2925.
+* Enable "+ New" and "Edit" buttons when user has "Settings (Inventory): Configure single-record import" permission. Refs UIIN-2771.
 
 ## [11.0.4](https://github.com/folio-org/ui-inventory/tree/v11.0.4) (2024-04-30)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.3...v11.0.4)

--- a/package.json
+++ b/package.json
@@ -430,7 +430,8 @@
           "copycat.profiles.item.post",
           "copycat.profiles.item.put",
           "copycat.profiles.item.delete",
-          "converter-storage.jobprofile.get"
+          "converter-storage.jobprofile.get",
+          "inventory-storage.identifier-types.collection.get"
         ],
         "visible": true
       },

--- a/src/settings/TargetProfiles.js
+++ b/src/settings/TargetProfiles.js
@@ -63,9 +63,9 @@ class TargetProfiles extends React.Component {
               entryFormComponent={TargetProfileForm}
               nameKey="displayName"
               permissions={{
-                put: 'ui-inventory.single-record-import',
-                post: 'ui-inventory.single-record-import',
-                delete: 'ui-inventory.single-record-import',
+                put: 'ui-inventory.settings.single-record-import',
+                post: 'ui-inventory.settings.single-record-import',
+                delete: 'ui-inventory.settings.single-record-import',
               /*
           // Once these are defined
           put: 'ui-inventory.single-record-import.create',


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
 * When user has `Settings (Inventory): Configure single-record import` permission, we should enable `+New` and `Edit`

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Replace the `ui-inventory.single-record-import` permission with `ui-inventory.settings.single-record-import`.
* Add additional `inventory-storage.identifier-types.collection.get` permission to `Settings (Inventory): Configure single-record import` in order to get identifier types.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-2771](https://folio-org.atlassian.net/browse/UIIN-2771)