### PR TITLE
UIIN-2969: Display shared instance immediately after the instance was shared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Add barcode values for "Bound pieces data" and update `useBoundPieces` hook query with `bindItemId` to fetch bound pieces correctly. Refs UIIN-2984.
 * Display "New order" action in instance action menu when active affiliation set to central tenant. Refs UIIN-2955.
 * Save Instances UUIDs - When request URI exceeds character limit split request. Refs UIIN-2977.
+* Display shared instance immediately after the instance was shared. Refs UIIN-2969.
 
 ## [11.0.4](https://github.com/folio-org/ui-inventory/tree/v11.0.4) (2024-04-30)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.3...v11.0.4)

--- a/src/common/hooks/useInstance.js
+++ b/src/common/hooks/useInstance.js
@@ -5,6 +5,7 @@ import useInstanceQuery from './useInstanceQuery';
 
 const useInstance = (id) => {
   const {
+    refetch,
     isLoading: isSearchInstanceByIdLoading,
     instance: _instance,
   } = useSearchInstanceByIdQuery(id);
@@ -16,8 +17,8 @@ const useInstance = (id) => {
     isLoading: isInstanceLoading,
     isFetching,
     instance: data,
-    refetch,
-    ...rest
+    isError,
+    error,
   } = useInstanceQuery(
     id,
     { tenantId: instanceTenantId },
@@ -42,7 +43,8 @@ const useInstance = (id) => {
     isLoading,
     isFetching,
     refetch,
-    ...rest,
+    isError,
+    error,
   };
 };
 

--- a/src/common/hooks/useInstanceQuery/useInstanceQuery.js
+++ b/src/common/hooks/useInstanceQuery/useInstanceQuery.js
@@ -11,7 +11,6 @@ const useInstanceQuery = (instanceId, { tenantId = '' } = {}, options = {}) => {
   const {
     isLoading,
     data: instance = {},
-    refetch,
     ...rest
   } = useQuery(
     [namespace, instanceId, tenantId],
@@ -25,7 +24,6 @@ const useInstanceQuery = (instanceId, { tenantId = '' } = {}, options = {}) => {
   return ({
     isLoading,
     instance,
-    refetch,
     ...rest,
   });
 };

--- a/src/common/hooks/useSearchInstanceByIdQuery/useSearchInstanceByIdQuery.js
+++ b/src/common/hooks/useSearchInstanceByIdQuery/useSearchInstanceByIdQuery.js
@@ -9,7 +9,7 @@ const useSearchInstanceByIdQuery = (instanceId) => {
   const ky = useOkapiKy();
   const [namespace] = useNamespace({ key: 'search-instance' });
 
-  const { isLoading, data = {} } = useQuery(
+  const { refetch, isLoading, data = {} } = useQuery(
     {
       queryKey: [namespace, instanceId],
       queryFn: () => ky.get(`search/instances?query=id==${instanceId}`).json(),
@@ -18,6 +18,7 @@ const useSearchInstanceByIdQuery = (instanceId) => {
   );
 
   return ({
+    refetch,
     isLoading,
     instance: data?.instances?.[0],
   });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
When local Instance is successfully shared User can see the Shadow copy of that Instance (UUID the same, HRID is changed to reflect the central sequence, source is MARC/FOLIO-shared). This Instance appears to be manageable even though it is not, any attempt to edit it will result in error. When page is refreshed, the Shared Instance is displayed and can be successfully edited.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Display Shared Instance right after the sharing. In that case, User will not be able to see/access Shadow copy in any way from UI.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-2969

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
