### PR TITLE
UIIN-2955: Display 'New order' action in instance action menu when active affiliation set to central tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Update "Edit Instance" workform for resources with source "LINKED_DATA". Refs UIIN-2967.
 * Inventory App: Consume {{FormattedTime}} via stripes-component. Refs UIIN-1273.
 * Update request to go to inventory API when Holdings is updated. Refs UIIN-2779.
+* Display "New order" action in instance action menu when active affiliation set to central tenant. Refs UIIN-2955.
 
 ## [11.0.4](https://github.com/folio-org/ui-inventory/tree/v11.0.4) (2024-04-30)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.3...v11.0.4)

--- a/src/ViewInstance.test.js
+++ b/src/ViewInstance.test.js
@@ -220,6 +220,13 @@ const defaultProp = {
         },
       ]
     },
+    centralOrdering: {
+      records: [{
+        settings: [{
+          value: 'true',
+        }],
+      }],
+    },
     instanceRequests: {
       other: {
         totalRecords: 10,
@@ -738,7 +745,52 @@ describe('ViewInstance', () => {
       }, 10000);
 
       describe('when user is in central tenant', () => {
-        it('should be hidden', () => {
+        beforeEach(() => {
+          checkIfUserInCentralTenant.mockClear().mockReturnValue(true);
+        });
+
+        const stripes = {
+          ...defaultProp.stripes,
+          okapi: { tenant: 'consortium' },
+          user: {
+            user: {
+              consortium: { centralTenantId: 'consortium' },
+              tenants: ['testTenantId'],
+            },
+          },
+        };
+
+        describe('when central ordering is active', () => {
+          it('should be visible', () => {
+            const inactiveCenralOrdering = {
+              records: [{
+                settings: [{
+                  value: 'false',
+                }],
+              }],
+            };
+
+            renderViewInstance({
+              stripes,
+              resources: {
+                ...defaultProp.resources,
+                centralOrdering: inactiveCenralOrdering,
+              },
+            });
+            fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+
+            expect(screen.queryByRole('button', { name: 'New order' })).not.toBeInTheDocument();
+          });
+        });
+        describe('when central ordering is inactive', () => {
+          it('should be visible', () => {
+            renderViewInstance({ stripes });
+            fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+
+            expect(screen.queryByRole('button', { name: 'New order' })).toBeInTheDocument();
+          });
+        });
+        /* it('should be hidden', () => {
           const stripes = {
             ...defaultProp.stripes,
             okapi: { tenant: 'consortium' },
@@ -755,7 +807,7 @@ describe('ViewInstance', () => {
           fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
 
           expect(screen.queryByRole('button', { name: 'New order' })).not.toBeInTheDocument();
-        });
+        }); */
       });
     });
     describe('"View requests" action item', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -880,3 +880,5 @@ export const sendCalloutOnAffiliationChange = (stripes, tenantId, callout) => {
     }
   }
 };
+
+export const checkIfCentralOrderingIsActive = centralOrdering => centralOrdering.records[0]?.settings[0]?.value === 'true';

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -17,6 +17,7 @@ import {
   parseEmptyFormValue,
   redirectToMarcEditPage,
   sendCalloutOnAffiliationChange,
+  checkIfCentralOrderingIsActive,
 } from './utils';
 import {
   CONTENT_TYPE_HEADER,
@@ -348,5 +349,31 @@ describe('sendCalloutOnAffiliationChange', () => {
 
       expect(callout.sendCallout).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('checkIfCentralOrderingIsActive', () => {
+  const inactiveCenralOrdering = {
+    records: [{
+      settings: [{
+        value: 'false',
+      }],
+    }],
+  };
+
+  const activeCenralOrdering = {
+    records: [{
+      settings: [{
+        value: 'true',
+      }],
+    }],
+  };
+
+  it('should return false, when central ordering is inactive', () => {
+    expect(checkIfCentralOrderingIsActive(inactiveCenralOrdering)).toBeFalsy();
+  });
+
+  it('should return true, when central ordering is active', () => {
+    expect(checkIfCentralOrderingIsActive(activeCenralOrdering)).toBeTruthy();
   });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
