### PR TITLE
UIIN-2907: Create a text link for classification numbers based on classification types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Focus on record title after closing record details view, on search field after canceling record creation, on close record details view icon after closing quick-marc. Refs UIIN-2962.
 * Include `stripes-inventory-components` and `stripes-marc-components` in `stripesDeps` to include their translations. Refs UIIN-2968.
 * Trigger search from icon in related titles on Instance detail view. Refs UIIN-2943.
+* Create a text link for classification numbers based on classification types. Refs UIIN-2907.
 
 ## [11.0.4](https://github.com/folio-org/ui-inventory/tree/v11.0.4) (2024-04-30)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.3...v11.0.4)

--- a/src/components/BrowseResultsList/BrowseResultsList.test.js
+++ b/src/components/BrowseResultsList/BrowseResultsList.test.js
@@ -7,7 +7,6 @@ import {
   FACETS,
   browseModeOptions,
   browseCallNumberOptions,
-  browseClassificationOptions,
 } from '@folio/stripes-inventory-components';
 import { createMemoryHistory } from 'history';
 import { Router } from 'react-router-dom';
@@ -75,6 +74,25 @@ const mockContext = {
     id: '6e09d47d-95e2-4d8a-831b-f777b8ef6d81',
     name: 'Author',
   }],
+  classificationBrowseConfig: [
+    {
+      id: 'all',
+      typeIds: [],
+    },
+    {
+      id: 'dewey',
+      typeIds: [
+        'id-dewey',
+      ]
+    },
+    {
+      id: 'lc',
+      typeIds: [
+        'id-lc',
+        'id-lc-local',
+      ],
+    },
+  ],
 };
 
 const contributorsData = [
@@ -165,43 +183,124 @@ describe('BrowseResultsList', () => {
     });
   });
 
