### PR TITLE
UIIN-3054 Fetch bound item related pieces from the central tenant in the central ordering mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Display an item that has an open loan whose patron record has been removed. Fixes UIIN-3044.
 * Display "Classification browse" settings for non-consortia. Fixes UIIN-3057.
 * Fix eslint warnings. Refs UIIN-3064.
+* Fetch bound item related pieces from the central tenant in the central ordering mode. UIIN-3054.
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
       "orders": "11.0 12.0",
       "orders.holding-summary": "1.0",
       "order-lines": "2.0 3.0",
+      "orders-storage.settings": "1.0",
       "organizations.organizations": "1.0",
       "pieces": "3.0",
       "titles": "1.2"
@@ -611,6 +612,7 @@
           "orders.po-lines.item.get",
           "orders.collection.get",
           "orders.item.get",
+          "orders-storage.settings.collection.get",
           "orders.titles.collection.get",
           "organizations.organizations.item.get",
           "acquisitions-units.units.collection.get",

--- a/src/Instance/utils.js
+++ b/src/Instance/utils.js
@@ -1,3 +1,5 @@
+import { OKAPI_TENANT_HEADER } from '@folio/stripes-inventory-components';
+
 export const isItemsSelected = (items, selectedItemsMap) => {
   return items.every((item) => Boolean(
     selectedItemsMap[item.holdingsRecordId] && selectedItemsMap[item.holdingsRecordId][item.id]
@@ -54,6 +56,18 @@ export const navigateToHoldingsViewPage = (history, location, instance, holding,
     state: {
       tenantTo,
       tenantFrom,
+    },
+  });
+};
+
+export const extendKyWithTenant = (ky, tenantId) => {
+  return ky.extend({
+    hooks: {
+      beforeRequest: [
+        request => {
+          request.headers.set(OKAPI_TENANT_HEADER, tenantId);
+        },
+      ],
     },
   });
 };

--- a/src/common/hooks/useBoundPieces/useBoundPieces.js
+++ b/src/common/hooks/useBoundPieces/useBoundPieces.js
@@ -1,25 +1,42 @@
 import { useQuery } from 'react-query';
 
 import {
+  getConsortiumCentralTenantId,
   LIMIT_MAX,
   ORDER_PIECES_API,
+  useCentralOrderingSettings,
 } from '@folio/stripes-acq-components';
 import {
   useNamespace,
   useOkapiKy,
+  useStripes,
 } from '@folio/stripes/core';
 
+import { extendKyWithTenant } from '../../../Instance/utils';
+
 const DEFAULT_DATA = [];
+const SORTING_FIELD = 'receivedDate';
 
 const useBoundPieces = (itemId, options = {}) => {
   const { enabled = true, ...otherOptions } = options;
+
+  const stripes = useStripes();
   const ky = useOkapiKy();
   const [namespace] = useNamespace({ key: 'bound-pieces' });
   const filterQuery = `bindItemId==${itemId} and isBound==true`;
 
+  const consortiumCentralTenantId = getConsortiumCentralTenantId(stripes);
+
+  const {
+    enabled: isCentralOrderingEnabled,
+    isFetching: isCentralOrderingSettingsFetching,
+  } = useCentralOrderingSettings({
+    enabled: stripes.hasInterface('orders-storage.settings'),
+  });
+
   const searchParams = {
     limit: LIMIT_MAX,
-    query: `${filterQuery} sortby receivedDate`,
+    query: `${filterQuery} sortby ${SORTING_FIELD}`,
   };
 
   const {
@@ -29,8 +46,35 @@ const useBoundPieces = (itemId, options = {}) => {
     refetch,
   } = useQuery({
     queryKey: [namespace, itemId],
-    queryFn: () => ky.get(ORDER_PIECES_API, { searchParams }).json(),
-    enabled: Boolean(enabled && itemId),
+    queryFn: ({ signal }) => {
+      const makeRequest = (httpClient) => httpClient.get(ORDER_PIECES_API, { searchParams, signal }).json();
+
+      if (isCentralOrderingEnabled) {
+        return Promise.allSettled([
+          makeRequest(ky),
+          makeRequest(extendKyWithTenant(ky, consortiumCentralTenantId))
+        ]).then((results) => {
+          const fulfilledResults = results.filter(({ status }) => status === 'fulfilled');
+          const totalRecords = fulfilledResults.reduce((acc, { value }) => acc + value.totalRecords, 0);
+          const pieces = fulfilledResults
+            .flatMap(({ value }, index) => value.pieces.map(piece => ({ ...piece, tenantId: index === 1 ? consortiumCentralTenantId : stripes.okapi.tenant })))
+            .sort((a, b) => new Date(a[SORTING_FIELD]) - new Date(b[SORTING_FIELD]));
+
+          return {
+            pieces,
+            totalRecords,
+          };
+        });
+      }
+
+      return makeRequest(ky);
+    },
+    enabled: Boolean(
+      enabled
+      && itemId
+      && consortiumCentralTenantId
+      && !isCentralOrderingSettingsFetching
+    ),
     ...otherOptions,
   });
 

--- a/src/common/hooks/useBoundPieces/useBoundPieces.js
+++ b/src/common/hooks/useBoundPieces/useBoundPieces.js
@@ -13,6 +13,7 @@ import {
 } from '@folio/stripes/core';
 
 import { extendKyWithTenant } from '../../../Instance/utils';
+import { isUserInConsortiumMode } from '../../../utils';
 
 const DEFAULT_DATA = [];
 const SORTING_FIELD = 'receivedDate';
@@ -71,8 +72,8 @@ const useBoundPieces = (itemId, options = {}) => {
     enabled: Boolean(
       enabled
       && itemId
-      && consortiumCentralTenantId
       && !isCentralOrderingSettingsFetching
+      && (isUserInConsortiumMode(stripes) ? consortiumCentralTenantId : true)
     ),
     ...otherOptions,
   });

--- a/src/common/hooks/useBoundPieces/useBoundPieces.test.js
+++ b/src/common/hooks/useBoundPieces/useBoundPieces.test.js
@@ -1,45 +1,149 @@
-import {
-  QueryClient,
-  QueryClientProvider,
-} from 'react-query';
+import { useQuery } from 'react-query';
 
 import {
   renderHook,
   waitFor,
 } from '@folio/jest-config-stripes/testing-library/react';
-import { useOkapiKy } from '@folio/stripes/core';
 import {
-  LIMIT_MAX,
-  ORDER_PIECES_API,
+  getConsortiumCentralTenantId,
+  useCentralOrderingSettings,
 } from '@folio/stripes-acq-components';
+import {
+  useNamespace,
+  useOkapiKy,
+  useStripes,
+} from '@folio/stripes/core';
 
 import useBoundPieces from './useBoundPieces';
 
-const queryClient = new QueryClient();
-const wrapper = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    {children}
-  </QueryClientProvider>
-);
+jest.mock('react-query', () => ({
+  useQuery: jest.fn(),
+}));
 
+jest.mock('@folio/stripes-acq-components', () => ({
+  getConsortiumCentralTenantId: jest.fn(),
+  useCentralOrderingSettings: jest.fn(() => ({ enabled: false })),
+}));
+
+jest.mock('@folio/stripes/core', () => ({
+  useNamespace: jest.fn(),
+  useOkapiKy: jest.fn(),
+  useStripes: jest.fn(),
+}));
+
+jest.mock('../../../Instance/utils', () => ({
+  extendKyWithTenant: jest.fn(),
+}));
 
 describe('useBoundPieces', () => {
+  const mockKy = {
+    get: jest.fn(() => ({
+      json: jest.fn(),
+    })),
+  };
+
+  const mockStripes = {
+    okapi: { tenant: 'member-tenant' },
+    hasInterface: jest.fn(() => true),
+  };
+
   beforeEach(() => {
-    useOkapiKy.mockClear();
+    jest.clearAllMocks();
+
+    useOkapiKy.mockReturnValue(mockKy);
+    useStripes.mockReturnValue(mockStripes);
+    useNamespace.mockReturnValue(['bound-pieces']);
   });
 
-  it('should return the data from the GET request', async () => {
-    const mockData = [{ id: '1', itemId: 'itemId' }];
-    const mockKy = jest.fn().mockReturnValue({
-      json: jest.fn().mockResolvedValue(mockData),
-    });
-    useOkapiKy.mockReturnValue(mockKy);
+  it('should return default data when query is not enabled', async () => {
+    const itemId = null; // Query won't be enabled
+    const mockQuery = {
+      data: null,
+      isLoading: false,
+      isFetching: false,
+      refetch: jest.fn(),
+    };
 
-    const { result } = renderHook(() => useBoundPieces('itemId'), { wrapper });
+    useQuery.mockReturnValue(mockQuery);
 
-    await waitFor(async () => expect(result.current.isLoading).toBe(false));
+    const { result } = renderHook(() => useBoundPieces(itemId));
 
-    expect(mockKy).toHaveBeenCalledWith(`${ORDER_PIECES_API}?query=(itemId=="itemId")&limit=${LIMIT_MAX}&offset=0&sort=receivedDate`);
-    expect(result.current.boundPieces).toEqual(mockData);
+    expect(result.current.boundPieces).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isFetching).toBe(false);
+  });
+
+  it('should fetch bound pieces for the given item ID', async () => {
+    const itemId = '12345';
+    const mockQuery = {
+      data: {
+        pieces: [{ id: 'piece1', receivedDate: '2023-01-01T00:00:00.000Z' }],
+        totalRecords: 1,
+      },
+      isLoading: false,
+      isFetching: false,
+      refetch: jest.fn(),
+    };
+
+    useQuery.mockReturnValue(mockQuery);
+    getConsortiumCentralTenantId.mockReturnValue('central-tenant');
+    useCentralOrderingSettings.mockReturnValue({ enabled: true, isFetching: false });
+
+    const { result } = renderHook(() => useBoundPieces(itemId));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.boundPieces).toEqual([{ id: 'piece1', receivedDate: '2023-01-01T00:00:00.000Z' }]);
+    expect(result.current.isFetching).toBe(false);
+  });
+
+  it('should handle central ordering logic when central ordering is enabled', async () => {
+    const itemId = '12345';
+    const mockQuery = {
+      data: {
+        pieces: [
+          { id: 'piece1', receivedDate: '2023-01-01T00:00:00.000Z', tenantId: 'member-tenant' },
+          { id: 'piece2', receivedDate: '2023-02-01T00:00:00.000Z', tenantId: 'central-tenant' }
+        ],
+        totalRecords: 2,
+      },
+      isLoading: false,
+      isFetching: false,
+      refetch: jest.fn(),
+    };
+
+    useQuery.mockReturnValue(mockQuery);
+    getConsortiumCentralTenantId.mockReturnValue('central-tenant');
+    useCentralOrderingSettings.mockReturnValue({ enabled: true, isFetching: false });
+
+    const { result } = renderHook(() => useBoundPieces(itemId));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.boundPieces).toEqual([
+      { id: 'piece1', receivedDate: '2023-01-01T00:00:00.000Z', tenantId: 'member-tenant' },
+      { id: 'piece2', receivedDate: '2023-02-01T00:00:00.000Z', tenantId: 'central-tenant' },
+    ]);
+  });
+
+  it('should handle loading state correctly', async () => {
+    const itemId = '12345';
+    const mockQuery = {
+      data: null,
+      isLoading: true,
+      isFetching: true,
+      refetch: jest.fn(),
+    };
+
+    useQuery.mockReturnValue(mockQuery);
+    getConsortiumCentralTenantId.mockReturnValue('central-tenant');
+    useCentralOrderingSettings.mockReturnValue({ enabled: true, isFetching: false });
+
+    const { result } = renderHook(() => useBoundPieces(itemId));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+
+    expect(result.current.boundPieces).toEqual([]);
+    expect(result.current.isFetching).toBe(true);
   });
 });

