### PR TITLE
UIIN-2994: Store item IDs in local storage in order to make it visited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Add the ability to update ownership of holdings. Refs UIIN-2753.
 * Add the ability to update ownership of items. Refs UIIN-2754.
 * Update user when switching affiliation. Fixes UIIN-2932.
+* Store item IDs in local storage in order to make it visited. Fixes UIIN-2994.
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/src/Instance/ItemsList/ItemBarcode.js
+++ b/src/Instance/ItemsList/ItemBarcode.js
@@ -21,6 +21,7 @@ import {
 } from '@folio/stripes/components';
 import css from '../../View.css';
 import { QUERY_INDEXES } from '../../constants';
+import { useLocalStorageItems } from '../../hooks';
 import {
   switchAffiliation,
   sendCalloutOnAffiliationChange,
@@ -37,6 +38,10 @@ const ItemBarcode = ({
   const history = useHistory();
   const stripes = useStripes();
   const callout = useContext(CalloutContext);
+  const {
+    addItem,
+    getItem,
+  } = useLocalStorageItems(holdingId);
   const { search } = location;
   const queryBarcode = queryString.parse(search)?.query;
   const isQueryByBarcode = queryString.parse(search)?.qindex === QUERY_INDEXES.BARCODE;
@@ -82,8 +87,10 @@ const ItemBarcode = ({
           to={`/inventory/view/${instanceId}/${holdingId}/${item.id}`}
           onClick={async (e) => {
             e.preventDefault();
+            addItem(item.id);
             await switchAffiliation(stripes, tenantId, onViewItem);
           }}
+          className={getItem(item.id) && css.visited}
         >
           {itemBarcode}
         </TextLink>

--- a/src/View.css
+++ b/src/View.css
@@ -32,3 +32,7 @@
   background: transparent;
   box-shadow: none;
 }
+
+.visited {
+  color: #800080;
+}

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -13,5 +13,6 @@ export { default as useSearchForShadowInstanceTenants } from './useSearchForShad
 export { default as useClassificationIdentifierTypes } from './useClassificationIdentifierTypes';
 export { default as useClassificationBrowseConfig } from './useClassificationBrowseConfig';
 export { default as useUpdateOwnership } from './useUpdateOwnership';
+export { default as useLocalStorageItems } from './useLocalStorageItems';
 export * from './useQuickExport';
 export * from '@folio/stripes-inventory-components/lib/queries/useInstanceDateTypes';

--- a/src/hooks/useLocalStorageItems/index.js
+++ b/src/hooks/useLocalStorageItems/index.js
@@ -1,0 +1,1 @@
+export { default } from './useLocalStorageItems';

--- a/src/hooks/useLocalStorageItems/useLocalStorageItems.js
+++ b/src/hooks/useLocalStorageItems/useLocalStorageItems.js
@@ -1,0 +1,37 @@
+import {
+  useRef,
+  useEffect,
+} from 'react';
+
+import { useNamespace } from '@folio/stripes/core';
+
+const useLocalStorageItems = holdingId => {
+  const [namespace] = useNamespace();
+  const storageKey = `${namespace}/items`;
+
+  const itemsDataRef = useRef({});
+
+  useEffect(() => {
+    const storedItems = localStorage.getItem(storageKey);
+    itemsDataRef.current = storedItems ? JSON.parse(storedItems) : {};
+  }, []);
+
+  const addItem = itemId => {
+    const holdingItems = itemsDataRef.current[holdingId] || [];
+
+    if (!holdingItems.includes(itemId)) {
+      const updatedHoldingItems = [...holdingItems, itemId];
+      const updatedItems = { ...itemsDataRef.current, [holdingId]: updatedHoldingItems };
+      localStorage.setItem(storageKey, JSON.stringify(updatedItems));
+      itemsDataRef.current = updatedItems;
+    }
+  };
+
+  const getItem = (itemId) => {
+    return itemsDataRef.current[holdingId]?.find(item => item === itemId);
+  };
+
+  return { addItem, getItem };
+};
+
+export default useLocalStorageItems;

--- a/src/hooks/useLocalStorageItems/useLocalStorageItems.test.js
+++ b/src/hooks/useLocalStorageItems/useLocalStorageItems.test.js
@@ -1,0 +1,63 @@
+import { act } from 'react';
+import { renderHook } from '@folio/jest-config-stripes/testing-library/react';
+
+import useLocalStorageItems from './useLocalStorageItems';
+
+const holdingId = 'holding1';
+
+describe('useLocalStorageItems hook', () => {
+  beforeEach(() => {
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      return JSON.stringify({ 'holding1': ['item1'] });
+    });
+
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should retrieve existing item from localStorage', () => {
+    const { result } = renderHook(() => useLocalStorageItems(holdingId));
+
+    const item = result.current.getItem('item1');
+    expect(item).toBe('item1');
+  });
+
+  it('should return undefined for a non-existent item', () => {
+    const { result } = renderHook(() => useLocalStorageItems(holdingId));
+
+    const item = result.current.getItem('item2');
+    expect(item).toBeUndefined();
+  });
+
+  it('should add a new item and update localStorage', () => {
+    const { result } = renderHook(() => useLocalStorageItems(holdingId));
+
+    act(() => {
+      result.current.addItem('item2');
+    });
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      '@folio/inventory/items',
+      JSON.stringify({ 'holding1': ['item1', 'item2'] })
+    );
+
+    const newItem = result.current.getItem('item2');
+    expect(newItem).toBe('item2');
+  });
+
+  it('should not add duplicate items', () => {
+    const { result } = renderHook(() => useLocalStorageItems(holdingId));
+
+    act(() => {
+      result.current.addItem('item1');
+    });
+
+    expect(localStorage.setItem).not.toHaveBeenCalledWith(
+      '@folio/inventory/items',
+      JSON.stringify({ 'holding1': ['item1'] })
+    );
+  });
+});


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
 * Since Poppy, the color of the linked item barcodes in the accordion under the holdings isn't changing once been clicked and viewed. This makes it hard to tell where the user has checked in a long list of items.
 * It is necessary to use `<TextLink />` in order to have default options when click right mouse button (**Open link in new tab** etc).
 * At the same time we need to switch affiliation when click on `<TextLink />` component. It's available only with `e.preventDefault()`.
 * `e.preventDefault()` doesn't mark the link as visited.
 * As the **TEMPORARY** solution it was decided to store items' ID in local storage.
 * When we get rid of switching the affiliation ([UXPROD-4715](https://folio-org.atlassian.net/browse/UXPROD-4715)) we won't need to store IDs in local storage and `e.preventDefault()` will be removed.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Store ID of the item in the local storage.
* Add className `visited` when the item was visited by user.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-2994](https://folio-org.atlassian.net/browse/UIIN-2994)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/user-attachments/assets/229447f2-fffe-4485-9fdd-fdf0dd697006