-  describe.each([
-    { searchOption: browseClassificationOptions.CLASSIFICATION_ALL, shared: FACETS.CLASSIFICATION_SHARED },
-    { searchOption: browseClassificationOptions.DEWEY_CLASSIFICATION, shared: FACETS.CLASSIFICATION_SHARED },
-    { searchOption: browseClassificationOptions.LC_CLASSIFICATION, shared: FACETS.CLASSIFICATION_SHARED },
-  ])('when the search option is $searchOption and the Shared facets is selected', ({ searchOption, shared }) => {
-    describe('and a user hits on a classification number in the list', () => {
-      it('should be navigated to the Search lookup with those filters', async () => {
-        const classificationNumber = 'BD638 .T46 2018';
+  describe('when the search option is classificationAll and the Shared facet is selected', () => {
+    describe('and there are no selected classification types in Settings', () => {
+      describe('and user hits a classification number', () => {
+        it('should be redirected to the Search lookup with the correct query', () => {
+          const classificationNumber = 'BD638 .T46 2018';
+          const qindex = 'classificationAll';
 
-        history = createMemoryHistory({
-          initialEntries: [{
-            pathname: BROWSE_INVENTORY_ROUTE,
-            search: `qindex=${searchOption}&query=${classificationNumber}&${shared}=true&${shared}=false`,
-          }],
-        });
+          history = createMemoryHistory({
+            initialEntries: [{
+              pathname: BROWSE_INVENTORY_ROUTE,
+              search: `qindex=${qindex}&query=${classificationNumber}&classificationShared=true&classificationShared=false`,
+            }],
+          });
 
-        renderBrowseResultsList({
-          filters: {
-            qindex: searchOption,
-            query: classificationNumber,
-            [shared]: ['true', 'false'],
-          },
-          browseData: [
-            {
-              classificationNumber,
-              classificationTypeId: '42471af9-7d25-4f3a-bf78-60d29dcf463b',
-              isAnchor: true,
-              totalRecords: 1,
+          renderBrowseResultsList({
+            filters: {
+              qindex,
+              query: classificationNumber,
+              classificationShared: ['true', 'false'],
             },
-          ]
+            browseData: [
+              {
+                classificationNumber,
+                classificationTypeId: '42471af9-7d25-4f3a-bf78-60d29dcf463b',
+                isAnchor: true,
+                totalRecords: 1,
+              },
+            ]
+          });
+
+          fireEvent.click(screen.getByText(classificationNumber));
+
+          const query = 'classifications.classificationNumber%3D%3D%22BD638%20.T46%202018%22&selectedBrowseResult=true';
+
+          expect(history.location.search).toBe(`?filters=shared.true%2Cshared.false&qindex=querySearch&query=${query}`);
         });
+      });
+    });
+  });
 
-        fireEvent.click(screen.getByText(classificationNumber));
+  describe('when the search option is deweyClassification and the Shared facet is selected', () => {
+    describe('and one classification type is selected in Settings', () => {
+      describe('and user hits a classification number', () => {
+        it('should be redirected to the Search lookup with the correct query', () => {
+          const classificationNumber = 'BD638 .T46 2018';
+          const qindex = 'deweyClassification';
 
-        expect(history.location.search).toBe(
-          '?filters=shared.true%2Cshared.false&qindex=querySearch&query=classifications.classificationNumber%3D%3D%22BD638%20.T46%202018%22&selectedBrowseResult=true'
-        );
+          history = createMemoryHistory({
+            initialEntries: [{
+              pathname: BROWSE_INVENTORY_ROUTE,
+              search: `qindex=${qindex}&query=${classificationNumber}&classificationShared=true&classificationShared=false`,
+            }],
+          });
+
+          renderBrowseResultsList({
+            filters: {
+              qindex,
+              query: classificationNumber,
+              classificationShared: ['true', 'false'],
+            },
+            browseData: [
+              {
+                classificationNumber,
+                classificationTypeId: '42471af9-7d25-4f3a-bf78-60d29dcf463b',
+                isAnchor: true,
+                totalRecords: 1,
+              },
+            ]
+          });
+
+          fireEvent.click(screen.getByText(classificationNumber));
+
+          const classificationTypeQuery = '%20and%20%28classifications.classificationTypeId%3D%3D%22id-dewey%22%29';
+          const query = `classifications.classificationNumber%3D%3D%22BD638%20.T46%202018%22${classificationTypeQuery}&selectedBrowseResult=true`;
+
+          expect(history.location.search).toBe(`?filters=shared.true%2Cshared.false&qindex=querySearch&query=${query}`);
+        });
+      });
+    });
+  });
+
+  describe('when the search option is lcClassification and the Shared facet is selected', () => {
+    describe('and two classification types are selected in Settings', () => {
+      describe('and user hits a classification number', () => {
+        it('should be redirected to the Search lookup with the correct query', () => {
+          const classificationNumber = 'BD638 .T46 2018';
+          const qindex = 'lcClassification';
+
+          history = createMemoryHistory({
+            initialEntries: [{
+              pathname: BROWSE_INVENTORY_ROUTE,
+              search: `qindex=${qindex}&query=${classificationNumber}&classificationShared=true&classificationShared=false`,
+            }],
+          });
+
+          renderBrowseResultsList({
+            filters: {
+              qindex,
+              query: classificationNumber,
+              classificationShared: ['true', 'false'],
+            },
+            browseData: [
+              {
+                classificationNumber,
+                classificationTypeId: '42471af9-7d25-4f3a-bf78-60d29dcf463b',
+                isAnchor: true,
+                totalRecords: 1,
+              },
+            ]
+          });
+
+          fireEvent.click(screen.getByText(classificationNumber));
+
+          const classificationTypesQuery = '%20and%20%28classifications.classificationTypeId%3D%3D%22id-lc%22%20or%20classifications.classificationTypeId%3D%3D%22id-lc-local%22%29';
+          const query = `classifications.classificationNumber%3D%3D%22BD638%20.T46%202018%22${classificationTypesQuery}&selectedBrowseResult=true`;
+
+          expect(history.location.search).toBe(`?filters=shared.true%2Cshared.false&qindex=querySearch&query=${query}`);
+        });
       });
     });
   });

--- a/src/components/BrowseResultsList/getBrowseResultsFormatter.js
+++ b/src/components/BrowseResultsList/getBrowseResultsFormatter.js
@@ -36,9 +36,10 @@ const getTargetRecord = (
   browseOption,
   filters,
   namespace,
+  data,
 ) => {
   const record = getFullMatchRecord(item, row.isAnchor);
-  const searchParams = getSearchParams(row, browseOption, filters);
+  const searchParams = getSearchParams(row, browseOption, filters, data);
   const isNotClickable = isRowPreventsClick(row, browseOption);
 
   if (isNotClickable) return record;
@@ -113,6 +114,8 @@ const getBrowseResultsFormatter = ({
   filters,
   namespace,
 }) => {
+  const commonTargetRecordArgs = [browseOption, filters, namespace, data];
+
   return {
     title: r => getFullMatchRecord(r.instance?.title, r.isAnchor),
     subject: r => {
@@ -120,7 +123,7 @@ const getBrowseResultsFormatter = ({
         return <MissedMatchItem query={r?.value} />;
       }
 
-      const subject = getTargetRecord(r?.value, r, browseOption, filters, namespace);
+      const subject = getTargetRecord(r?.value, r, ...commonTargetRecordArgs);
       if (browseOption === browseModeOptions.SUBJECTS && r.authorityId) {
         return renderMarcAuthoritiesLink(r.authorityId, subject);
       }
@@ -129,13 +132,13 @@ const getBrowseResultsFormatter = ({
     },
     callNumber: r => {
       if (r?.instance || r?.totalRecords) {
-        return getTargetRecord(r?.fullCallNumber, r, browseOption, filters, namespace);
+        return getTargetRecord(r?.fullCallNumber, r, ...commonTargetRecordArgs);
       }
       return <MissedMatchItem query={r.fullCallNumber} />;
     },
     classificationNumber: r => {
       if (r?.totalRecords) {
-        return getTargetRecord(r?.classificationNumber, r, browseOption, filters, namespace);
+        return getTargetRecord(r?.classificationNumber, r, ...commonTargetRecordArgs);
       }
       return <MissedMatchItem query={r.classificationNumber} />;
     },
@@ -144,7 +147,7 @@ const getBrowseResultsFormatter = ({
         return <MissedMatchItem query={r.name} />;
       }
 
-      const fullMatchRecord = getTargetRecord(r.name, r, browseOption, filters, namespace);
+      const fullMatchRecord = getTargetRecord(r.name, r, ...commonTargetRecordArgs);
 
       if (browseOption === browseModeOptions.CONTRIBUTORS && r.authorityId) {
         return renderMarcAuthoritiesLink(r.authorityId, fullMatchRecord);

--- a/src/components/BrowseResultsList/getBrowseResultsFormatter.test.js
+++ b/src/components/BrowseResultsList/getBrowseResultsFormatter.test.js
@@ -28,6 +28,25 @@ let history;
 const data = {
   contributorNameTypes: [{ id: 'contributorNameTypeId', name: 'nameType' }],
   contributorTypes: [{ id: 'contributorTypeId', name: 'type' }],
+  classificationBrowseConfig: [
+    {
+      id: 'all',
+      typeIds: [],
+    },
+    {
+      id: 'dewey',
+      typeIds: [
+        'id-dewey',
+      ]
+    },
+    {
+      id: 'lc',
+      typeIds: [
+        'id-lc',
+        'id-lc-local',
+      ],
+    },
+  ],
 };
 const missedMatchText = 'would be here';
 
@@ -287,6 +306,7 @@ describe('getBrowseResultsFormatter', () => {
         qindex: 'classificationAll',
         query: classificationNumber,
       },
+      data,
     });
     const missedMatchRecord = {
       classificationNumber: 'foo',


### PR DESCRIPTION

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Create a text link for classification numbers based on classification types.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Description:
Currently, when a user hits a classification number in the Browse search, they are redirected to the Search lookup, and the search is performed without regard to the classification types selected in Settings. 

Now, the search respects the selected types by extending the text link with `classifications.classificationTypeId`.


## Refs
[UIIN-2907](https://folio-org.atlassian.net/browse/UIIN-2907)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots


https://github.com/folio-org/ui-inventory/assets/77053927/c8145aa2-7794-47ac-a569-f375d15f8302




<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
