### PR TITLE
UIIN-2823: View -- Subject accordion instance UI changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Instance Detail/Edit/New: Add new section for Date type, Date 1, & Date 2. Refs UIIN-2849.
 * Add the ability to update ownership of holdings. Refs UIIN-2753.
 * Add the ability to update ownership of items. Refs UIIN-2754.
+* View -- Subject accordion instance UI changes. Refs UIIN-2823.
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/src/Instance/InstanceDetails/InstanceDetails.js
+++ b/src/Instance/InstanceDetails/InstanceDetails.js
@@ -277,6 +277,8 @@ const InstanceDetails = forwardRef(({
             <InstanceSubjectView
               id={accordions.subjects}
               subjects={instance.subjects}
+              subjectSources={referenceData.subjectSources}
+              subjectTypes={referenceData.subjectTypes}
               source={instance.source}
               segment={searchParams.get('segment')}
             />

--- a/src/Instance/InstanceDetails/InstanceSubjectView/InstanceSubjectView.js
+++ b/src/Instance/InstanceDetails/InstanceSubjectView/InstanceSubjectView.js
@@ -7,19 +7,24 @@ import { useIntl } from 'react-intl';
 import {
   Accordion,
   MultiColumnList,
+  NoValue,
 } from '@folio/stripes/components';
 import { segments } from '@folio/stripes-inventory-components';
 
 import { ControllableDetail } from '../ControllableDetail';
 
-const visibleColumns = ['subject'];
+const visibleColumns = ['subject', 'subjectSource', 'subjectType'];
 const getColumnMapping = intl => ({
   subject: intl.formatMessage({ id: 'ui-inventory.subjectHeadings' }),
+  subjectSource: intl.formatMessage({ id: 'ui-inventory.subjectSource' }),
+  subjectType: intl.formatMessage({ id: 'ui-inventory.subjectType' }),
 });
 
 const InstanceSubjectView = ({
   id,
-  subjects,
+  subjects = [],
+  subjectSources = [],
+  subjectTypes = [],
   segment,
   source,
 }) => {
@@ -36,6 +41,8 @@ const InstanceSubjectView = ({
         source={source}
       />
     ),
+    subjectSource: item => subjectSources.find(src => src.id === item.sourceId)?.name || <NoValue />,
+    subjectType: item => subjectTypes.find(type => type.id === item.typeId)?.name || <NoValue />,
   };
 
   return (
@@ -58,13 +65,11 @@ const InstanceSubjectView = ({
 
 InstanceSubjectView.propTypes = {
   id: PropTypes.string.isRequired,
-  subjects: PropTypes.arrayOf(PropTypes.string),
   segment: PropTypes.oneOf(Object.values(segments)).isRequired,
   source: PropTypes.string.isRequired,
-};
-
-InstanceSubjectView.defaultProps = {
-  subjects: [],
+  subjects: PropTypes.arrayOf(PropTypes.object),
+  subjectSources: PropTypes.arrayOf(PropTypes.object),
+  subjectTypes: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default InstanceSubjectView;

--- a/src/Instance/InstanceDetails/InstanceSubjectView/InstanceSubjectView.test.js
+++ b/src/Instance/InstanceDetails/InstanceSubjectView/InstanceSubjectView.test.js
@@ -1,23 +1,50 @@
-import React from 'react';
+import { Router } from 'react-router';
+import { createMemoryHistory } from 'history';
+
+import {
+  screen,
+  act,
+} from '@folio/jest-config-stripes/testing-library/react';
+import { runAxeTest } from '@folio/stripes-testing';
+import { segments } from '@folio/stripes-inventory-components';
 
 import '../../../../test/jest/__mock__';
 
-import { Router } from 'react-router';
-import { createMemoryHistory } from 'history';
-import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
-import { segments } from '@folio/stripes-inventory-components';
-
 import { DataContext } from '../../../contexts';
-
-import { renderWithIntl, translationsProperties } from '../../../../test/jest/helpers';
-
 import InstanceSubjectView from './InstanceSubjectView';
+
+import {
+  renderWithIntl,
+  translationsProperties,
+} from '../../../../test/jest/helpers';
 
 const history = createMemoryHistory();
 
 const defaultProps = {
   id: 'subject-accordion',
-  subjects: ['Subject 1'],
+  subjects: [{
+    value: 'subject 1',
+    sourceId: 'source1',
+    typeId: 'type1',
+  }, {
+    value: 'subject 2',
+    sourceId: 'source2',
+    typeId: 'type2',
+  }],
+  subjectSources: [{
+    id: 'source1',
+    name: 'source 1',
+  }, {
+    id: 'source2',
+    name: 'source 2',
+  }],
+  subjectTypes: [{
+    id: 'type1',
+    name: 'type 1',
+  }, {
+    id: 'type2',
+    name: 'type 2',
+  }],
 };
 
 const renderInstanceSubjectView = (props) => renderWithIntl(
@@ -30,16 +57,38 @@ const renderInstanceSubjectView = (props) => renderWithIntl(
       />
     </DataContext.Provider>
   </Router>,
-  translationsProperties
+  translationsProperties,
 );
 
 describe('InstanceSubjectView', () => {
-  it('renders InstanceSubjectView component', () => {
-    const { getByText, getByRole } = renderInstanceSubjectView({ ...defaultProps });
-    const subjectButton = getByRole('button', { name: /Subject/i });
-    userEvent.click(subjectButton);
-    expect(getByText(/Subject headings/i)).toBeInTheDocument();
-    expect(getByText(/No value set/i)).toBeInTheDocument();
-    expect(getByText(/End of list/i)).toBeInTheDocument();
+  it('should be rendered with no axe errors', async () => {
+    const { container } = await act(async () => renderInstanceSubjectView({ ...defaultProps }));
+
+    await runAxeTest({ rootNode: container });
+  });
+
+  it('should render Subject accordion', () => {
+    renderInstanceSubjectView({ ...defaultProps });
+
+    expect(screen.getByText('Subject')).toBeInTheDocument();
+  });
+
+  it('should render correct table columns', () => {
+    renderInstanceSubjectView({ ...defaultProps });
+
+    expect(screen.getByText('Subject headings')).toBeInTheDocument();
+    expect(screen.getByText('Subject source')).toBeInTheDocument();
+    expect(screen.getByText('Subject type')).toBeInTheDocument();
+  });
+
+  it('should render correct table content', () => {
+    renderInstanceSubjectView({ ...defaultProps });
+
+    expect(screen.getByText('subject 1')).toBeInTheDocument();
+    expect(screen.getByText('source 1')).toBeInTheDocument();
+    expect(screen.getByText('type 1')).toBeInTheDocument();
+    expect(screen.getByText('subject 2')).toBeInTheDocument();
+    expect(screen.getByText('source 2')).toBeInTheDocument();
+    expect(screen.getByText('type 2')).toBeInTheDocument();
   });
 });

--- a/src/Instance/InstanceEdit/ChildInstanceFields/ChildInstanceFields.test.js
+++ b/src/Instance/InstanceEdit/ChildInstanceFields/ChildInstanceFields.test.js
@@ -1,9 +1,13 @@
 import React from 'react';
 import { noop, keyBy } from 'lodash';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { Button } from '@folio/stripes-testing';
 
 import '../../../../test/jest/__mock__';
+
+import {
+  fireEvent,
+  screen,
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import { StripesContext } from '@folio/stripes/core';
 import stripesFinalForm from '@folio/stripes/final-form';
@@ -66,21 +70,17 @@ describe('ChildInstanceFields', () => {
   });
 
   describe('change child instance', () => {
-    beforeEach(async () => {
-      await Button('+').click();
-    });
-
     it('should change instance', () => {
+      fireEvent.click(screen.getByRole('button', { name: '+' }));
+
       expect(document.querySelectorAll('[data-test="instance-title-0"] .kvValue')[0].innerHTML).toEqual('new instance');
     });
   });
 
   describe('add child instance', () => {
-    beforeEach(async () => {
-      await Button('Add child instance').click();
-    });
+    it('should add child instance', async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Add child instance' }));
 
-    it('should add child instance', () => {
       expect(document.querySelectorAll('#clickable-add-child-instance li').length).toEqual(2);
     });
   });

--- a/src/Instance/InstanceEdit/ParentInstanceFields/ParentInstanceFields.test.js
+++ b/src/Instance/InstanceEdit/ParentInstanceFields/ParentInstanceFields.test.js
@@ -1,9 +1,13 @@
 import React from 'react';
 import { noop, keyBy } from 'lodash';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { Button } from '@folio/stripes-testing';
 
 import '../../../../test/jest/__mock__';
+
+import {
+  fireEvent,
+  screen,
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import { StripesContext } from '@folio/stripes/core';
 import stripesFinalForm from '@folio/stripes/final-form';
@@ -66,21 +70,17 @@ describe('ParentInstanceFields', () => {
   });
 
   describe('change parent instance', () => {
-    beforeEach(async () => {
-      await Button('+').click();
-    });
-
     it('should change instance', () => {
+      fireEvent.click(screen.getByRole('button', { name: '+' }));
+
       expect(document.querySelectorAll('[data-test="instance-title-0"] .kvValue')[0].innerHTML).toEqual('new instance');
     });
   });
 
   describe('add parent instance', () => {
-    beforeEach(async () => {
-      await Button('Add parent instance').click();
-    });
-
     it('should add parent instance', () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Add parent instance' }));
+
       expect(document.querySelectorAll('#clickable-add-parent-instance li').length).toEqual(2);
     });
   });

--- a/src/components/UpdateItemOwnershipModal/UpdateItemOwnershipModal.test.js
+++ b/src/components/UpdateItemOwnershipModal/UpdateItemOwnershipModal.test.js
@@ -59,6 +59,7 @@ describe('UpdateItemOwnershipModal', () => {
     it('should call the function to change the affiliation', () => {
       renderUpdateItemOwnershipModal();
 
+      fireEvent.click(screen.getByText('Select control'));
       fireEvent.click(screen.getByText('University'));
 
       expect(onChangeAffiliationMock).toHaveBeenCalledWith(defaultProps.tenantsList[0]);
@@ -69,6 +70,7 @@ describe('UpdateItemOwnershipModal', () => {
     it('should enable "Update" button', () => {
       renderUpdateItemOwnershipModal();
 
+      fireEvent.click(screen.getByText('Select control'));
       fireEvent.click(screen.getByText('University'));
 
       FieldHolding.mock.calls[0][0].onChange({ id: 'locationId' });

--- a/src/edit/subjectFields.js
+++ b/src/edit/subjectFields.js
@@ -16,6 +16,8 @@ import {
   TextField,
 } from '@folio/stripes/components';
 
+const SOURCE_SPECIFIED_IN_SUBFIELD_$2 = 'Source specified in subfield $2';
+
 const SubjectFields = ({
   subjectSources,
   subjectTypes,
@@ -25,10 +27,12 @@ const SubjectFields = ({
 }) => {
   const { formatMessage } = useIntl();
 
-  const subjectSourcesOptions = subjectSources.map(it => ({
-    label: it.name,
-    value: it.id,
-  }));
+  const subjectSourcesOptions = subjectSources
+    .filter(it => it.name !== SOURCE_SPECIFIED_IN_SUBFIELD_$2)
+    .map(it => ({
+      label: it.name,
+      value: it.id,
+    }));
   const subjectTypesOptions = subjectTypes.map(it => ({
     label: it.name,
     value: it.id,
@@ -71,7 +75,7 @@ const SubjectFields = ({
         </Col>
         <Col sm={4}>
           <Field
-            name={`${field}.subjectSourceId`}
+            name={`${field}.sourceId`}
             component={Select}
             dataOptions={subjectSourcesOptions}
             placeholder={formatMessage({ id: 'ui-inventory.subjectSource.placeholder' })}
@@ -80,7 +84,7 @@ const SubjectFields = ({
         </Col>
         <Col sm={4}>
           <Field
-            name={`${field}.subjectTypeId`}
+            name={`${field}.typeId`}
             component={Select}
             dataOptions={subjectTypesOptions}
             placeholder={formatMessage({ id: 'ui-inventory.subjectType.placeholder' })}

--- a/src/settings/TargetProfileForm.test.js
+++ b/src/settings/TargetProfileForm.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import {
   fireEvent,
+  screen,
   waitFor,
 } from '@folio/jest-config-stripes/testing-library/react';
 
@@ -83,7 +84,6 @@ describe('TargetProfileForm', () => {
       const {
         container,
         getByText,
-        getAllByText,
         getByLabelText,
       } = renderTargetProfileForm();
       const nameInput = container.querySelector('#input-targetprofile-name');
@@ -91,14 +91,14 @@ describe('TargetProfileForm', () => {
 
       const addJobCreateButton = getByText('Add job profile for import/create');
       fireEvent.click(addJobCreateButton);
-      fireEvent.click(getByLabelText('Select job profile for import/create'));
-      fireEvent.click(getAllByText('Job profile for create (job profile id for create)')[0]);
+      fireEvent.click(screen.getAllByText('Select control')[0]);
+      fireEvent.click(getByText('Job profile for create (job profile id for create)'));
       fireEvent.click(getByLabelText('Set 0 job profile for create as default'));
 
       const addJobUpdateButton = getByText('Add job profile for overlay/update');
       fireEvent.click(addJobUpdateButton);
-      fireEvent.click(getByLabelText('Select job profile for overlay/update'));
-      fireEvent.click(getAllByText('Job profile for update (job profile id for update)')[1]);
+      fireEvent.click(screen.getAllByText('Select control')[1]);
+      fireEvent.click(getByText('Job profile for update (job profile id for update)'));
       fireEvent.click(getByLabelText('Set 0 job profile for update as default'));
 
       const submit = getByText('Save & close');


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
To updating the Instance View to display new subject fields.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Add Subject source/type to instance view screen
- Update field names for create/edit screen
- Omit the 'Source specified in subfield $2' value for the subject source dropdown

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-2823

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
