### PR TITLE
UIIN-3061: Update sub permissions in the `package.json` and upgrade `holdings-storage` to `8.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Add code to subject source settings. UIIN-3056.
 * Alter rules for display of 'Edit in Linked data editor' option in Inventory Action drop down. Refs UIIN-3051.
 * Upgrade `inventory` to `14.0` and `instance-storage` to `11.0`. Refs UIIN-3065.
+* Update sub permissions in the `package.json` and upgrade `holdings-storage` to `8.0`. Refs UIIN-3061.
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
       "electronic-access-relationships": "1.0",
       "holdings-note-types": "1.0",
       "holdings-sources": "1.0",
-      "holdings-storage": "3.0 4.4 5.0 6.0 7.0",
+      "holdings-storage": "3.0 4.4 5.0 6.0 7.0 8.0",
       "holdings-types": "1.0",
       "identifier-types": "1.1",
       "ill-policies": "1.0",
@@ -700,7 +700,8 @@
         "subPermissions": [
           "ui-inventory.item.create",
           "inventory.items.item.put",
-          "inventory-storage.bound-with-parts.item.delete"
+          "inventory-storage.bound-with-parts.item.delete",
+          "inventory-storage.bound-withs.collection.put"
         ],
         "visible": true
       },

--- a/src/utils.js
+++ b/src/utils.js
@@ -782,9 +782,9 @@ const handleUpdateUser = async (stripes) => {
 
 export const switchAffiliation = async (stripes, tenantId, move) => {
   if (stripes.okapi.tenant !== tenantId) {
-    const updateTenantPromise = updateTenant(stripes.okapi, tenantId);
+    await updateTenant(stripes.okapi, tenantId);
 
-    const validateUserPromise = validateUser(
+    await validateUser(
       stripes.okapi.url,
       stripes.store,
       tenantId,
@@ -794,11 +794,8 @@ export const switchAffiliation = async (stripes, tenantId, move) => {
         perms: stripes.user.perms,
       },
     );
+
     await handleUpdateUser(stripes);
-
-    const handleUpdateUserPromise = handleUpdateUser(stripes);
-
-    await Promise.all([updateTenantPromise, validateUserPromise, handleUpdateUserPromise]);
 
     move();
   } else {


### PR DESCRIPTION
## Purpose
* Update the `subPermissions` in the `package.json`, as the permissions for `mod-inventory-storage` have been changed according to this story: [MODINVSTOR-1247](https://folio-org.atlassian.net/browse/MODINVSTOR-1247)

## Approach
* Upgraded `holdings-storage` to `8.0`.
* Added `inventory-storage.bound-withs.collection.put` sub permission to `Inventory: View, create, edit items` permission.
* Endpoint `/holdings-storage/holdings/retrieve` is not used in `ui-inventory` so no changes are needed.

## Refs
[UIIN-3061](https://folio-org.atlassian.net/browse/UIIN-3061)