### PR TITLE
UIIN-3034 Implement default Date type when not present - No attempt to code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Add the ability to update ownership of holdings. Refs UIIN-2753.
 * Add the ability to update ownership of items. Refs UIIN-2754.
 * Update user when switching affiliation. Fixes UIIN-2932.
+* Implement default Date type when not present - No attempt to code. Refs UIIN-3034.
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/src/Instance/InstanceEdit/InstanceEdit.js
+++ b/src/Instance/InstanceEdit/InstanceEdit.js
@@ -43,7 +43,11 @@ const InstanceEdit = ({
   stripes,
 }) => {
   const { formatMessage } = useIntl();
-  const { identifierTypesById, identifierTypesByName } = referenceData ?? {};
+  const {
+    identifierTypesById,
+    identifierTypesByName,
+    instanceDateTypesByCode,
+  } = referenceData ?? {};
   const [httpError, setHttpError] = useState();
   const [initialValues, setInitialValues] = useState();
   const callout = useCallout();
@@ -118,7 +122,7 @@ const InstanceEdit = ({
   });
 
   const onSubmit = useCallback(async (initialInstance) => {
-    const updatedInstance = marshalInstance(initialInstance, identifierTypesByName);
+    const updatedInstance = marshalInstance(initialInstance, identifierTypesByName, instanceDateTypesByCode);
 
     return mutateInstance(updatedInstance).catch(onError);
   }, [mutateInstance]);

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -471,10 +471,10 @@ class InstancesList extends React.Component {
   };
 
   createInstance = (instanceData) => {
-    const { data: { identifierTypesByName } } = this.props;
+    const { data: { identifierTypesByName, instanceDateTypesByCode } } = this.props;
 
     // Massage record to add preceeding and succeeding title fields
-    const instance = marshalInstance(instanceData, identifierTypesByName);
+    const instance = marshalInstance(instanceData, identifierTypesByName, instanceDateTypesByCode);
 
     // POST item record
     return this.props.parentMutator.records.POST(instance);

--- a/src/edit/InstanceForm.js
+++ b/src/edit/InstanceForm.js
@@ -351,16 +351,13 @@ class InstanceForm extends React.Component {
       }),
     ) : [];
 
