### PR TITLE
UIIN-2772: Update `Settings (Inventory): Create, edit, delete statistical codes` permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Make item barcode column narrower. Fixes UIIN-2925.
 * i18n item status in item edit view. Refs UIIN-2766.
 * Enable "+ New" and "Edit" buttons when user has "Settings (Inventory): Configure single-record import" permission. Refs UIIN-2771.
+* Update "Settings (Inventory): Create, edit, delete statistical codes" permission. Refs UIIN-2772.
 
 ## [11.0.4](https://github.com/folio-org/ui-inventory/tree/v11.0.4) (2024-04-30)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.3...v11.0.4)

--- a/package.json
+++ b/package.json
@@ -312,7 +312,8 @@
           "inventory-storage.statistical-codes.item.get",
           "inventory-storage.statistical-codes.item.post",
           "inventory-storage.statistical-codes.item.put",
-          "settings.inventory.enabled"
+          "settings.inventory.enabled",
+          "inventory-storage.statistical-code-types.collection.get"
         ],
         "visible": true
       },

--- a/src/settings/TargetProfileForm.test.js
+++ b/src/settings/TargetProfileForm.test.js
@@ -18,7 +18,7 @@ const onSubmitMock = jest.fn();
 const defaultInitialValues = { targetOptions: { key: 'testKey' } };
 const defaultProps = {
   onSubmit: onSubmitMock,
-  onCancel: jest.fn(),
+  onCancel: jest.mock(),
   resources: {
     jobProfiles: {
       records: [{
@@ -78,29 +78,20 @@ describe('TargetProfileForm', () => {
     });
   });
 
-  describe('when click Save & close button', () => {
-    it('onSubmit function should be called', async () => {
+  describe('when click "Save & close" button', () => {
+    it('onSubmit function should be called', () => {
       const {
         container,
         getByText,
         getAllByText,
         getByLabelText,
-        debug,
-        findByRole,
       } = renderTargetProfileForm();
       const nameInput = container.querySelector('#input-targetprofile-name');
       fireEvent.change(nameInput, { target: { value: 'test name' } });
 
-      const addJobCreateButton = await findByRole('button', { name: 'Add job profile for import/create' });
-      // const addJobCreateButton = getByText('Add job profile for import/create');
+      const addJobCreateButton = getByText('Add job profile for import/create');
       fireEvent.click(addJobCreateButton);
-
-      debug(container, 300000);
-      await waitFor(() => {
-        const element = getByLabelText('Select job profile for import/create');
-        expect(element).toBeInTheDocument();
-        fireEvent.click(element);
-      });
+      fireEvent.click(getByLabelText('Select job profile for import/create'));
       fireEvent.click(getAllByText('Job profile for create (job profile id for create)')[0]);
       fireEvent.click(getByLabelText('Set 0 job profile for create as default'));
 

--- a/src/settings/TargetProfileForm.test.js
+++ b/src/settings/TargetProfileForm.test.js
@@ -18,7 +18,7 @@ const onSubmitMock = jest.fn();
 const defaultInitialValues = { targetOptions: { key: 'testKey' } };
 const defaultProps = {
   onSubmit: onSubmitMock,
-  onCancel: jest.mock(),
+  onCancel: jest.fn(),
   resources: {
     jobProfiles: {
       records: [{
@@ -78,18 +78,22 @@ describe('TargetProfileForm', () => {
     });
   });
 
-  describe('when click "Save & close" button', () => {
+  describe('when click Save & close button', () => {
     it('onSubmit function should be called', () => {
       const {
+        debug,
         container,
         getByText,
+        getByRole,
         getAllByText,
         getByLabelText,
       } = renderTargetProfileForm();
+      // debug(container, 300000);
       const nameInput = container.querySelector('#input-targetprofile-name');
       fireEvent.change(nameInput, { target: { value: 'test name' } });
 
-      const addJobCreateButton = getByText('Add job profile for import/create');
+      const addJobCreateButton = getByRole('button', { name: 'Add job profile for import/create' });
+      // const addJobCreateButton = getByText('Add job profile for import/create');
       fireEvent.click(addJobCreateButton);
       fireEvent.click(getByLabelText('Select job profile for import/create'));
       fireEvent.click(getAllByText('Job profile for create (job profile id for create)')[0]);

--- a/src/settings/TargetProfileForm.test.js
+++ b/src/settings/TargetProfileForm.test.js
@@ -95,13 +95,13 @@ describe('TargetProfileForm', () => {
       const nameInput = container.querySelector('#input-targetprofile-name');
       fireEvent.change(nameInput, { target: { value: 'test name' } });
 
-      debug(container, 300000);
 
       const addJobCreateButton = await findByRole('button', { name: 'Add job profile for import/create' });
       fireEvent.click(addJobCreateButton);
 
-      const selectJobProfileButton = await findByRole('button', { name: 'Select job profile for import/create' });
+      const selectJobProfileButton = container.querySelector('[name="allowedCreateJobProfileIds[0]"]');
       fireEvent.click(selectJobProfileButton);
+      debug(container, 300000);
 
       const jobProfileOption = await findAllByText('Job profile for create (job profile id for create)');
       fireEvent.click(jobProfileOption[0]);
@@ -112,7 +112,7 @@ describe('TargetProfileForm', () => {
       const addJobUpdateButton = await findByRole('button', { name: 'Add job profile for overlay/update' });
       fireEvent.click(addJobUpdateButton);
 
-      const selectJobProfileUpdateButton = await findByRole('button', { name: 'Select job profile for overlay/update' });
+      const selectJobProfileUpdateButton = container.querySelector('[name="allowedUpdateJobProfileIds[0]"]');
       fireEvent.click(selectJobProfileUpdateButton);
 
       const jobProfileUpdateOption = await findAllByText('Job profile for update (job profile id for update)');

--- a/src/settings/TargetProfileForm.test.js
+++ b/src/settings/TargetProfileForm.test.js
@@ -79,7 +79,7 @@ describe('TargetProfileForm', () => {
   });
 
   describe('when click Save & close button', () => {
-    it('onSubmit function should be called', () => {
+    it('onSubmit function should be called', async () => {
       const {
         debug,
         container,
@@ -87,23 +87,38 @@ describe('TargetProfileForm', () => {
         getByRole,
         getAllByText,
         getByLabelText,
+        findByText,
+        findByLabelText,
+        findAllByText,
       } = renderTargetProfileForm();
       // debug(container, 300000);
       const nameInput = container.querySelector('#input-targetprofile-name');
       fireEvent.change(nameInput, { target: { value: 'test name' } });
 
-      const addJobCreateButton = getByRole('button', { name: 'Add job profile for import/create' });
-      // const addJobCreateButton = getByText('Add job profile for import/create');
+      // const addJobCreateButton = getByRole('button', { name: 'Add job profile for import/create' });
+      const addJobCreateButton = await findByText('Add job profile for import/create');
       fireEvent.click(addJobCreateButton);
-      fireEvent.click(getByLabelText('Select job profile for import/create'));
-      fireEvent.click(getAllByText('Job profile for create (job profile id for create)')[0]);
-      fireEvent.click(getByLabelText('Set 0 job profile for create as default'));
+
+      const selectJobProfileButton = await findByLabelText('Select job profile for import/create');
+      fireEvent.click(selectJobProfileButton);
+
+      const jobProfileOption = getAllByText('Job profile for create (job profile id for create)');
+      fireEvent.click(jobProfileOption[0]);
+
+      const setDefaultJobProfileButton = await findByLabelText('Set 0 job profile for create as default');
+      fireEvent.click(setDefaultJobProfileButton);
 
       const addJobUpdateButton = getByText('Add job profile for overlay/update');
       fireEvent.click(addJobUpdateButton);
-      fireEvent.click(getByLabelText('Select job profile for overlay/update'));
-      fireEvent.click(getAllByText('Job profile for update (job profile id for update)')[1]);
-      fireEvent.click(getByLabelText('Set 0 job profile for update as default'));
+
+      const selectJobProfileUpdateButton = await findByLabelText('Select job profile for overlay/update');
+      fireEvent.click(selectJobProfileUpdateButton);
+
+      const jobProfileUpdateOption = getAllByText('Job profile for update (job profile id for update)');
+      fireEvent.click(jobProfileUpdateOption[1]);
+
+      const setDefaultJobProfileUpdateButton = await findByLabelText('Set 0 job profile for update as default');
+      fireEvent.click(setDefaultJobProfileUpdateButton);
 
       const submit = getByText('Save & close');
       fireEvent.click(submit);

--- a/src/settings/TargetProfileForm.test.js
+++ b/src/settings/TargetProfileForm.test.js
@@ -81,45 +81,34 @@ describe('TargetProfileForm', () => {
   describe('when click Save & close button', () => {
     it('onSubmit function should be called', async () => {
       const {
-        debug,
         container,
         getByText,
-        getByRole,
         getAllByText,
         getByLabelText,
-        findByText,
-        findByLabelText,
-        findAllByText,
+        debug,
         findByRole,
       } = renderTargetProfileForm();
       const nameInput = container.querySelector('#input-targetprofile-name');
       fireEvent.change(nameInput, { target: { value: 'test name' } });
 
-
       const addJobCreateButton = await findByRole('button', { name: 'Add job profile for import/create' });
+      // const addJobCreateButton = getByText('Add job profile for import/create');
       fireEvent.click(addJobCreateButton);
 
-      const selectJobProfileButton = container.querySelector('[name="allowedCreateJobProfileIds[0]"]');
-      fireEvent.click(selectJobProfileButton);
       debug(container, 300000);
+      await waitFor(() => {
+        const element = getByLabelText('Select job profile for import/create');
+        expect(element).toBeInTheDocument();
+        fireEvent.click(element);
+      });
+      fireEvent.click(getAllByText('Job profile for create (job profile id for create)')[0]);
+      fireEvent.click(getByLabelText('Set 0 job profile for create as default'));
 
-      const jobProfileOption = await findAllByText('Job profile for create (job profile id for create)');
-      fireEvent.click(jobProfileOption[0]);
-
-      const setDefaultJobProfileButton = await findByRole('radio', { name: 'Set 0 job profile for create as default' });
-      fireEvent.click(setDefaultJobProfileButton);
-
-      const addJobUpdateButton = await findByRole('button', { name: 'Add job profile for overlay/update' });
+      const addJobUpdateButton = getByText('Add job profile for overlay/update');
       fireEvent.click(addJobUpdateButton);
-
-      const selectJobProfileUpdateButton = container.querySelector('[name="allowedUpdateJobProfileIds[0]"]');
-      fireEvent.click(selectJobProfileUpdateButton);
-
-      const jobProfileUpdateOption = await findAllByText('Job profile for update (job profile id for update)');
-      fireEvent.click(jobProfileUpdateOption[1]);
-
-      const setDefaultJobProfileUpdateButton = await findByRole('radio', { name: 'Set 0 job profile for update as default' });
-      fireEvent.click(setDefaultJobProfileUpdateButton);
+      fireEvent.click(getByLabelText('Select job profile for overlay/update'));
+      fireEvent.click(getAllByText('Job profile for update (job profile id for update)')[1]);
+      fireEvent.click(getByLabelText('Set 0 job profile for update as default'));
 
       const submit = getByText('Save & close');
       fireEvent.click(submit);

--- a/src/settings/TargetProfileForm.test.js
+++ b/src/settings/TargetProfileForm.test.js
@@ -90,34 +90,35 @@ describe('TargetProfileForm', () => {
         findByText,
         findByLabelText,
         findAllByText,
+        findByRole,
       } = renderTargetProfileForm();
-      // debug(container, 300000);
       const nameInput = container.querySelector('#input-targetprofile-name');
       fireEvent.change(nameInput, { target: { value: 'test name' } });
 
-      // const addJobCreateButton = getByRole('button', { name: 'Add job profile for import/create' });
-      const addJobCreateButton = await findByText('Add job profile for import/create');
+      debug(container, 300000);
+
+      const addJobCreateButton = await findByRole('button', { name: 'Add job profile for import/create' });
       fireEvent.click(addJobCreateButton);
 
-      const selectJobProfileButton = await findByLabelText('Select job profile for import/create');
+      const selectJobProfileButton = await findByRole('button', { name: 'Select job profile for import/create' });
       fireEvent.click(selectJobProfileButton);
 
-      const jobProfileOption = getAllByText('Job profile for create (job profile id for create)');
+      const jobProfileOption = await findAllByText('Job profile for create (job profile id for create)');
       fireEvent.click(jobProfileOption[0]);
 
-      const setDefaultJobProfileButton = await findByLabelText('Set 0 job profile for create as default');
+      const setDefaultJobProfileButton = await findByRole('radio', { name: 'Set 0 job profile for create as default' });
       fireEvent.click(setDefaultJobProfileButton);
 
-      const addJobUpdateButton = getByText('Add job profile for overlay/update');
+      const addJobUpdateButton = await findByRole('button', { name: 'Add job profile for overlay/update' });
       fireEvent.click(addJobUpdateButton);
 
-      const selectJobProfileUpdateButton = await findByLabelText('Select job profile for overlay/update');
+      const selectJobProfileUpdateButton = await findByRole('button', { name: 'Select job profile for overlay/update' });
       fireEvent.click(selectJobProfileUpdateButton);
 
-      const jobProfileUpdateOption = getAllByText('Job profile for update (job profile id for update)');
+      const jobProfileUpdateOption = await findAllByText('Job profile for update (job profile id for update)');
       fireEvent.click(jobProfileUpdateOption[1]);
 
-      const setDefaultJobProfileUpdateButton = await findByLabelText('Set 0 job profile for update as default');
+      const setDefaultJobProfileUpdateButton = await findByRole('radio', { name: 'Set 0 job profile for update as default' });
       fireEvent.click(setDefaultJobProfileUpdateButton);
 
       const submit = getByText('Save & close');


### PR DESCRIPTION
## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
* In order to get list of statistical code types when view statistical codes, we need to update  `Settings (Inventory): Create, edit, delete statistical codes` permission.

## Approach
* Added `inventory-storage.statistical-code-types.collection.get` to sub permissions.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-2772](https://folio-org.atlassian.net/browse/UIIN-2772)