--- a/src/common/hooks/useBoundPieces/useBoundPieces.test.js
+++ b/src/common/hooks/useBoundPieces/useBoundPieces.test.js
@@ -15,6 +15,7 @@ import {
 
 import { extendKyWithTenant } from '../../../Instance/utils';
 import useBoundPieces from './useBoundPieces';
+import { isUserInConsortiumMode } from '../../../utils';
 
 jest.mock('@folio/stripes-acq-components', () => ({
   getConsortiumCentralTenantId: jest.fn(() => 'central-tenant'),
@@ -29,6 +30,10 @@ jest.mock('@folio/stripes/core', () => ({
 
 jest.mock('../../../Instance/utils', () => ({
   extendKyWithTenant: jest.fn(),
+}));
+
+jest.mock('../../../utils', () => ({
+  isUserInConsortiumMode: jest.fn(() => false),
 }));
 
 const queryClient = new QueryClient();
@@ -70,6 +75,8 @@ describe('useBoundPieces', () => {
   });
 
   it('should handle central ordering logic when central ordering is enabled', async () => {
+    isUserInConsortiumMode.mockReturnValue(true);
+
     const itemId = '12345';
     const extendedKy = {
       get: jest.fn(() => ({

--- a/src/common/hooks/useBoundPieces/useBoundPieces.test.js
+++ b/src/common/hooks/useBoundPieces/useBoundPieces.test.js
@@ -1,0 +1,45 @@
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+
+import {
+  renderHook,
+  waitFor,
+} from '@folio/jest-config-stripes/testing-library/react';
+import { useOkapiKy } from '@folio/stripes/core';
+import {
+  LIMIT_MAX,
+  ORDER_PIECES_API,
+} from '@folio/stripes-acq-components';
+
+import useBoundPieces from './useBoundPieces';
+
+const queryClient = new QueryClient();
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+
+describe('useBoundPieces', () => {
+  beforeEach(() => {
+    useOkapiKy.mockClear();
+  });
+
+  it('should return the data from the GET request', async () => {
+    const mockData = [{ id: '1', itemId: 'itemId' }];
+    const mockKy = jest.fn().mockReturnValue({
+      json: jest.fn().mockResolvedValue(mockData),
+    });
+    useOkapiKy.mockReturnValue(mockKy);
+
+    const { result } = renderHook(() => useBoundPieces('itemId'), { wrapper });
+
+    await waitFor(async () => expect(result.current.isLoading).toBe(false));
+
+    expect(mockKy).toHaveBeenCalledWith(`${ORDER_PIECES_API}?query=(itemId=="itemId")&limit=${LIMIT_MAX}&offset=0&sort=receivedDate`);
+    expect(result.current.boundPieces).toEqual(mockData);
+  });
+});

--- a/src/common/hooks/usePiecesMutation/usePiecesMutation.js
+++ b/src/common/hooks/usePiecesMutation/usePiecesMutation.js
@@ -9,8 +9,8 @@ const usePiecesMutation = (options = {}) => {
   const ky = useOkapiKy();
 
   const { mutateAsync, isLoading } = useMutation({
-    mutationFn: (piece) => {
-      const httpClient = piece?.tenantId ? extendKyWithTenant(ky, piece.tenantId) : ky;
+    mutationFn: ({ tenantId, ...piece }) => {
+      const httpClient = tenantId ? extendKyWithTenant(ky, tenantId) : ky;
 
       return httpClient.put(`${ORDER_PIECES_API}/${piece.id}`, { json: piece });
     },

--- a/src/common/hooks/usePiecesMutation/usePiecesMutation.js
+++ b/src/common/hooks/usePiecesMutation/usePiecesMutation.js
@@ -3,11 +3,17 @@ import { useMutation } from 'react-query';
 import { ORDER_PIECES_API } from '@folio/stripes-acq-components';
 import { useOkapiKy } from '@folio/stripes/core';
 
+import { extendKyWithTenant } from '../../../Instance/utils';
+
 const usePiecesMutation = (options = {}) => {
   const ky = useOkapiKy();
 
   const { mutateAsync, isLoading } = useMutation({
-    mutationFn: (piece) => ky.put(`${ORDER_PIECES_API}/${piece.id}`, { json: piece }),
+    mutationFn: (piece) => {
+      const httpClient = piece?.tenantId ? extendKyWithTenant(ky, piece.tenantId) : ky;
+
+      return httpClient.put(`${ORDER_PIECES_API}/${piece.id}`, { json: piece });
+    },
     ...options,
   });
 

--- a/src/common/hooks/usePiecesMutation/usePiecesMutation.test.js
+++ b/src/common/hooks/usePiecesMutation/usePiecesMutation.test.js
@@ -1,0 +1,32 @@
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+
+import {
+  act,
+  renderHook,
+} from '@folio/jest-config-stripes/testing-library/react-hooks';
+
+import usePiecesMutation from './usePiecesMutation';
+
+const queryClient = new QueryClient();
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+describe('usePiecesMutation', () => {
+  it('should call the mutation function with the correct arguments', () => {
+    const mockMutation = jest.fn();
+    const mockOptions = { onSuccess: jest.fn() };
+    const { result } = renderHook(() => usePiecesMutation(mockOptions), { wrapper });
+
+    act(() => {
+      result.current(mockMutation);
+    });
+
+    expect(mockMutation).toHaveBeenCalledWith(mockOptions);
+  });
+});

--- a/src/common/hooks/useTenantKy/useTenantKy.js
+++ b/src/common/hooks/useTenantKy/useTenantKy.js
@@ -1,20 +1,11 @@
 import { useOkapiKy } from '@folio/stripes/core';
-import { OKAPI_TENANT_HEADER } from '@folio/stripes-inventory-components';
+
+import { extendKyWithTenant } from '../../../Instance/utils';
 
 const useTenantKy = ({ tenantId } = {}) => {
   const ky = useOkapiKy();
 
-  return tenantId
-    ? ky.extend({
-      hooks: {
-        beforeRequest: [
-          request => {
-            request.headers.set(OKAPI_TENANT_HEADER, tenantId);
-          },
-        ],
-      },
-    })
-    : ky;
+  return tenantId ? extendKyWithTenant(ky, tenantId) : ky;
 };
 
 export default useTenantKy;


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

When a user is on a member tenant and central ordering is enabled in the platform, it's necessary to fetch bound item-related pieces from the active tenant and the central one.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3054
## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/user-attachments/assets/5266b308-0418-4a50-b2c5-5f34b820615d

---

non-ECS

https://github.com/user-attachments/assets/6e29d635-c20c-4268-b7af-249abd47f27d



