### PR TITLE
UIIN-3076 Rename inventory.consortia permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Fix eslint warnings. Refs UIIN-3064.
 * Disable link to POL when it leads to another tenant (instance, holding and item). Refs UIIN-3024.
 * Add code to subject source settings. UIIN-3056.
+* Rename inventory.consortia permissions UIIN-3076
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -458,7 +458,7 @@ class ViewHoldingsRecord extends React.Component {
     const canDelete = stripes.hasPerm('ui-inventory.holdings.delete');
     const canViewMARC = stripes.hasPerm('ui-quick-marc.quick-marc-holdings-editor.view');
     const canEditMARC = stripes.hasPerm('ui-quick-marc.quick-marc-holdings-editor.all');
-    const hasUpdateOwnershipPermission = stripes.hasPerm('consortia.inventory.update.ownership');
+    const hasUpdateOwnershipPermission = stripes.hasPerm('consortia.inventory.update-ownership.item.post');
     const canUpdateOwnership = hasUpdateOwnershipPermission && isSharedInstance && !isEmpty(this.state.tenants);
 
     const isSourceMARC = this.isMARCSource();

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -740,7 +740,7 @@ class ViewInstance extends React.Component {
     const canViewInstance = stripes.hasPerm('ui-inventory.instance.view');
     const canViewSource = canViewMARCSource && canViewInstance;
     const canShareLocalInstance = checkIfUserInMemberTenant(stripes)
-      && stripes.hasPerm('consortia.inventory.share.local.instance')
+      && stripes.hasPerm('consortia.inventory.local.sharing-instances.execute')
       && !isShared
       && !isInstanceShadowCopy(source);
 

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -328,7 +328,7 @@ const ItemView = props => {
     const newRequestLink = `/requests?itemId=${firstItem.id}&query=${firstItem.id}&layer=create`;
     const userHasPermToCreate = stripes.hasPerm('ui-inventory.item.create');
     const userHasPermToEdit = stripes.hasPerm('ui-inventory.item.edit');
-    const canUpdateOwnership = stripes.hasPerm('consortia.inventory.update.ownership');
+    const canUpdateOwnership = stripes.hasPerm('consortia.inventory.update-ownership.item.post');
     const userHasPermToUpdateOwnership = canUpdateOwnership && isSharedInstance && !isEmpty(tenants);
     const userHasPermToMarkAsMissing = stripes.hasPerm('ui-inventory.item.markasmissing');
     const userHasPermToMarkAsWithdrawn = stripes.hasPerm('ui-inventory.items.mark-items-withdrawn');

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -743,8 +743,8 @@
   "permission.items.mark-unavailable": "Inventory: Mark items unavailable",
   "permission.items.mark-long-missing": "Inventory: Mark items long missing",
   "permission.items.mark-in-process-non-requestable": "Inventory: Mark items in process (non-requestable)",
-  "permission.consortia.inventory.share.local.instance": "Inventory: Share local instance with consortium",
-  "permission.consortia.inventory.update.ownership": "Inventory: Update ownership",
+  "permission.consortia.inventory.local.sharing-instances.execute": "Inventory: Share local instance with consortium",
+  "permission.consortia.inventory.update-ownership.item.post": "Inventory: Update ownership",
   "permission.items.create-in-transit-report": "Inventory: Create and download In transit items report",
   "permission.settings.displaySettings": "Settings (Inventory): Can view and edit general settings",
 


### PR DESCRIPTION

## Purpose
According to the epic [FOLIO-4044](https://folio-org.atlassian.net/browse/FOLIO-4044) in scope of [MODCON-156 ](https://folio-org.atlassian.net/browse/MODCON-156) some permissions have been changed in the `mod-consortia v1.1`
It should be replaced with new ones:

```
"consortia.inventory.local.sharing-instances.execute"
"consortia.inventory.update-ownership.item.post"
```
## Refs
https://folio-org.atlassian.net/browse/UIIN-3076

