### PR TITLE
UIIN-2773: Disable fields in "HRID handling" section when `Settings (Inventory): Create, edit and delete HRID handling` permission is not assigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
 * Make item barcode column narrower. Fixes UIIN-2925.
 * i18n item status in item edit view. Refs UIIN-2766.
 * Enable "+ New" and "Edit" buttons when user has "Settings (Inventory): Configure single-record import" permission. Refs UIIN-2771.
+* Allow user to view `HRID handling` section when "Settings (Inventory): View list of settings pages" permission is assigned
+and disable fields when "Settings (Inventory): Create, edit and delete HRID handling" permission is not assigned. Refs UIIN-2773.
 
 ## [11.0.4](https://github.com/folio-org/ui-inventory/tree/v11.0.4) (2024-04-30)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.3...v11.0.4)

--- a/src/settings/HRIDHandling/HRIDHandlingSettings.js
+++ b/src/settings/HRIDHandling/HRIDHandlingSettings.js
@@ -65,6 +65,7 @@ class HRIDHandlingSettings extends Component {
   static propTypes = {
     mutator: PropTypes.object.isRequired,
     resources: PropTypes.object.isRequired,
+    stripes: PropTypes.object.isRequired,
   };
 
   constructor(props) {
@@ -154,8 +155,9 @@ class HRIDHandlingSettings extends Component {
   }
 
   render() {
-    const { mutator } = this.props;
+    const { mutator, stripes } = this.props;
     const initialValues = this.getInitialValues();
+    const isEnabled = stripes.hasPerm('ui-inventory.settings.hrid-handling');
 
     return (
       <IntlConsumer>

--- a/src/settings/HRIDHandling/HRIDHandlingSettings.js
+++ b/src/settings/HRIDHandling/HRIDHandlingSettings.js
@@ -157,7 +157,7 @@ class HRIDHandlingSettings extends Component {
   render() {
     const { mutator, stripes } = this.props;
     const initialValues = this.getInitialValues();
-    const isEnabled = stripes.hasPerm('ui-inventory.settings.hrid-handling');
+    const canEdit = stripes.hasPerm('ui-inventory.settings.hrid-handling');
 
     return (
       <IntlConsumer>
@@ -192,6 +192,7 @@ class HRIDHandlingSettings extends Component {
                               }}
                               inline
                               labelClass={css.checkboxLabel}
+                              disabled={!canEdit}
                             />
                           )}
                         />
@@ -230,6 +231,7 @@ class HRIDHandlingSettings extends Component {
                               component={TextField}
                               className={`${css.margin0} startWithField startWithField--${record.type}`}
                               validate={composeValidators(validateNumericField, validateRequiredField, validateStartWithMaxLength)}
+                              disabled={!canEdit}
                             />
                           </div>
                         </Col>
@@ -251,6 +253,7 @@ class HRIDHandlingSettings extends Component {
                               component={TextField}
                               className={`${css.margin0} assignPrefixField assignPrefixField--${record.type}`}
                               validate={composeValidators(validateAlphaNumericField, validateAssignPrefixMaxLength)}
+                              disabled={!canEdit}
                             />
                           </div>
                         </Col>

--- a/src/settings/HRIDHandling/HRIDHandlingSettings.test.js
+++ b/src/settings/HRIDHandling/HRIDHandlingSettings.test.js
@@ -1,12 +1,11 @@
+import React, { act } from 'react';
 import {
   screen,
   fireEvent,
   waitFor,
-  act,
 } from '@folio/jest-config-stripes/testing-library/react';
 
 import '../../../test/jest/__mock__';
-import React from 'react';
 import { renderWithIntl } from '../../../test/jest/helpers';
 import renderWithRouter from '../../../test/jest/helpers/renderWithRouter';
 
@@ -31,12 +30,21 @@ const mockMutator = {
   },
 };
 
+const mockStripes = { hasPerm: () => false };
 
-const renderComponent = ({ resources = initialResources, mutator = mockMutator }) => {
+const renderComponent = ({
+  stripes,
+  resources = initialResources,
+  mutator = mockMutator,
+}) => {
   return (
     renderWithIntl(
       renderWithRouter(
-        <HRIDHandlingSettings resources={resources} mutator={mutator} />
+        <HRIDHandlingSettings
+          resources={resources}
+          mutator={mutator}
+          stripes={stripes}
+        />
       )
     )
   );
@@ -50,6 +58,26 @@ describe('HRIDHandlingSettings', () => {
   it('renders without crashing', () => {
     renderComponent({});
     expect(screen.getByText(/ViewMetaData/)).toBeInTheDocument();
+  });
+
+  describe('when user doesn\'t have permission to edit form', () => {
+    it('all the fields should be disabled', () => {
+      renderComponent({ stripes: mockStripes });
+
+      const prefixInputs = screen.getAllByRole('textbox', { name: /hridHandling.label.startWith/ });
+      const assignPrefix = screen.getAllByRole('textbox', { name: /label.assignPrefix/ });
+      const checkbox = screen.getByRole('checkbox');
+
+      expect(checkbox).toBeDisabled();
+
+      prefixInputs.forEach((input) => {
+        expect(input).toBeDisabled();
+      });
+
+      assignPrefix.forEach((input) => {
+        expect(input).toBeDisabled();
+      });
+    });
   });
 
   it('should call PUT rejected on submit form', async () => {

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -175,7 +175,7 @@ class InventorySettings extends React.Component {
             route: 'hridHandling',
             label: <FormattedMessage id="ui-inventory.hridHandling" />,
             component: HRIDHandlingSettings,
-            perm: 'ui-inventory.settings.hrid-handling',
+            perm: this.addPerm('ui-inventory.settings.hrid-handling'),
           },
           {
             route: 'statisticalCodeTypes',


### PR DESCRIPTION
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Allow user to view "HRID handling" section when `Settings (Inventory): View list of settings pages` permission is assigned.
* Disable fields in "HRID handling" section when `Settings (Inventory): Create, edit and delete HRID handling` permission is not assigned to user.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-2773](https://folio-org.atlassian.net/browse/UIIN-2773)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![image](https://github.com/folio-org/ui-inventory/assets/85172747/9e64df64-bdd6-4e81-bd05-9e5abe0fec17)