-    const instanceDateTypeOptions = [{
-      label: <FormattedMessage id="ui-inventory.selectInstanceDateType" />,
-      value: '',
-    }, ...referenceTables.instanceDateTypes ? referenceTables.instanceDateTypes.map(
+    const instanceDateTypeOptions = referenceTables.instanceDateTypes ? referenceTables.instanceDateTypes.map(
       it => ({
         label: it.name,
         value: it.id,
         selected: it.id === initialValues.instanceDate?.instanceDateTypeId,
       }),
-    ) : []];
+    ) : [];
 
     const instanceNoteTypeOptions = referenceTables.instanceNoteTypes ? referenceTables.instanceNoteTypes.map(
       it => ({
@@ -754,7 +751,10 @@ class InstanceForm extends React.Component {
                         canEdit={!this.isFieldBlocked('publicationRange')}
                         canDelete={!this.isFieldBlocked('publicationRange')}
                       />
-                      <DateFields instanceDateTypeOptions={instanceDateTypeOptions} />
+                      <DateFields
+                        instanceDateTypeOptions={instanceDateTypeOptions}
+                        initialDateTypeId={initialValues.dates?.dateTypeId}
+                      />
                     </Accordion>
                     <Accordion
                       label={(

--- a/src/edit/dateFields.js
+++ b/src/edit/dateFields.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'react-final-form';
 import { useIntl } from 'react-intl';
@@ -12,12 +12,24 @@ import {
 
 import { DATE_LENGTH } from '../validation';
 
-const DateFields = ({ instanceDateTypeOptions }) => {
+const DateFields = ({ instanceDateTypeOptions, initialDateTypeId }) => {
   const { formatMessage } = useIntl();
 
   const typeLabel = formatMessage({ id: 'ui-inventory.dateType' });
   const date1Label = formatMessage({ id: 'ui-inventory.date1' });
   const date2Label = formatMessage({ id: 'ui-inventory.date2' });
+
+  // if there is no initial date type value - means it's not been saved so a user can unselect it
+  // once a value is saved - user cannot unselect it, but they can still select "No attempt to code"
+  const canUnselectDateType = !initialDateTypeId;
+  const dataOptions = useMemo(() => {
+    return canUnselectDateType
+      ? [{
+        label: formatMessage({ id: 'ui-inventory.selectInstanceDateType' }),
+        value: '',
+      }, ...instanceDateTypeOptions]
+      : instanceDateTypeOptions;
+  }, [initialDateTypeId]);
 
   return (
     <Row>
@@ -26,7 +38,8 @@ const DateFields = ({ instanceDateTypeOptions }) => {
           label={typeLabel}
           name="dates.dateTypeId"
           component={Select}
-          dataOptions={instanceDateTypeOptions}
+          dataOptions={dataOptions}
+          placeholder={canUnselectDateType ? null : formatMessage({ id: 'ui-inventory.selectInstanceDateType' })}
         />
       </Col>
       <Col sm={3}>

--- a/src/edit/dateFields.test.js
+++ b/src/edit/dateFields.test.js
@@ -1,0 +1,66 @@
+import PropTypes from 'prop-types';
+
+import {
+  screen,
+  fireEvent,
+} from '@folio/jest-config-stripes/testing-library/react';
+import stripesFinalForm from '@folio/stripes/final-form';
+
+import renderWithRouter from '../../test/jest/helpers/renderWithRouter';
+import renderWithIntl from '../../test/jest/helpers/renderWithIntl';
+
+import DateFields from './dateFields';
+import translationsProperties from '../../test/jest/helpers/translationsProperties';
+
+jest.unmock('@folio/stripes/components');
+
+const onSubmit = jest.fn();
+
+const instanceDateTypeOptions = [{
+  label: 'type 1',
+  value: 'type-1',
+}];
+
+const Form = ({ handleSubmit, ...props }) => (
+  <form onSubmit={handleSubmit}>
+    <DateFields
+      instanceDateTypeOptions={instanceDateTypeOptions}
+      {...props}
+    />
+  </form>
+);
+
+Form.propTypes = {
+  handleSubmit: PropTypes.func.isRequired,
+};
+
+const WrappedForm = stripesFinalForm({
+  canAdd: true,
+  canEdit: true,
+  canDelete: true,
+})(Form);
+
+const renderDateFields = (props = {}) => renderWithIntl(
+  renderWithRouter(<WrappedForm onSubmit={onSubmit} {...props} />),
+  translationsProperties,
+);
+
+describe('DateFields', () => {
+  describe('when initial date type is not present', () => {
+    it('should add an option to unselect date type', () => {
+      renderDateFields();
+
+      expect(screen.getByRole('option', { name: 'Select date type' })).toBeInTheDocument();
+    });
+  });
+
+  describe('when initial date type is present', () => {
+    it('should disable the option to unselect date type', () => {
+      renderDateFields({
+        initialDateTypeId: 'type-2',
+      });
+
+      expect(screen.getByRole('option', { name: 'Select date type' })).toBeDisabled();
+    });
+  });
+});

--- a/src/edit/dateFields.test.js
+++ b/src/edit/dateFields.test.js
@@ -1,9 +1,6 @@
 import PropTypes from 'prop-types';
 
-import {
-  screen,
-  fireEvent,
-} from '@folio/jest-config-stripes/testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 import stripesFinalForm from '@folio/stripes/final-form';
 
 import renderWithRouter from '../../test/jest/helpers/renderWithRouter';

--- a/src/providers/DataProvider.js
+++ b/src/providers/DataProvider.js
@@ -47,11 +47,13 @@ const DataProvider = ({
     const {
       identifierTypes,
       instanceRelationshipTypes,
+      instanceDateTypes,
     } = loadedData;
 
     loadedData.locationsById = keyBy(loadedData.locations, 'id');
     loadedData.identifierTypesById = keyBy(identifierTypes, 'id');
     loadedData.identifierTypesByName = keyBy(identifierTypes, 'name');
+    loadedData.instanceDateTypesByCode = keyBy(instanceDateTypes, 'code');
     loadedData.holdingsSourcesByName = keyBy(commonData.holdingsSources, 'name');
     loadedData.instanceRelationshipTypesById = keyBy(instanceRelationshipTypes, 'id');
     loadedData.classificationBrowseConfig = classificationBrowseConfig;

--- a/src/providers/DataProvider.test.js
+++ b/src/providers/DataProvider.test.js
@@ -32,7 +32,7 @@ const commonData = {
   instanceFormats: [{ id: 'id-1', code: 'sb' }],
   holdingsSources: [{ id: 'id-1', name: 'FOLIO' }],
   instanceTypes: [{ id: 'id-1', code: 'crd' }],
-  instanceDateTypes: [{ id: 'id-1', name: 'date type' }],
+  instanceDateTypes: [{ id: 'id-1', code: 'dt', name: 'date type' }],
 };
 
 useCommonData.mockReturnValue({
@@ -95,6 +95,13 @@ describe('DataProvider', () => {
         'IdentifierType 1': {
           id: 'identifierTypes-1',
           name: 'IdentifierType 1',
+        },
+      },
+      instanceDateTypesByCode: {
+        'dt': {
+          id: 'id-1',
+          name: 'date type',
+          code: 'dt',
         },
       },
       instanceRelationshipTypesById: {

--- a/src/utils.js
+++ b/src/utils.js
@@ -579,9 +579,10 @@ export const marshalRelationship = (instance, relationshipName, relationshipIdKe
  *
  * @param instance instance object
  * @param identifierTypesByName object
+ * @param instanceDateTypesByCode object
  *
  */
-export const marshalInstance = (instance, identifierTypesByName) => {
+export const marshalInstance = (instance, identifierTypesByName, instanceDateTypesByCode) => {
   const marshaledInstance = { ...instance };
 
   marshalTitles(marshaledInstance, identifierTypesByName, 'preceding');
@@ -589,6 +590,14 @@ export const marshalInstance = (instance, identifierTypesByName) => {
 
   marshalRelationship(marshaledInstance, 'parentInstances', 'superInstanceId');
   marshalRelationship(marshaledInstance, 'childInstances', 'subInstanceId');
+
+  const { dates } = instance;
+  if (dates && (dates.date1 || dates.date2) && !dates.dateTypeId) {
+    marshaledInstance.dates = {
+      ...dates,
+      dateTypeId: instanceDateTypesByCode['|']?.id
+    };
+  }
 
   return marshaledInstance;
 };

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -20,6 +20,7 @@ import {
   batchQueryIntoSmaller,
   checkIfCentralOrderingIsActive,
   omitCurrentAndCentralTenants,
+  marshalInstance,
 } from './utils';
 import {
   CONTENT_TYPE_HEADER,
@@ -413,5 +414,34 @@ describe('omitCurrentAndCentralTenants', () => {
 
   it('should omit current and central tenants', () => {
     expect(omitCurrentAndCentralTenants(stripes)).toEqual([{ id: 'university' }]);
+  });
+});
+
+describe('marshalInstance', () => {
+  describe('when dates are present and date type is missing', () => {
+    it('should add a default date type', () => {
+      const instance = {
+        title: 'test',
+        dates: {
+          date1: '1234',
+          date2: '1235',
+        },
+      };
+
+      const instanceDateTypesByCode = {
+        '|': {
+          id: 'date-type-id',
+        },
+      };
+
+      expect(marshalInstance(instance, {}, instanceDateTypesByCode)).toEqual(expect.objectContaining({
+        ...instance,
+        dates: {
+          date1: '1234',
+          date2: '1235',
+          dateTypeId: 'date-type-id',
+        },
+      }));
+    });
   });
 });


### PR DESCRIPTION
## Description
When a user creates an Instance they can save dates without date type, but it should be saved as "No attempt to code"
If no dates are saved then date type should also be empty
When editing a record - date type cannot be unselected

## Screenshots

https://github.com/user-attachments/assets/1c7fe1c5-58f8-4bae-9db7-1b93e461c22e


## Issues
[UIIN-3034](https://folio-org.atlassian.net/browse/UIIN-3034)