### PR TITLE
UIIN-2977 Save Instances UUIDs - When request URI exceeds character limit split request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Enable "View source" option for "LINKED_DATA" source type in "Actions" dropdown. Refs in UIIN-2966.
 * Create a text link for classification numbers based on classification types. Refs UIIN-2907.
 * Add "Edit in Linked Data editor" action for resources with source "LINKED_DATA". Refs UIIN-2963.
+* Save Instances UUIDs - When request URI exceeds character limit split request. Refs UIIN-2977.
 
 ## [11.0.4](https://github.com/folio-org/ui-inventory/tree/v11.0.4) (2024-04-30)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.3...v11.0.4)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -8,6 +8,7 @@ import {
   size,
   isEmpty,
   noop,
+  uniqBy,
 } from 'lodash';
 import {
   injectIntl,
@@ -77,6 +78,7 @@ import {
   switchAffiliation,
   addFilter,
   replaceFilter,
+  batchQueryIntoSmaller,
 } from '../../utils';
 import {
   INSTANCES_ID_REPORT_TIMEOUT,
@@ -550,8 +552,49 @@ class InstancesList extends React.Component {
     this.setState({ inTransitItemsExportInProgress: true }, this.generateInTransitItemReport);
   };
 
+  isURIExceedsLimit = (endpointPath, query) => {
+    const URI_LIMIT = 4000;
+
+    return `${endpointPath}?query=${stringify({ query })}`.length > URI_LIMIT;
+  }
+
+  splitRequestToInstancesIds = async (endpointPath, query) => {
+    const { GET } = this.props.parentMutator.recordsToExportIDs;
+
+    // URI too long, need to split into several requests
+    let splitQueries = [];
+
+    let valuesPerBatch = 50;
+    const valuesPerBatchDecreasePerTry = 5;
+
+    // 50 values per batch might still exceed limit, so we need to check split queries for limit and keep trying with smaller bathes
+    // until all queries are within URI length limit
+    do {
+      splitQueries = batchQueryIntoSmaller(query, valuesPerBatch);
+
+      if (splitQueries.some(_query => this.isURIExceedsLimit(endpointPath, _query))) {
+        valuesPerBatch -= valuesPerBatchDecreasePerTry;
+      } else {
+        break;
+      }
+      // eslint-disable-next-line no-constant-condition
+    } while (true);
+
+    const requests = splitQueries.map(_query => {
+      return GET({ params: { query: _query } });
+    });
+
+    const itemBatches = await Promise.all(requests);
+
+    return itemBatches.flat();
+  }
+
   generateInstancesIdReport = async (sendCallout) => {
     const { instancesIdExportInProgress } = this.state;
+    const {
+      data,
+      stripes,
+    } = this.props;
 
     if (instancesIdExportInProgress) return;
 
@@ -572,14 +615,24 @@ class InstancesList extends React.Component {
           });
         }, INSTANCES_ID_REPORT_TIMEOUT);
 
-        const items = await GET();
+        const endpointPath = `${stripes.okapi.url}/search/instances/ids?query=`;
+        const query = buildSearchQuery(applyDefaultStaffSuppressFilter)(data.query, {}, data, { log: noop }, this.props);
+
+        let items = [];
+
+        if (this.isURIExceedsLimit(endpointPath, query)) {
+          items = await this.splitRequestToInstancesIds(endpointPath, query);
+        } else {
+          items = await GET();
+        }
+
 
         clearTimeout(infoCalloutTimer);
 
         const report = new IdReportGenerator('SearchInstanceUUIDs');
 
         if (!isEmpty(items)) {
-          report.toCSV(items, record => record.id);
+          report.toCSV(uniqBy(items, 'id'), record => record.id);
         }
       } catch (error) {
         clearTimeout(infoCalloutTimer);
@@ -872,7 +925,7 @@ class InstancesList extends React.Component {
             icon: 'save',
             messageId: 'ui-inventory.saveInstancesUIIDS',
             onClickHandler: buildOnClickHandler(this.generateInstancesIdReport),
-            isDisabled: isInstancesListEmpty,
+            isDisabled: false // isInstancesListEmpty,
           })}
           {segment === 'holdings' && this.getActionItem({
             id: 'dropdown-clickable-get-holdings-uiids',

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -615,7 +615,7 @@ class InstancesList extends React.Component {
           });
         }, INSTANCES_ID_REPORT_TIMEOUT);
 
-        const endpointPath = `${stripes.okapi.url}/search/instances/ids?query=`;
+        const endpointPath = `${stripes.okapi.url}/search/instances/ids`;
         const query = buildSearchQuery(applyDefaultStaffSuppressFilter)(data.query, {}, data, { log: noop }, this.props);
 
         let items = [];

