### PR TITLE
UIIN-2922: Wrong statistical code column heading is displayed in instances, holdings, and items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Enable "View source" option for "LINKED_DATA" source type in "Actions" dropdown. Refs in UIIN-2966.
 * Create a text link for classification numbers based on classification types. Refs UIIN-2907.
 * Add "Edit in Linked Data editor" action for resources with source "LINKED_DATA". Refs UIIN-2963.
+* Wrong statistical code column heading is displayed in instances, holdings, and items. Fixes UIIN-2922.
 
 ## [11.0.4](https://github.com/folio-org/ui-inventory/tree/v11.0.4) (2024-04-30)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.3...v11.0.4)

--- a/src/Instance/InstanceDetails/InstanceAdministrativeView/StatisticalCodesList.js
+++ b/src/Instance/InstanceDetails/InstanceAdministrativeView/StatisticalCodesList.js
@@ -18,7 +18,7 @@ const noValue = <NoValue />;
 const visibleColumns = ['type', 'name'];
 const getColumnMapping = intl => ({
   type: intl.formatMessage({ id: 'ui-inventory.statisticalCodeType' }),
-  name: intl.formatMessage({ id: 'ui-inventory.statisticalCode' }),
+  name: intl.formatMessage({ id: 'ui-inventory.statisticalCodeName' }),
 });
 const formatter = {
   type: item => item.type || noValue,

--- a/src/Instance/InstanceDetails/InstanceDetails.test.js
+++ b/src/Instance/InstanceDetails/InstanceDetails.test.js
@@ -91,7 +91,7 @@ describe('InstanceDetails', () => {
     expect(screen.getByText('Instance status source')).toBeInTheDocument();
     expect(screen.getByText('Mode of issuance')).toBeInTheDocument();
     expect(screen.getByText('Statistical code type')).toBeInTheDocument();
-    expect(screen.getByText('Statistical code')).toBeInTheDocument();
+    expect(screen.getByText('Statistical code name')).toBeInTheDocument();
     expect(screen.getByText('Format category')).toBeInTheDocument();
     expect(screen.getByText('Format term')).toBeInTheDocument();
     expect(screen.getByText('Format code')).toBeInTheDocument();

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -886,17 +886,17 @@ class ViewHoldingsRecord extends React.Component {
                             <MultiColumnList
                               id="list-statistical-codes"
                               contentData={statisticalCodeIdsContent}
-                              visibleColumns={['Statistical code type', 'Statistical code']}
+                              visibleColumns={['Statistical code type', 'Statistical code name']}
                               columnMapping={{
                                 'Statistical code type': intl.formatMessage({ id: 'ui-inventory.statisticalCodeType' }),
-                                'Statistical code': intl.formatMessage({ id: 'ui-inventory.statisticalCode' }),
+                                'Statistical code name': intl.formatMessage({ id: 'ui-inventory.statisticalCodeName' }),
                               }}
                               columnWidths={{ 'Statistical code type': '16%' }}
                               formatter={{
                                 'Statistical code type':
                                     x => this.refLookup(referenceTables.statisticalCodeTypes,
                                       this.refLookup(referenceTables.statisticalCodes, get(x, ['codeId'])).statisticalCodeTypeId).name || noValue,
-                                'Statistical code':
+                                'Statistical code name':
                                     x => this.refLookup(referenceTables.statisticalCodes, get(x, ['codeId'])).name || noValue,
                               }}
                               ariaLabel={intl.formatMessage({ id: 'ui-inventory.statisticalCodes' })}

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -900,7 +900,7 @@ class ItemView extends React.Component {
     const statisticalCodeFormatter = {
       'Statistical code type': x => refLookup(referenceTables.statisticalCodeTypes,
         refLookup(referenceTables.statisticalCodes, get(x, ['codeId'])).statisticalCodeTypeId).name || noValue,
-      'Statistical code': x => refLookup(referenceTables.statisticalCodes, get(x, ['codeId'])).name || noValue,
+      'Statistical code name': x => refLookup(referenceTables.statisticalCodes, get(x, ['codeId'])).name || noValue,
     };
 
     const electronicAccessFormatter = {
@@ -1213,10 +1213,10 @@ class ItemView extends React.Component {
                         <MultiColumnList
                           id="item-list-statistical-codes"
                           contentData={statisticalCodeContent}
-                          visibleColumns={['Statistical code type', 'Statistical code']}
+                          visibleColumns={['Statistical code type', 'Statistical code name']}
                           columnMapping={{
                             'Statistical code type': intl.formatMessage({ id: 'ui-inventory.statisticalCodeType' }),
-                            'Statistical code': intl.formatMessage({ id: 'ui-inventory.statisticalCode' }),
+                            'Statistical code name': intl.formatMessage({ id: 'ui-inventory.statisticalCodeName' }),
                           }}
                           formatter={statisticalCodeFormatter}
                           ariaLabel={intl.formatMessage({ id: 'ui-inventory.statisticalCodes' })}


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
In the Inventory Settings page there are **Statistical code type** and **Statistical code name** fields, but in instances, holdings, and items there are **Statistical code type** and **Statistical code**. This is confusing because when a user sets up these codes then they have to specify a name and a code, but these configurations don’t match with the Inventory UI.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Render correct labels.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-2922

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
