### PR TITLE
UIIN-2949: Prevent callbacks from being triggered when clicking on the current tab, whether it's lookup mode or a search segment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Edit in Linked Data Editor when source=MARC. Refs UIIN-2978.
 * Display shared instance immediately after the instance was shared. Refs UIIN-2969.
 * Disable Move to button if no items selected or no more holdings exists within an instance. Refs UIIN-2995.
+* Prevent callbacks from being triggered when clicking on the current tab, whether it's lookup mode or a segment. Fixes UIIN-2949.
 
 ## [11.0.4](https://github.com/folio-org/ui-inventory/tree/v11.0.4) (2024-04-30)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.3...v11.0.4)

--- a/src/components/FilterNavigation/FilterNavigation.js
+++ b/src/components/FilterNavigation/FilterNavigation.js
@@ -7,7 +7,10 @@ import {
   ButtonGroup,
   Button,
 } from '@folio/stripes/components';
-import { segments } from '@folio/stripes-inventory-components';
+import {
+  handleSegmentChange,
+  segments,
+} from '@folio/stripes-inventory-components';
 
 import { SORTABLE_SEARCH_RESULT_LIST_COLUMNS } from '../../constants';
 import { useLastSearchTerms } from '../../hooks';
@@ -36,7 +39,7 @@ const FilterNavigation = ({ segment, onChange }) => {
               }}
               buttonStyle={`${segment === name ? 'primary' : 'default'}`}
               id={`segment-navigation-${name}`}
-              onClick={() => onChange(name)}
+              onClick={() => handleSegmentChange(name, segment, onChange)}
             >
               <FormattedMessage id={`ui-inventory.filters.${name}`} />
             </Button>