--- a/src/routes/buildManifestObject.test.js
+++ b/src/routes/buildManifestObject.test.js
@@ -8,6 +8,8 @@ import {
 import buildStripes from '../../test/jest/__mock__/stripesCore.mock';
 import { applyDefaultStaffSuppressFilter } from './buildManifestObject';
 
+jest.unmock('@folio/stripes-inventory-components');
+
 const getBuildQueryArgs = ({
   queryParams = {},
   pathComponents = {},

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,7 +17,6 @@ import {
   flatten,
   pick,
 } from 'lodash';
-import queryString from 'query-string';
 
 import {
   updateTenant,

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,6 +20,7 @@ import {
   flatten,
   pick,
 } from 'lodash';
+import queryString from 'query-string';
 
 import {
   updateTenant,
@@ -879,4 +880,167 @@ export const sendCalloutOnAffiliationChange = (stripes, tenantId, callout) => {
       });
     }
   }
+};
+
+export const batchQueryIntoSmaller = (query, VALUES_PER_BATCH = 50) => {
+  const arrayParameterRegexp = /[a-zA-Z.]+==\([a-zA-Z0-9-"\s]+\)/g;
+
+  const findArrays = (_query) => {
+    // arrays always follow this format: param==(c1 or c2 or c3 or...cN)
+    // this function will return start and end indexes in query string for all arrays
+
+    const matches = _query.matchAll(arrayParameterRegexp);
+
+    const indexes = [];
+
+    for (const match of matches) {
+      indexes.push({
+        arrayString: match[0],
+      });
+    }
+
+    return indexes;
+  };
+
+  /*
+    return object with information about search parameter
+    {
+      parameter: 'item.effectiveLocation',
+      values: ["id-1", "id-2", ...]
+    }
+  */
+  const parseArrayString = (arrayString) => {
+    const parameter = arrayString.match(/^(.+)==/)[1];
+    const values = arrayString.match(/==\((.+)\)/)[1].split(' or ');
+
+    return {
+      parameter,
+      values,
+    };
+  };
+
+  /*
+    splits `values` in array returned from `parseArrayString` into arrays with batches.
+    Max number of items in sub-array is VALUES_PER_BATCH items.
+    Example:
+    [["id-1", "id-2", "id-3"], ["id-4", "id-5", "id-6"]]
+  */
+  const splitArrayIntoMultiple = (parsedArray) => {
+    if (parsedArray.values.length <= VALUES_PER_BATCH) {
+      return [parsedArray.values];
+    }
+
+    return parsedArray.values.reduce((acc, cur) => {
+      const lastBatch = acc[acc.length - 1];
+      if (lastBatch.length < VALUES_PER_BATCH) {
+        lastBatch.push(cur);
+      } else {
+        const newBatch = [cur];
+        acc.push(newBatch);
+      }
+
+      return acc;
+    }, [[]]);
+  };
+
+  /*
+    returns a cartesian product of multiple arrays. Example
+
+    cartesianProduct([[1, 2], [3, 4]]) --> [[1, 3], [1, 4], [2, 3], [2, 4]]]
+  */
+  const cartesianProduct = (arr) => {
+    return arr.reduce((a, b) => a.map(x => b.map(y => x.concat(y))).reduce((_a, _b) => _a.concat(_b), []), [[]]);
+  };
+
+  /*
+    To get same results with split requests we need to request all combinations of parameter values
+    For a simple example like (modeOfIssuanceId==("id1" or "id2") and items.effectiveLocationId==("id1" or "id2") sortby title
+    We can get the same result with 4 requests like:
+    (modeOfIssuanceId==("id1") and items.effectiveLocationId==("id1") sortby title
+    (modeOfIssuanceId==("id1") and items.effectiveLocationId==("id2") sortby title
+    (modeOfIssuanceId==("id2") and items.effectiveLocationId==("id1") sortby title
+    (modeOfIssuanceId==("id2") and items.effectiveLocationId==("id2") sortby title
+
+    So basically we accounted for all combinations of parameters.
+    We don't need to make combinations with just 1 parameter, of course.
+    If an original query has 100 items for each parameter - we can combine by 50 items.
+    So:
+      50 first items for param1 and 50 first items for param2
+      50 first for param1, 50 last for param2
+      50 last for param1, 50 first for param2
+      50 last for param2, 50 last for param 2
+  */
+  const getCombinationsOfBatches = (batchesByParameter) => {
+    /*
+      Format of `batchesByParameter` parameter doesn't let us use it in `cartesianProduct` function directly
+      So we're going to generate cartesian product of indesex of batches
+
+      Basically, from [{ parameter: 'param1', batches: [batch1, batch2] }]
+      We'll get `batchIndexes` = [[0, 1], [0, 1]]
+
+      With this we can generate cartesian product of batch indexes = [[0, 0], [0, 1], [1, 0], [1, 1]]
+
+      And then iterate over these combinations and take batches by those indexes
+    */
+    const batchIndexes = batchesByParameter.map(({ batches }) => batches.map((_, index) => index));
+
+    const indexCombinations = cartesianProduct(batchIndexes);
+    const combinations = [];
+
+    indexCombinations.forEach((combination, combinationIndex) => {
+      combinations.push([]);
+
+      combination.forEach((batchIndex, parameterIndex) => {
+        combinations[combinationIndex].push({
+          parameter: batchesByParameter[parameterIndex].parameter,
+          values: batchesByParameter[parameterIndex].batches[batchIndex],
+        });
+      });
+    });
+
+
+    return combinations;
+  };
+
+  const arrayIndexes = findArrays(query);
+
+  const batchesByParameter = [];
+  let queryStringWithPlaceholders = query;
+
+  for (const arrayIndex of arrayIndexes) {
+    const parsedArray = parseArrayString(arrayIndex.arrayString);
+    const batches = splitArrayIntoMultiple(parsedArray);
+
+    // don't want to mess with string indexes when replacing original values with batches
+    // so just mark in original query places where we've taken parameter values. later we'll replace placeholders with actual batches values
+
+    queryStringWithPlaceholders = queryStringWithPlaceholders.replace(arrayIndex.arrayString, `${parsedArray.parameter}_placeholder`);
+    batchesByParameter.push({
+      parameter: parsedArray.parameter,
+      batches,
+    });
+  }
+
+  // this is where we get all permutations from parameters
+  const permutations = getCombinationsOfBatches(batchesByParameter);
+  const resultingQueryStrings = [];
+  // now we can generate new query searches by replacing original arrays with permutations
+
+  for (const permutation of permutations) {
+    const arrayStringsByParameter = {};
+    for (const parameterArray of permutation) {
+      const { parameter, values } = parameterArray;
+      arrayStringsByParameter[parameter] = `${parameter}==(${values.join(' or ')})`;
+    }
+
+    let updatedQueryString = queryStringWithPlaceholders;
+
+    Object.keys(arrayStringsByParameter).forEach(parameter => {
+      updatedQueryString = updatedQueryString.replace(`${parameter}_placeholder`, arrayStringsByParameter[parameter]);
+    });
+
+    resultingQueryStrings.push(updatedQueryString);
+  }
+
+  return resultingQueryStrings;
 };

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -17,6 +17,7 @@ import {
   parseEmptyFormValue,
   redirectToMarcEditPage,
   sendCalloutOnAffiliationChange,
+  batchQueryIntoSmaller,
 } from './utils';
 import {
   CONTENT_TYPE_HEADER,
@@ -348,5 +349,19 @@ describe('sendCalloutOnAffiliationChange', () => {
 
       expect(callout.sendCallout).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('batchQueryIntoSmaller', () => {
+  it('should split one query into several batches', () => {
+    const originalQuery = 'item.effectiveLocationId==("id-1" or "id-2" or "id-3" or "id-4" or "id-5") or language==("en" or "de" or "sp" or "it" or "ua") sortby title';
+    const queries = batchQueryIntoSmaller(originalQuery, 3);
+
+    expect(queries).toEqual([
+      'item.effectiveLocationId==("id-1" or "id-2" or "id-3") or language==("en" or "de" or "sp") sortby title',
+      'item.effectiveLocationId==("id-1" or "id-2" or "id-3") or language==("it" or "ua") sortby title',
+      'item.effectiveLocationId==("id-4" or "id-5") or language==("en" or "de" or "sp") sortby title',
+      'item.effectiveLocationId==("id-4" or "id-5") or language==("it" or "ua") sortby title',
+    ]);
   });
 });

--- a/test/jest/__mock__/stripesInventoryComponents.mock.js
+++ b/test/jest/__mock__/stripesInventoryComponents.mock.js
@@ -18,4 +18,5 @@ jest.mock('@folio/stripes-inventory-components', () => ({
   InstanceFilters: jest.fn(() => <div>InstanceFilters</div>),
   HoldingsRecordFilters: jest.fn(() => <div>HoldingsRecordFilters</div>),
   ItemFilters: jest.fn(() => <div>ItemFilters</div>),
+  buildSearchQuery: jest.fn(),
 }));


### PR DESCRIPTION
## Description
Browsers have a limit of how many characters can be in a URI. When that limit exceeds HTTP requests fail
That happens in Inventory as well. When there are too many characters we need to split one query into multiple and join responses

## Screenshots

https://github.com/user-attachments/assets/b6253605-6454-4c92-9e47-c7148c0ef4a5



## Issues
[UIIN-2977](https://folio-org.atlassian.net/browse/UIIN-2977)