### PR TITLE
UIIN-2986: Revert `NON_INTERACTIVE_HEADERS` to be able to navigate through all result list headers using the Tab key, not just the interactive ones (follow-up).

### DIFF
--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -127,7 +127,7 @@ const ALL_COLUMNS = Array.from(new Set([
 const VISIBLE_COLUMNS_STORAGE_KEY = 'inventory-visible-columns';
 const SORTABLE_COLUMNS = Object.values(SORT_OPTIONS)
   .filter(column => column !== SORT_OPTIONS.RELEVANCE);
-const NON_INTERACTIVE_HEADERS = ALL_COLUMNS.filter(column => !SORTABLE_COLUMNS.includes(column));
+const NON_INTERACTIVE_HEADERS = ['select'];
 
 class InstancesList extends React.Component {
   static defaultProps = {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Description
Follow-up PR.

After adding the `showSortIndicator` property and extending the `nonInteractiveHeaders`, the Tab key navigating through the results list headers only works for interactive fields (not in the `nonInteractiveHeaders` list).

Revert `nonInteractiveHeaders` and use `sortableColumns` for MCL to be able to navigate through all result list headers and keep the sort indicator.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Related PRs
https://github.com/folio-org/stripes-smart-components/pull/1513

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-2986](https://folio-org.atlassian.net/browse/UIIN-2986)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots

![image](https://github.com/user-attachments/assets/79a4b199-09e1-4733-a7d9-c0c150ab2811)
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