--- a/src/components/FilterNavigation/FilterNavigation.test.js
+++ b/src/components/FilterNavigation/FilterNavigation.test.js
@@ -1,0 +1,60 @@
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+
+import { fireEvent } from '@folio/jest-config-stripes/testing-library/react';
+import { segments } from '@folio/stripes-inventory-components';
+
+import FilterNavigation from './FilterNavigation';
+import { renderWithIntl, translationsProperties } from '../../../test/jest/helpers';
+import { useLastSearchTerms } from '../../hooks';
+
+jest.mock('../../hooks', () => ({
+  ...jest.requireActual('../../hooks'),
+  useLastSearchTerms: jest.fn(),
+}));
+
+const mockOnChange = jest.fn();
+
+const defaultHistory = createMemoryHistory();
+
+const renderFilterNavigation = ({ history, ...props } = {}) => renderWithIntl(
+  <Router history={history || defaultHistory}>
+    <FilterNavigation
+      segment={segments.instances}
+      onChange={mockOnChange}
+      {...props}
+    />
+  </Router>,
+  translationsProperties
+);
+
+describe('Given FilterNavigation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useLastSearchTerms.mockReturnValue({
+      getLastSearch: jest.fn(() => '?filters=staffSuppress.false&segment=instances&sort=title'),
+    });
+  });
+
+  describe('when pressing the current segment', () => {
+    it('should not fire onChange', () => {
+      const { getByRole } = renderFilterNavigation();
+
+      const instanceSegment = getByRole('button', { name: 'Instance' });
+      fireEvent.click(instanceSegment);
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when clicking another segment', () => {
+    it('should fire onChange', () => {
+      const { getByRole } = renderFilterNavigation();
+
+      const holdingsSegment = getByRole('button', { name: 'Holdings' });
+      fireEvent.click(holdingsSegment);
+
+      expect(mockOnChange).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -497,6 +497,8 @@ class InstancesList extends React.Component {
 
     const id = pathname.split('/')[3];
 
+    deleteFacetStates(namespace);
+
     if (id) {
       setItem(`${namespace}.${segment}.lastOpenRecord`, id);
     }

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -21,6 +21,7 @@ import {
   queryIndexes,
   USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY,
   buildSearchQuery,
+  resetFacetStates,
 } from '@folio/stripes-inventory-components';
 
 import translationsProperties from '../../../test/jest/helpers/translationsProperties';
@@ -121,6 +122,7 @@ const getInstancesListTree = ({ segment, ...rest }) => {
       <Router history={history}>
         <ModuleHierarchyProvider module="@folio/inventory">
           <InstancesList
+            isRequestUrlExceededLimit={false}
             parentResources={resources}
             parentMutator={{
               resultOffset: { replace: mockResultOffsetReplace },
@@ -196,6 +198,28 @@ describe('InstancesList', () => {
             state: undefined,
           }));
         });
+      });
+    });
+
+    describe('when switching lookup mode', () => {
+      it('should delete facet states', () => {
+        renderInstancesList({
+          segment: 'instances',
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Browse' }));
+
+        expect(deleteFacetStates).toHaveBeenCalledWith('@folio/inventory');
+      });
+    });
+
+    describe('when switching segment (Instance/Holdings/Item)', () => {
+      it('should delete facet states', async () => {
+        renderInstancesList({ segment: 'instances' });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Holdings' }));
+
+        expect(deleteFacetStates).toHaveBeenCalledWith('@folio/inventory');
       });
     });
 
@@ -373,6 +397,14 @@ describe('InstancesList', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Reset all' }));
 
         expect(mockSetItem).toHaveBeenCalledWith(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY, false);
+      });
+
+      it('should reset facet states', () => {
+        renderInstancesList({ segment: 'instances' });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Reset all' }));
+
+        expect(resetFacetStates).toHaveBeenCalledWith({ namespace: '@folio/inventory' });
       });
     });
 

--- a/src/components/SearchModeNavigation/SearchModeNavigation.js
+++ b/src/components/SearchModeNavigation/SearchModeNavigation.js
@@ -11,7 +11,6 @@ import {
   Button,
   ButtonGroup,
 } from '@folio/stripes/components';
-import { deleteFacetStates } from '@folio/stripes-inventory-components';
 
 import { useNamespace } from '@folio/stripes/core';
 import {
@@ -35,10 +34,8 @@ const SearchModeNavigation = ({ search, state, onSearchModeSwitch }) => {
   const onClick = useCallback((segment) => {
     const isCurrentSegment = path === searchModeRoutesMap[segment];
 
-    deleteFacetStates(namespace);
-
-    if (onSearchModeSwitch) {
-      onSearchModeSwitch(namespace);
+    if (onSearchModeSwitch && !isCurrentSegment) {
+      onSearchModeSwitch();
     }
 
     history.push({

--- a/src/components/SearchModeNavigation/SearchModeNavigation.test.js
+++ b/src/components/SearchModeNavigation/SearchModeNavigation.test.js
@@ -17,10 +17,11 @@ import {
 } from '../../constants';
 
 const mockPush = jest.fn();
+const mockOnSearchModeSwitch = jest.fn();
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useRouteMatch: jest.fn().mockReturnValue({ path: '/inventory/browse' }),
+  useRouteMatch: jest.fn(),
   useHistory: () => ({
     push: mockPush,
   }),
@@ -39,6 +40,8 @@ const renderSearchModeNavigation = (
     }]}
   >
     <SearchModeNavigation
+      search=""
+      onSearchModeSwitch={mockOnSearchModeSwitch}
       {...props}
     />
   </MemoryRouter>,
@@ -48,6 +51,7 @@ const renderSearchModeNavigation = (
 describe('SearchModeNavigation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    useRouteMatch.mockReturnValue({ path: '/inventory/browse' });
   });
 
   it('should render search mode navigation buttons', () => {
@@ -124,6 +128,34 @@ describe('SearchModeNavigation', () => {
         pathname: BROWSE_INVENTORY_ROUTE,
         search,
       });
+    });
+  });
+
+  describe('when pressing the current lookup mode', () => {
+    it('should not fire onSearchModeSwitch', () => {
+      useRouteMatch.mockReturnValue({ path: INVENTORY_ROUTE });
+
+      const { getByRole } = renderSearchModeNavigation({}, {
+        initialRoute: INVENTORY_ROUTE,
+      });
+
+      fireEvent.click(getByRole('button', { name: 'Search' }));
+
+      expect(mockOnSearchModeSwitch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when clicking another lookup mode', () => {
+    it('should fire onSearchModeSwitch', () => {
+      useRouteMatch.mockReturnValue({ path: INVENTORY_ROUTE });
+
+      const { getByRole } = renderSearchModeNavigation({}, {
+        initialRoute: INVENTORY_ROUTE,
+      });
+
+      fireEvent.click(getByRole('button', { name: 'Browse' }));
+
+      expect(mockOnSearchModeSwitch).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Be able to see facet options after clicking on the current tab (Search/Browse or Instance/Holdings/Item) and then opening the facet.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Description
If a user clicks a current search segment or search mode, do nothing.

Test will pass after the related PR is merged.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Related PRs
https://github.com/folio-org/stripes-inventory-components/pull/67

## Refs
[UIIN-2949](https://folio-org.atlassian.net/browse/UIIN-2949)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots



https://github.com/user-attachments/assets/9dbe1d67-0140-4d4a-984c-30e902459eb3



<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
