### PR TITLE
UIIN-2889 Trim call numbers when Creating/Editing/Deriving Holdings/Items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Add `showSortIndicator` prop to `SearchAndSort` to display sort indicator next to the column names, and add correct `nonInteractiveHeaders`. Refs UIIN-2986.
 * Change casing of `Linked data editor` label. Refs UIIN-3007.
 * MARC bib/holdings | View Source: Add Edit and Export actions. Refs UIIN-3012.
+* Trim call numbers when Creating/Editing/Deriving Holdings/Items. Fixes UIIN-2889.
 
 ## [11.0.4](https://github.com/folio-org/ui-inventory/tree/v11.0.4) (2024-04-30)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.3...v11.0.4)

--- a/src/edit/holdings/HoldingsForm.js
+++ b/src/edit/holdings/HoldingsForm.js
@@ -566,6 +566,8 @@ class HoldingsForm extends React.Component {
                           component={TextArea}
                           rows={1}
                           fullWidth
+                          format={v => v?.trim()}
+                          formatOnBlur
                           disabled={this.isFieldBlocked('callNumberPrefix')}
                         />
                       </Col>
@@ -577,6 +579,8 @@ class HoldingsForm extends React.Component {
                           component={TextArea}
                           rows={1}
                           fullWidth
+                          format={v => v?.trim()}
+                          formatOnBlur
                           disabled={this.isFieldBlocked('callNumber')}
                         />
                       </Col>
@@ -588,6 +592,8 @@ class HoldingsForm extends React.Component {
                           component={TextArea}
                           rows={1}
                           fullWidth
+                          format={v => v?.trim()}
+                          formatOnBlur
                           disabled={this.isFieldBlocked('callNumberSuffix')}
                         />
                       </Col>

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -596,6 +596,8 @@ class ItemForm extends React.Component {
                           name="itemLevelCallNumberPrefix"
                           id="additem_callnumberprefix"
                           component={TextArea}
+                          format={v => v?.trim()}
+                          formatOnBlur
                           rows={1}
                           fullWidth
                         />
@@ -606,6 +608,8 @@ class ItemForm extends React.Component {
                           name="itemLevelCallNumber"
                           id="additem_callnumber"
                           component={TextArea}
+                          format={v => v?.trim()}
+                          formatOnBlur
                           rows={1}
                           fullWidth
                         />
@@ -616,6 +620,8 @@ class ItemForm extends React.Component {
                           name="itemLevelCallNumberSuffix"
                           id="additem_callnumbersuffix"
                           component={TextArea}
+                          format={v => v?.trim()}
+                          formatOnBlur
                           rows={1}
                           fullWidth
                         />


### PR DESCRIPTION
## Description
Trim call numbers when Creating/Editing/Deriving Holdings/Items.
New/updated Holdings/Items will not have trailing spaces

## Screenshots

https://github.com/user-attachments/assets/45ade92a-aa85-4a01-81d4-42cc8c7d6d79


## Issues
[UIIN-2889](https://folio-org.atlassian.net/browse/UIIN-2889)