### PR TITLE
UIIN-2923: Revert hiding some of the Browse options.

### DIFF
--- a/src/views/BrowseInventory/BrowseInventory.js
+++ b/src/views/BrowseInventory/BrowseInventory.js
@@ -15,7 +15,6 @@ import querystring from 'query-string';
 import {
   TitleManager,
   useNamespace,
-  useStripes,
 } from '@folio/stripes/core';
 import {
   PersistedPaneset,
@@ -28,10 +27,7 @@ import {
   useItemToView,
   useLocationFilters,
 } from '@folio/stripes-acq-components';
-import {
-  browseModeOptions,
-  useResetFacetStates,
-} from '@folio/stripes-inventory-components';
+import { useResetFacetStates } from '@folio/stripes-inventory-components';
 
 import {
   BrowseInventoryFilters,
@@ -48,7 +44,6 @@ import { INIT_PAGE_CONFIG } from '../../hooks/useInventoryBrowse';
 import css from './BrowseInventory.css';
 
 const BrowseInventory = () => {
-  const stripes = useStripes();
   const history = useHistory();
   const location = useLocation();
   const intl = useIntl();
@@ -124,16 +119,6 @@ const BrowseInventory = () => {
   const searchableIndexesPlaceholder = intl.formatMessage({ id: 'ui-inventory.browse.searchableIndexesPlaceholder' });
   const isResetButtonDisabled = !location.search && !searchQuery;
 
-  const isSearchOptionHidden = (option) => {
-    // Hide some of the call number type options for this temporary environment (UIIN-2923).
-    return stripes.okapi.url === 'https://folio-perf-quesnelia-okapi.ci.folio.org'
-      && [
-        browseModeOptions.LOCAL,
-        browseModeOptions.OTHER,
-        browseModeOptions.SUPERINTENDENT,
-      ].includes(option.value);
-  };
-
   const searchableOptions = browseInstanceIndexes.map((searchableIndex) => {
     if (searchableIndex.subIndexes) {
       return (
@@ -142,16 +127,14 @@ const BrowseInventory = () => {
           label={intl.formatMessage({ id: searchableIndex.label })}
           className={css.optgroup}
         >
-          {searchableIndex.subIndexes
-            .filter(subOption => !isSearchOptionHidden(subOption))
-            .map((subOption) => (
-              <option
-                key={subOption.value}
-                value={subOption.value}
-              >
-                {intl.formatMessage({ id: subOption.label })}
-              </option>
-            ))}
+          {searchableIndex.subIndexes.map((subOption) => (
+            <option
+              key={subOption.value}
+              value={subOption.value}
+            >
+              {intl.formatMessage({ id: subOption.label })}
+            </option>
+          ))}
         </optgroup>
       );
     }

--- a/src/views/BrowseInventory/BrowseInventory.test.js
+++ b/src/views/BrowseInventory/BrowseInventory.test.js
@@ -7,8 +7,6 @@ import { act, screen, fireEvent, waitFor } from '@folio/jest-config-stripes/test
 
 import stripesAcqComponents from '@folio/stripes-acq-components';
 import { browseModeOptions } from '@folio/stripes-inventory-components';
-import { useStripes } from '@folio/stripes/core';
-
 
 import {
   renderWithIntl,
@@ -21,7 +19,6 @@ import {
   useLastSearchTerms,
   useInventoryBrowse,
 } from '../../hooks';
-import buildStripes from '../../../test/jest/__mock__/stripesCore.mock';
 
 const { useLocationFilters } = stripesAcqComponents;
 
@@ -105,7 +102,6 @@ describe('BrowseInventory', () => {
       isFetched: false,
       isFetching: false,
     });
-    useStripes.mockReturnValue(buildStripes());
   });
 
   describe('when the component is mounted', () => {
@@ -318,22 +314,6 @@ describe('BrowseInventory', () => {
     expect(getAllByText('Library of Congress classification')[1]).toBeDefined();
     expect(getByText('Contributors')).toBeDefined();
     expect(getByText('Subjects')).toBeDefined();
-  });
-
-  describe('when environment is https://folio-perf-quesnelia-okapi.ci.folio.org', () => {
-    it('should remove browse options: "Local", "Other scheme", and "Superintendent of Documents classification"', () => {
-      useStripes.mockReturnValue(buildStripes({
-        okapi: {
-          url: 'https://folio-perf-quesnelia-okapi.ci.folio.org',
-        },
-      }));
-
-      const { queryByText } = renderBrowseInventory();
-
-      expect(queryByText('Local')).not.toBeInTheDocument();
-      expect(queryByText('Other scheme')).not.toBeInTheDocument();
-      expect(queryByText('Superintendent of Documents classification')).not.toBeInTheDocument();
-    });
   });
 
   describe('when user clicks on Reset all', () => {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Revert hiding some of the Browse options.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-2923](https://folio-org.atlassian.net/browse/UIIN-2923)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
![image](https://github.com/user-attachments/assets/1f682134-d1ca-4f6d-b26c-31d7025a28e9)

<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
