### PR TITLE
UIIN-2958: Make `Barcode` field wrapping to next row when there are many characters in the value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Extend permissions for creating, editing and deleting reference data. Fixes UIIN-2586.
 * Update "Barcode" column link in "Bound pieces data" accordion. Refs UIIN-3041.
 * ECS - check for central tenant permissions in Settings > Classification Browse. Fixes UIIN-3038.
+* Make "Barcode" field wrapping to next row when there are many characters in the value. Fixes UIIN-2958.
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/src/Instance/ItemsList/ItemsList.js
+++ b/src/Instance/ItemsList/ItemsList.js
@@ -149,6 +149,7 @@ const visibleColumns = [
   'yearCaption',
   'materialType',
 ];
+const columnWidths = { barcode: '160px' };
 const dragVisibleColumns = ['dnd', 'select', ...visibleColumns];
 const rowMetadata = ['id', 'holdingsRecordId'];
 
@@ -243,6 +244,7 @@ const ItemsList = ({
       ariaLabel={ariaLabel}
       interactive={false}
       onNeedMoreData={onNeedMoreData}
+      columnWidths={columnWidths}
       pagingType={MCLPagingTypes.PREV_NEXT}
       totalCount={total}
       nonInteractiveHeaders={['loanType', 'effectiveLocation', 'materialType']}


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
 * When user have big barcode value (e.g. 40 characters) it represents as one big and long row. After the collapsing and expanding holdings accordion the barcode link become trimmed and not showing the “Copy” button. Make the Barcode with many characters (e.g. 40) be wrapped into the next row.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Set default width for `Barcode` column.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-2958](https://folio-org.atlassian.net/browse/UIIN-2958)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
### Before
![image](https://github.com/user-attachments/assets/b8b41bd9-b12e-4722-a252-672e3b7396cc)

### After
![image](https://github.com/user-attachments/assets/2ca4d9b1-6b08-4fe0-9945-88beb6a9bf54)


