### PR TITLE
UIIN-3057: Display 'Classification browse' settings for non-consortia.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Make "Barcode" field wrapping to next row when there are many characters in the value. Fixes UIIN-2958.
 * Fixed "Settings" > "Inventory" page does not load. Fixes UIIN-3053.
 * Display an item that has an open loan whose patron record has been removed. Fixes UIIN-3044.
+* Display "Classification browse" settings for non-consortia. Fixes UIIN-3057.
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/src/settings/InventorySettings/InventorySettings.js
+++ b/src/settings/InventorySettings/InventorySettings.js
@@ -78,8 +78,10 @@ const InventorySettings = (props) => {
   };
 
   const getSections = (_centralTenantPermissions) => {
-    const canUserViewClassificationBrowse = checkIfUserInCentralTenant(stripes)
-      || flattenCentralTenantPermissions(_centralTenantPermissions).has('ui-inventory.settings.classification-browse');
+    const canUserViewClassificationBrowse = isUserInConsortiumMode(stripes)
+      ? checkIfUserInCentralTenant(stripes)
+        || flattenCentralTenantPermissions(_centralTenantPermissions).has('ui-inventory.settings.classification-browse')
+      : true;
 
     const _sections = [
       {

--- a/src/settings/InventorySettings/InventorySettings.test.js
+++ b/src/settings/InventorySettings/InventorySettings.test.js
@@ -3,6 +3,7 @@ import {
   useUserTenantPermissions,
   checkIfUserInMemberTenant,
 } from '@folio/stripes/core';
+import { Settings } from '@folio/stripes/smart-components';
 
 import {
   renderWithIntl,
@@ -15,7 +16,7 @@ import * as utils from '../../utils';
 
 jest.mock('@folio/stripes/smart-components', () => ({
   ...jest.requireActual('@folio/stripes/smart-components'),
-  Settings: () => <div>Settings</div>
+  Settings: jest.fn(() => <div>Settings</div>),
 }));
 const spyOnIsUserInConsortiumMode = jest.spyOn(utils, 'isUserInConsortiumMode');
 
@@ -67,6 +68,36 @@ describe('InventorySettings', () => {
       const { getByText } = renderInventorySettings();
 
       expect(getByText('Settings')).toBeInTheDocument();
+    });
+  });
+
+  describe('when non-consortia', () => {
+    it('should display "Classification Browse" settings', () => {
+      spyOnIsUserInConsortiumMode.mockReturnValue(false);
+      checkIfUserInMemberTenant.mockReturnValue(false);
+      useUserTenantPermissions.mockReturnValue({
+        userPermissions: [],
+        isFetched: false,
+        isFetching: false,
+        isLoading: false,
+      });
+
+      renderInventorySettings();
+
+      const expectedProps = {
+        sections: expect.arrayContaining([
+          expect.objectContaining({
+            pages: expect.arrayContaining([
+              expect.objectContaining({
+                route: 'classificationBrowse',
+                perm: 'ui-inventory.settings.classification-browse',
+              }),
+            ]),
+          }),
+        ]),
+      };
+
+      expect(Settings).toHaveBeenCalledWith(expect.objectContaining(expectedProps), {});
     });
   });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Display `Classification browse` settings for non-consortia.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->



## Screenshots

![image](https://github.com/user-attachments/assets/0f3d3a60-af30-4b9b-bbfc-72761012a51e)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-3057](https://folio-org.atlassian.net/browse/UIIN-3057)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
