### PR TITLE
UIIN-2970: Use `withSearchErrors` HOC and `buildRecordsManifest` to display an error when the request URL is exceeded.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Inventory App: Consume {{FormattedTime}} via stripes-component. Refs UIIN-1273.
 * Update request to go to inventory API when Holdings is updated. Refs UIIN-2779.
 * Add barcode values for "Bound pieces data" and update `useBoundPieces` hook query with `bindItemId` to fetch bound pieces correctly. Refs UIIN-2984.
+* Use `withSearchErrors` HOC and `buildRecordsManifest` to display an error when the request URL is exceeded. Refs UIIN-2970.
 
 ## [11.0.4](https://github.com/folio-org/ui-inventory/tree/v11.0.4) (2024-04-30)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.3...v11.0.4)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -126,6 +126,7 @@ class InstancesList extends React.Component {
     updateLocation: PropTypes.func.isRequired,
     goTo: PropTypes.func.isRequired,
     getParams: PropTypes.func.isRequired,
+    isRequestUrlExceededLimit: PropTypes.bool.isRequired,
     segment: PropTypes.string,
     intl: PropTypes.object,
     match: PropTypes.shape({

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -1175,6 +1175,7 @@ class InstancesList extends React.Component {
       canUseSingleRecordImport,
       disableRecordCreation,
       intl,
+      isRequestUrlExceededLimit,
       data,
       parentResources,
       parentMutator,
@@ -1323,6 +1324,7 @@ class InstancesList extends React.Component {
             inputRef={this.inputRef}
             indexRef={this.indexRef}
             isCursorAtEnd
+            isRequestUrlExceededLimit={isRequestUrlExceededLimit}
             resultCountIncrement={RESULT_COUNT_INCREMENT}
             viewRecordComponent={ViewInstanceWrapper}
             editRecordComponent={InstanceForm}

--- a/src/routes/InstancesRoute.js
+++ b/src/routes/InstancesRoute.js
@@ -7,6 +7,7 @@ import {
   filterConfig,
   renderFilters,
   segments,
+  withSearchErrors,
 } from '@folio/stripes-inventory-components';
 
 import withLocation from '../withLocation';
@@ -51,6 +52,7 @@ class InstancesRoute extends React.Component {
       storeLastSearch,
       storeLastSearchOffset,
       storeLastSegment,
+      isRequestUrlExceededLimit,
     } = this.props;
     const { segment = segments.instances } = getParams(this.props);
     const { indexes } = filterConfig[segment];
@@ -78,6 +80,7 @@ class InstancesRoute extends React.Component {
             storeLastSearch={storeLastSearch}
             storeLastSearchOffset={storeLastSearchOffset}
             storeLastSegment={storeLastSegment}
+            isRequestUrlExceededLimit={isRequestUrlExceededLimit}
           />
         )}
       </DataContext.Consumer>
@@ -89,4 +92,5 @@ export default flowRight(
   stripesConnect,
   withLocation,
   withLastSearchTerms,
+  withSearchErrors,
 )(InstancesRoute);

--- a/src/routes/InstancesRoute.js
+++ b/src/routes/InstancesRoute.js
@@ -25,6 +25,7 @@ class InstancesRoute extends React.Component {
     getParams: PropTypes.func,
     getLastBrowse: PropTypes.func.isRequired,
     getLastSearchOffset: PropTypes.func.isRequired,
+    isRequestUrlExceededLimit: PropTypes.bool.isRequired,
     storeLastSearch: PropTypes.func.isRequired,
     storeLastSearchOffset: PropTypes.func.isRequired,
     storeLastSegment: PropTypes.func.isRequired,

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -2,6 +2,7 @@ import {
   FACETS,
   USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY,
   buildSearchQuery,
+  buildRecordsManifest,
 } from '@folio/stripes-inventory-components';
 
 import { replaceFilter } from '../utils';
@@ -28,28 +29,6 @@ export const applyDefaultStaffSuppressFilter = (query, stripes) => {
   }
 };
 
-const buildRecordsManifest = (options = {}) => {
-  const { path } = options;
-
-  return {
-    type: 'okapi',
-    records: 'instances',
-    resultOffset: '%{resultOffset}',
-    perRequest: 100,
-    throwErrors: false,
-    path: 'inventory/instances',
-    resultDensity: 'sparse',
-    accumulate: 'true',
-    GET: {
-      path,
-      params: {
-        expandAll: true,
-        query: buildSearchQuery(applyDefaultStaffSuppressFilter),
-      },
-    },
-  };
-};
-
 export function buildManifestObject() {
   return {
     numFiltersLoaded: { initialValue: 1 }, // will be incremented as each filter loads
@@ -63,9 +42,8 @@ export function buildManifestObject() {
     },
     resultCount: { initialValue: INITIAL_RESULT_COUNT },
     resultOffset: { initialValue: 0 },
-    records: buildRecordsManifest({
-      path: 'search/instances',
-    }),
+    requestUrlQuery: { initialValue: '' },
+    records: buildRecordsManifest(applyDefaultStaffSuppressFilter),
     recordsToExportIDs: {
       type: 'okapi',
       records: 'ids',

--- a/src/routes/buildManifestObject.test.js
+++ b/src/routes/buildManifestObject.test.js
@@ -8,12 +8,19 @@ import {
 import buildStripes from '../../test/jest/__mock__/stripesCore.mock';
 import { applyDefaultStaffSuppressFilter } from './buildManifestObject';
 
+const defaultProps = {
+  stripes: buildStripes(),
+  mutator: {
+    requestUrlQuery: { replace: jest.fn() },
+  },
+};
+
 const getBuildQueryArgs = ({
   queryParams = {},
   pathComponents = {},
   resourceData = {},
   logger = { log: jest.fn() },
-  props = { stripes: buildStripes() }
+  props = defaultProps,
 } = {}) => {
   const resData = { query: { ...queryParams }, ...resourceData };
 

--- a/src/views/InstancesView.js
+++ b/src/views/InstancesView.js
@@ -17,6 +17,6 @@ InstancesView.propTypes = {
 export default memo(InstancesView, (prevProps, nextProps) => {
   return isEqual(prevProps.data, nextProps.data) &&
     isEqual(prevProps.parentResources.records, nextProps.parentResources.records) &&
-    isEqual(prevProps.parentResources.facets, nextProps.parentResources.facets) &&
+    prevProps.isRequestUrlExceededLimit === nextProps.isRequestUrlExceededLimit &&
     prevProps.segment === nextProps.segment;
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
When the request URL exceeds the limit:
1. Show an error toast message;
2. Show a specific error message inside the results list.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
Export `buildRecordsManifest` to have one source of truth for ui-inventory and ui-plugin-find-instance.

Use `withSearchErrors` to show the error toast message, it also provides the `isRequestUrlExceededLimit` property for displaying correct error message in results pane.

The tests will pass once the related PRs are merged.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-2970](https://folio-org.atlassian.net/browse/UIIN-2970)

## Related PRs
https://github.com/folio-org/stripes-inventory-components/pull/61
https://github.com/folio-org/stripes-smart-components/pull/1496
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
https://github.com/user-attachments/assets/6a60bced-cbc3-4d86-b78e-efe99428f664
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
