### PR TITLE
UIIN-3044: Display an item that has an open loan whose patron record has been removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Update "Barcode" column link in "Bound pieces data" accordion. Refs UIIN-3041.
 * ECS - check for central tenant permissions in Settings > Classification Browse. Fixes UIIN-3038.
 * Display action menu when user has only permission to move holdings/items. Fixes UIIN-3040.
+* Display an item that has an open loan whose patron record has been removed. Fixes UIIN-3044.
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -749,7 +749,7 @@ const ItemView = props => {
 
   let borrowerLink = <NoValue />;
 
-  if (openLoan) {
+  if (openLoan && openLoan.borrower) {
     borrowerLink = <Link to={`/users/view/${openLoan.userId}`}>{openLoan.borrower.barcode}</Link>;
   }
 

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -749,7 +749,7 @@ const ItemView = props => {
 
   let borrowerLink = <NoValue />;
 
-  if (openLoan && openLoan.borrower) {
+  if (openLoan?.borrower) {
     borrowerLink = <Link to={`/users/view/${openLoan.userId}`}>{openLoan.borrower.barcode}</Link>;
   }
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
* `.src/views/ItemView.js` has a potential NPE on line **753** if the patron record corresponding to the loan has been removed. 

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Check if `borrower` field exists. If not - leave borrower link as a `<NoValue />`.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-3044](https://folio-org.atlassian.net/browse/UIIN-3044)
