### PR TITLE
UIIN-2977 disable Save Instance UUIDs action when search results are empty and request did not faiol due to limit (follow-up)

### DIFF
--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -816,6 +816,7 @@ class InstancesList extends React.Component {
       intl,
       segment,
       stripes,
+      isRequestUrlExceededLimit,
     } = this.props;
     const { inTransitItemsExportInProgress } = this.state;
     const selectedRowsCount = size(this.state.selectedRows);
@@ -926,7 +927,7 @@ class InstancesList extends React.Component {
             icon: 'save',
             messageId: 'ui-inventory.saveInstancesUIIDS',
             onClickHandler: buildOnClickHandler(this.generateInstancesIdReport),
-            isDisabled: false // isInstancesListEmpty,
+            isDisabled: isInstancesListEmpty && !isRequestUrlExceededLimit,
           })}
           {segment === 'holdings' && this.getActionItem({
             id: 'dropdown-clickable-get-holdings-uiids',


### PR DESCRIPTION
## Description
disable Save Instance UUIDs action when search results are empty and request did not faiol due to limit

## Issues
[UIIN-2977](https://folio-org.atlassian.net/browse/UIIN-2977)