### PR TITLE
UIIN-2986: Add `showSortIndicator` prop to `SearchAndSort` to display sort indicator next to the column names, and add correct `nonInteractiveHeaders`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Prevent callbacks from being triggered when clicking on the current tab, whether it's lookup mode or a segment. Fixes UIIN-2949.
 * Hide call number type options for Local, Other scheme, and SuDoc for perf environment. Refs UIIN-2923.
 * Edit Inventory Instances: "Save & close" and "Save and keep editing" buttons could be clicked 2 times in a row. Fixes UIIN-2939.
+* Add `showSortIndicator` prop to `SearchAndSort` to display sort indicator next to the column names, and add correct `nonInteractiveHeaders`. Refs UIIN-2986.
 
 ## [11.0.4](https://github.com/folio-org/ui-inventory/tree/v11.0.4) (2024-04-30)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.3...v11.0.4)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -112,6 +112,9 @@ const ALL_COLUMNS = Array.from(new Set([
   ...TOGGLEABLE_COLUMNS,
 ]));
 const VISIBLE_COLUMNS_STORAGE_KEY = 'inventory-visible-columns';
+const SORTABLE_COLUMNS = Object.values(SORTABLE_SEARCH_RESULT_LIST_COLUMNS)
+  .filter(column => column !== SORTABLE_SEARCH_RESULT_LIST_COLUMNS.RELEVANCE);
+const NON_INTERACTIVE_HEADERS = ALL_COLUMNS.filter(column => !SORTABLE_COLUMNS.includes(column));
 
 class InstancesList extends React.Component {
   static defaultProps = {
@@ -1036,7 +1039,6 @@ class InstancesList extends React.Component {
     const { intl } = this.props;
 
     const columnMapping = {
-      callNumber: intl.formatMessage({ id: 'ui-inventory.instances.columns.callNumber' }),
       select: !this.state.isSelectedRecordsModalOpened && (
         <Checkbox
           checked={this.getIsAllRowsSelected()}
@@ -1048,11 +1050,6 @@ class InstancesList extends React.Component {
       contributors: intl.formatMessage({ id: 'ui-inventory.instances.columns.contributors' }),
       publishers: intl.formatMessage({ id: 'ui-inventory.instances.columns.publishers' }),
       relation: intl.formatMessage({ id: 'ui-inventory.instances.columns.relation' }),
-      numberOfTitles: intl.formatMessage({ id: 'ui-inventory.instances.columns.numberOfTitles' }),
-      subject: intl.formatMessage({ id: 'ui-inventory.subject' }),
-      contributor: intl.formatMessage({ id: 'ui-inventory.instances.columns.contributor' }),
-      contributorType: intl.formatMessage({ id: 'ui-inventory.instances.columns.contributorType' }),
-      relatorTerm: intl.formatMessage({ id: 'ui-inventory.instances.columns.relatorTerm' }),
     };
 
     return columnMapping;
@@ -1394,20 +1391,14 @@ class InstancesList extends React.Component {
               source: 'FOLIO',
             }}
             visibleColumns={visibleColumns}
-            nonInteractiveHeaders={['select']}
+            nonInteractiveHeaders={NON_INTERACTIVE_HEADERS}
             columnMapping={columnMapping}
             columnWidths={{
-              callNumber: '15%',
-              subject: '50%',
-              contributor: '50%',
               contributors: {
                 max: '400px',
               },
-              numberOfTitles: '15%',
               select: '30px',
               title: '40%',
-              contributorType: '15%',
-              relatorTerm: '15%',
             }}
             getCellClass={this.formatCellStyles}
             customPaneSub={this.renderPaneSub()}
@@ -1435,7 +1426,8 @@ class InstancesList extends React.Component {
             extraParamsToReset={this.extraParamsToReset}
             hasNewButton={false}
             onResetAll={this.handleResetAll}
-            sortableColumns={['title', 'contributors']}
+            showSortIndicator
+            sortableColumns={SORTABLE_COLUMNS}
             syncQueryWithUrl
             resultsVirtualize={false}
             resultsOnMarkPosition={this.onMarkPosition}

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -121,32 +121,34 @@ const getInstancesListTree = ({ segment, ...rest }) => {
     <Harness translations={translationsProperties}>
       <Router history={history}>
         <ModuleHierarchyProvider module="@folio/inventory">
-          <InstancesList
-            isRequestUrlExceededLimit={false}
-            parentResources={resources}
-            parentMutator={{
-              resultOffset: { replace: mockResultOffsetReplace },
-              resultCount: { replace: noop },
-              query: { update: updateMock, replace: mockQueryReplace },
-              records: { reset: mockRecordsReset },
-              itemsByQuery: { reset: noop, GET: mockItemsByQuery },
-              recordsToExportIDs: { reset: noop, GET: mockRecordsToExportIDs },
-            }}
-            data={{
-              ...data,
-              query
-            }}
-            onSelectRow={noop}
-            renderFilters={noop}
-            segment={segment}
-            searchableIndexes={indexes}
-            getLastBrowse={jest.fn()}
-            getLastSearchOffset={mockGetLastSearchOffset}
-            storeLastSearch={mockStoreLastSearch}
-            storeLastSearchOffset={mockStoreLastSearchOffset}
-            storeLastSegment={noop}
-            {...rest}
-          />
+          <div id="ModuleContainer">
+            <InstancesList
+              isRequestUrlExceededLimit={false}
+              parentResources={resources}
+              parentMutator={{
+                resultOffset: { replace: mockResultOffsetReplace },
+                resultCount: { replace: noop },
+                query: { update: updateMock, replace: mockQueryReplace },
+                records: { reset: mockRecordsReset },
+                itemsByQuery: { reset: noop, GET: mockItemsByQuery },
+                recordsToExportIDs: { reset: noop, GET: mockRecordsToExportIDs },
+              }}
+              data={{
+                ...data,
+                query
+              }}
+              onSelectRow={noop}
+              renderFilters={noop}
+              segment={segment}
+              searchableIndexes={indexes}
+              getLastBrowse={jest.fn()}
+              getLastSearchOffset={mockGetLastSearchOffset}
+              storeLastSearch={mockStoreLastSearch}
+              storeLastSearchOffset={mockStoreLastSearchOffset}
+              storeLastSegment={noop}
+              {...rest}
+            />
+          </div>
         </ModuleHierarchyProvider>
       </Router>
     </Harness>
@@ -518,7 +520,7 @@ describe('InstancesList', () => {
         });
 
         describe('when canceling a record', () => {
-          it('should remove the "layer" parameter and focus on the search field', () => {
+          it('should remove the "layer" parameter and focus on the search field', async () => {
             history.push('/inventory?filters=staffSuppress.false&layer=foo');
 
             jest.spyOn(history, 'push');
@@ -527,7 +529,7 @@ describe('InstancesList', () => {
             SearchAndSort.mock.calls[0][0].onCloseNewRecord();
 
             expect(history.push).toHaveBeenCalledWith('/?filters=staffSuppress.false');
-            expect(getByRole('textbox', { name: /search/i })).toHaveFocus();
+            await waitFor(() => expect(getByRole('textbox', { name: /search/i })).toHaveFocus())
           });
         });
       });

--- a/src/routes/InstancesRoute.test.js
+++ b/src/routes/InstancesRoute.test.js
@@ -70,50 +70,52 @@ const InstancesRouteSetup = ({
               storeLastBrowseOffset: jest.fn(),
             }}
             >
-              <Paneset>
-                <Layer
-                  isOpen
-                  contentLabel="label"
-                >
-                  <OverlayContainer />
-                  <InstancesRoute
-                    tenantId="diku"
-                    resources={{
-                      query: {
-                        query: '',
-                        sort: 'title',
-                      },
-                      records: {
-                        hasLoaded: true,
-                        resource: 'records',
-                        records: instances,
-                        other: { totalRecords: instances.length },
-                      },
-                      recordsBrowseCallNumber : {
-                        hasLoaded: true,
-                        resource: 'records',
-                        records: callNumbers,
-                        other: {
-                          totalRecords: callNumbers.length
+              <div id="ModuleContainer">
+                <Paneset>
+                  <Layer
+                    isOpen
+                    contentLabel="label"
+                  >
+                    <OverlayContainer />
+                    <InstancesRoute
+                      tenantId="diku"
+                      resources={{
+                        query: {
+                          query: '',
+                          sort: 'title',
                         },
-                      },
-                      resultCount: instances.length,
-                      resultOffset: 0,
-                    }}
-                    mutator={{
-                      quickExport: { POST: quickExportPOST },
-                      resultCount: { replace: noop },
-                      resultOffset: { replace: noop },
-                      query: {
-                        update: jest.fn(),
-                        replace: jest.fn(),
-                      },
-                      browseModeRecords: { reset: jest.fn() },
-                      records: { reset: jest.fn() },
-                    }}
-                  />
-                </Layer>
-              </Paneset>
+                        records: {
+                          hasLoaded: true,
+                          resource: 'records',
+                          records: instances,
+                          other: { totalRecords: instances.length },
+                        },
+                        recordsBrowseCallNumber : {
+                          hasLoaded: true,
+                          resource: 'records',
+                          records: callNumbers,
+                          other: {
+                            totalRecords: callNumbers.length
+                          },
+                        },
+                        resultCount: instances.length,
+                        resultOffset: 0,
+                      }}
+                      mutator={{
+                        quickExport: { POST: quickExportPOST },
+                        resultCount: { replace: noop },
+                        resultOffset: { replace: noop },
+                        query: {
+                          update: jest.fn(),
+                          replace: jest.fn(),
+                        },
+                        browseModeRecords: { reset: jest.fn() },
+                        records: { reset: jest.fn() },
+                      }}
+                    />
+                  </Layer>
+                </Paneset>
+              </div>
             </LastSearchTermsContext.Provider>
           </DataContext.Provider>
         </ModuleHierarchyProvider>


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Result list - add a sort indicator next to the column names for sortable fields and if the field is not currently sorted.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
- pass the `showSortIndicator` prop to the `SearchAndSort` component;
- point correct `nonInteractiveHeaders`.

Removed unused fields, they are from the time when Search and Browse searches were on the same page.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Related PRs
https://github.com/folio-org/stripes-components/pull/2333
https://github.com/folio-org/stripes-smart-components/pull/1500

## Refs
[UIIN-2986](https://folio-org.atlassian.net/browse/UIIN-2986)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots


https://github.com/user-attachments/assets/a92b05b1-ee16-4b77-8266-53b6893d53be




<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
