### PR TITLE
UIIN-2960: Add subject source and subject type to Inventory subject browse results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Add code to subject source settings. UIIN-3056.
 * Alter rules for display of 'Edit in Linked data editor' option in Inventory Action drop down. Refs UIIN-3051.
 * Upgrade `inventory` to `14.0` and `instance-storage` to `11.0`. Refs UIIN-3065.
+* Add subject source and subject type to Inventory subject browse results. Refs UIIN-2960.
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/src/components/BrowseResultsList/BrowseResultsList.test.js
+++ b/src/components/BrowseResultsList/BrowseResultsList.test.js
@@ -93,6 +93,8 @@ const mockContext = {
       ],
     },
   ],
+  subjectSources: [{ id: 'sourceId', name: 'sourceName' }],
+  subjectTypes: [{ id: 'typeId', name: 'typeName' }],
 };
 
 const contributorsData = [
@@ -109,6 +111,8 @@ const contributorsData = [
 const subjectsData = [
   {
     'value': 'Trivia and miscellanea',
+    'sourceId': 'sourceId',
+    'typeId': 'typeId',
     'totalRecords': 8
   },
 ];

--- a/src/components/BrowseResultsList/constants.js
+++ b/src/components/BrowseResultsList/constants.js
@@ -3,7 +3,7 @@ import { FormattedMessage } from 'react-intl';
 import { browseModeOptions } from '@folio/stripes-inventory-components';
 
 export const VISIBLE_COLUMNS_MAP = {
-  [browseModeOptions.SUBJECTS]: ['subject', 'numberOfTitles'],
+  [browseModeOptions.SUBJECTS]: ['subject', 'subjectSource', 'subjectType', 'numberOfTitles'],
   [browseModeOptions.CALL_NUMBERS]: ['callNumber', 'title', 'numberOfTitles'],
   [browseModeOptions.DEWEY]: ['callNumber', 'title', 'numberOfTitles'],
   [browseModeOptions.LIBRARY_OF_CONGRESS]: ['callNumber', 'title', 'numberOfTitles'],
@@ -25,6 +25,8 @@ export const COLUMNS_MAPPING = {
   relation: <FormattedMessage id="ui-inventory.instances.columns.relation" />,
   numberOfTitles: <FormattedMessage id="ui-inventory.instances.columns.numberOfTitles" />,
   subject: <FormattedMessage id="ui-inventory.subject" />,
+  subjectSource: <FormattedMessage id="ui-inventory.subjectSource" />,
+  subjectType: <FormattedMessage id="ui-inventory.subjectType" />,
   contributor: <FormattedMessage id="ui-inventory.instances.columns.contributor" />,
   contributorType: <FormattedMessage id="ui-inventory.instances.columns.contributorType" />,
   relatorTerm: <FormattedMessage id="ui-inventory.instances.columns.relatorTerm" />,
@@ -51,6 +53,8 @@ export const COLUMNS_WIDTHS = {
     relatorTerm: '15%',
   },
   [browseModeOptions.SUBJECTS]: {
-    subject: '50%',
+    subject: '40%',
+    subjectSource: '20%',
+    subjectType: '20%',
   },
 };

--- a/src/components/BrowseResultsList/getBrowseResultsFormatter.js
+++ b/src/components/BrowseResultsList/getBrowseResultsFormatter.js
@@ -5,6 +5,7 @@ import { AppIcon } from '@folio/stripes/core';
 import {
   TextLink,
   Tooltip,
+  NoValue,
 } from '@folio/stripes/components';
 import {
   browseModeOptions,
@@ -129,6 +130,18 @@ const getBrowseResultsFormatter = ({
       }
 
       return subject;
+    },
+    subjectSource: r => {
+      const sourceId = r?.sourceId;
+      const sourceName = data?.subjectSources.find(source => source.id === sourceId)?.name;
+
+      return sourceName || <NoValue />;
+    },
+    subjectType: r => {
+      const typeId = r?.typeId;
+      const typeName = data?.subjectTypes.find(source => source.id === typeId)?.name;
+
+      return typeName || <NoValue />;
     },
     callNumber: r => {
       if (r?.instance || r?.totalRecords) {

--- a/src/components/BrowseResultsList/getBrowseResultsFormatter.test.js
+++ b/src/components/BrowseResultsList/getBrowseResultsFormatter.test.js
@@ -47,6 +47,8 @@ const data = {
       ],
     },
   ],
+  subjectSources: [{ id: 'sourceId1', name: 'sourceName1' }, { id: 'sourceId2', name: 'sourceName2' }],
+  subjectTypes: [{ id: 'typeId1', name: 'typeName1' }, { id: 'typeId2', name: 'typeName2' }],
 };
 const missedMatchText = 'would be here';
 
@@ -252,10 +254,14 @@ describe('getBrowseResultsFormatter', () => {
       {
         isAnchor: true,
         value: 'Africa Politics and government 20th century',
+        sourceId: 'sourceId1',
+        typeId: 'typeId1',
         totalRecords: 1,
       },
       {
         value: 'Corporate governance',
+        sourceId: 'sourceId2',
+        typeId: 'typeId2',
         totalRecords: 2,
       }
     ];
@@ -273,9 +279,13 @@ describe('getBrowseResultsFormatter', () => {
 
       // Anchor row
       expect(screen.getByText(anchorRecord.value).tagName.toLowerCase()).toBe('strong');
+      expect(screen.getByText('sourceName1')).toBeInTheDocument();
+      expect(screen.getByText('typeName1')).toBeInTheDocument();
       expect(screen.getByText(anchorRecord.totalRecords).tagName.toLowerCase()).toBe('strong');
       // Default row
       expect(screen.getByText(nonAnchorRecord.value).tagName.toLowerCase()).not.toBe('strong');
+      expect(screen.getByText('sourceName2')).toBeInTheDocument();
+      expect(screen.getByText('typeName2')).toBeInTheDocument();
       expect(screen.getByText(nonAnchorRecord.totalRecords).tagName.toLowerCase()).not.toBe('strong');
     });
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
 We are updating the Instance schema to include more detailed information about subject headings - the subject source and the subject type. These new fields need to be added to the Inventory Browse results list. 

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Added two new columns after “Subject”: “Subject source” and “Subject type”

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-2960

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
<img width="1512" alt="Screenshot 2024-10-11 at 14 34 42" src="https://github.com/user-attachments/assets/c4234e69-d5b9-40a2-99e3-1a793a170213">
<img width="1512" alt="Screenshot 2024-10-11 at 14 54 00" src="https://github.com/user-attachments/assets/19bb5e3e-9fed-40c7-be01-84d21c41c6b5">
