### PR TITLE
UIIN-3009: Add inventory permission: Settings (Inventory): Create, edit, delete subject types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Prevent callbacks from being triggered when clicking on the current tab, whether it's lookup mode or a segment. Fixes UIIN-2949.
 * Hide call number type options for Local, Other scheme, and SuDoc for perf environment. Refs UIIN-2923.
 * Edit Inventory Instances: "Save & close" and "Save and keep editing" buttons could be clicked 2 times in a row. Fixes UIIN-2939.
+* Add inventory permission: Settings (Inventory): Create, edit, delete subject types. Refs UIIN-3009.
 
 ## [11.0.4](https://github.com/folio-org/ui-inventory/tree/v11.0.4) (2024-04-30)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.3...v11.0.4)

--- a/package.json
+++ b/package.json
@@ -293,6 +293,19 @@
         "visible": true
       },
       {
+        "permissionName": "ui-inventory.settings.subject-types",
+        "displayName": "Settings (Inventory): Create, edit, delete subject types",
+        "subPermissions": [
+          "inventory-storage.subject-types.collection.get",
+          "inventory-storage.subject-types.item.get",
+          "inventory-storage.subject-types.item.post",
+          "inventory-storage.subject-types.item.put",
+          "inventory-storage.subject-types.item.delete",
+          "settings.inventory.enabled"
+        ],
+        "visible": true
+      },
+      {
         "permissionName": "ui-inventory.settings.instance-statuses",
         "displayName": "Settings (Inventory): Create, edit, delete instance status types",
         "subPermissions": [

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -680,6 +680,7 @@
   "permission.settings.classification-browse": "Settings (Inventory): Configure classification browse",
   "permission.settings.classification-types": "Settings (Inventory): Create, edit, delete classification identifier types",
   "permission.settings.identifier-types": "Settings (Inventory): Create, edit, delete resource identifier types",
+  "permission.settings.subject-types": "Settings (Inventory): Create, edit, delete subject types",
   "permission.settings.instance-statuses": "Settings (Inventory): Create, edit, delete instance status types",
   "permission.settings.statistical-codes": "Settings (Inventory): Create, edit, delete statistical codes",
   "permission.settings.alternative-title-types": "Settings (Inventory): Create, edit, delete alternative title types",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Create a new ‘Settings (Inventory): Create, edit, delete subject types’ permission to control the display and edit of the Inventory Subject types settings.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Add a new permission

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3009

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
