### PR TITLE
UIIN-2849 disabled Dates fields when Instance has source MARC (follow-up)

### DIFF
--- a/src/edit/InstanceForm.js
+++ b/src/edit/InstanceForm.js
@@ -754,7 +754,10 @@ class InstanceForm extends React.Component {
                         canEdit={!this.isFieldBlocked('publicationRange')}
                         canDelete={!this.isFieldBlocked('publicationRange')}
                       />
-                      <DateFields instanceDateTypeOptions={instanceDateTypeOptions} />
+                      <DateFields
+                        disabled={this.isFieldBlocked('dates')}
+                        instanceDateTypeOptions={instanceDateTypeOptions}
+                      />
                     </Accordion>
                     <Accordion
                       label={(

--- a/src/edit/dateFields.js
+++ b/src/edit/dateFields.js
@@ -12,7 +12,7 @@ import {
 
 import { DATE_LENGTH } from '../validation';
 
-const DateFields = ({ instanceDateTypeOptions }) => {
+const DateFields = ({ instanceDateTypeOptions, disabled }) => {
   const { formatMessage } = useIntl();
 
   const typeLabel = formatMessage({ id: 'ui-inventory.dateType' });
@@ -27,6 +27,7 @@ const DateFields = ({ instanceDateTypeOptions }) => {
           name="dates.dateTypeId"
           component={Select}
           dataOptions={instanceDateTypeOptions}
+          disabled={disabled}
         />
       </Col>
       <Col sm={3}>
@@ -36,6 +37,7 @@ const DateFields = ({ instanceDateTypeOptions }) => {
           name="dates.date1"
           component={TextField}
           maxLength={DATE_LENGTH}
+          disabled={disabled}
         />
       </Col>
       <Col sm={3}>
@@ -45,6 +47,7 @@ const DateFields = ({ instanceDateTypeOptions }) => {
           name="dates.date2"
           component={TextField}
           maxLength={DATE_LENGTH}
+          disabled={disabled}
         />
       </Col>
     </Row>
@@ -57,6 +60,7 @@ DateFields.propTypes = {
     name: PropTypes.string.isRequired,
     selected: PropTypes.bool,
   })).isRequired,
+  disabled: PropTypes.bool,
 };
 
 export default DateFields;


### PR DESCRIPTION
## Description
disabled Dates fields when Instance has source MARC

## Screenshots

https://github.com/user-attachments/assets/10e75f71-cab1-436c-a4f0-2f2b51cffedc


## Issues
[UIIN-2849](https://folio-org.atlassian.net/browse/UIIN-2849)