### PR TITLE
UIIN-2968 include translations from all shared @folio libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 and disable fields when "Settings (Inventory): Create, edit and delete HRID handling" permission is not assigned. Refs UIIN-2773.
 * Update "Settings (Inventory): Create, edit, delete statistical codes" permission. Refs UIIN-2772.
 * Focus on record title after closing record details view, on search field after canceling record creation, on close record details view icon after closing quick-marc. Refs UIIN-2962.
+* Include `stripes-inventory-components` and `stripes-marc-components` in `stripesDeps` to include their translations. Refs UIIN-2968.
 
 ## [11.0.4](https://github.com/folio-org/ui-inventory/tree/v11.0.4) (2024-04-30)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.3...v11.0.4)

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
       }
     ],
     "stripesDeps": [
-      "@folio/stripes-acq-components"
+      "@folio/stripes-acq-components",
+      "@folio/stripes-inventory-components",
+      "@folio/stripes-marc-components"
     ],
     "okapiInterfaces": {
       "alternative-title-types": "1.0",


### PR DESCRIPTION
Include `@folio/stripes-inventory-components` and
`@folio/stripes-marc-components` in `stripesDeps` to cause the translations defined in those shared libraries to be picked up by stripes-webpack when creating the bundle. Although it is possible to add translations to the bundle by directly including these modules in `stripes.config.js`, that's the wrong way to go about it (although it has the same effect) since these are just shared modules, not directly-useable applications.

Refs [UIIN-2968](https://folio-org.atlassian.net/browse/UIIN-2968)