### PR TITLE
UIIN-2976: Add `skipTrimOnChange` option to `useLocationFilters` hook to prevent unnecessary trims on change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Enable "View source" option for "LINKED_DATA" source type in "Actions" dropdown. Refs in UIIN-2966.
 * Create a text link for classification numbers based on classification types. Refs UIIN-2907.
 * Add "Edit in Linked Data editor" action for resources with source "LINKED_DATA". Refs UIIN-2963.
+* Add `skipTrimOnChange` option to `useLocationFilters` hook to prevent unnecessary trims on change. Refs UIIN-2976.
 
 ## [11.0.4](https://github.com/folio-org/ui-inventory/tree/v11.0.4) (2024-04-30)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.3...v11.0.4)

--- a/src/views/BrowseInventory/BrowseInventory.js
+++ b/src/views/BrowseInventory/BrowseInventory.js
@@ -82,7 +82,8 @@ const BrowseInventory = () => {
     clearFilters,
   ] = useLocationFilters(location, history, () => {
     setPageConfig(INIT_PAGE_CONFIG);
-  });
+  },
+  { skipTrimOnChange: true });
 
   const withExtraFilters = useMemo(() => {
     const { qindex, query } = querystring.parse(search);

--- a/src/views/BrowseInventory/BrowseInventory.test.js
+++ b/src/views/BrowseInventory/BrowseInventory.test.js
@@ -186,6 +186,22 @@ describe('BrowseInventory', () => {
     expect(applySearch).not.toHaveBeenCalled();
   });
 
+  describe('when changing search term', () => {
+    it('should not be trimmed', async () => {
+      useLocationFilters.mockClear().mockReturnValue(getFiltersUtils({
+        searchQuery: '',
+      }));
+
+      const searchTerm = ' test ';
+
+      renderBrowseInventory();
+
+      await act(async () => userEvent.type(screen.getByRole('textbox'), searchTerm));
+
+      expect(screen.getByRole('textbox').value).toBe(searchTerm);
+    });
+  });
+
   describe('when a new search query is submitted', () => {
     it('should focus pane title', async () => {
       const { getByRole } = renderBrowseInventory();


### PR DESCRIPTION

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Prevent removing spaces on change in Browse search.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
Add `skipTrimOnChange` flag to `useLocationFilters` hook to prevent unnecessary trims on change.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-2976](https://folio-org.atlassian.net/browse/UIIN-2976)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots



https://github.com/user-attachments/assets/8db510bb-4d98-4998-a41d-c913fd85cda5




<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
