### PR TITLE
UIIN-3073: ECS - Disallow 'Move items within an instance' and 'Move holdings/items to another instance' if no LOCAL Items/Holdings exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Update 'Instance relationship' accordion name - VIEW/EDIT/CREATE Instance. Refs UIIN-3081.
 * Create alert to prevent moving holding to another instance if Po Line has multiple holdings. Refs UIIN-3046.
 * Update sub permissions in the `package.json` and upgrade `holdings-storage` to `8.0`. Refs UIIN-3061.
+* ECS - Disallow 'Move items within an instance' and 'Move holdings/items to another instance' if no LOCAL Items/Holdings exist. Refs UIIN-3073.
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -711,6 +711,7 @@ class ViewInstance extends React.Component {
       resources: {
         instanceRequests,
         centralOrdering,
+        allInstanceHoldings,
       },
     } = this.props;
     const {
@@ -719,6 +720,7 @@ class ViewInstance extends React.Component {
       titleLevelRequestsFeatureEnabled,
     } = this.state;
     const source = instance?.source;
+    const noInstanceHoldings = allInstanceHoldings?.other?.totalRecords === 0;
 
     const editBibRecordPerm = 'ui-quick-marc.quick-marc-editor.all';
     const editInstancePerm = 'ui-inventory.instance.edit';
@@ -727,9 +729,9 @@ class ViewInstance extends React.Component {
     const canEditInstance = stripes.hasPerm(editInstancePerm);
     const canCreateInstance = stripes.hasPerm('ui-inventory.instance.create');
     const canCreateRequest = stripes.hasPerm('ui-requests.create');
-    const canMoveItems = !checkIfUserInCentralTenant(stripes) && stripes.hasPerm('ui-inventory.item.move');
+    const canMoveItems = !checkIfUserInCentralTenant(stripes) && !noInstanceHoldings && stripes.hasPerm('ui-inventory.item.move');
     const canCreateMARCHoldings = stripes.hasPerm('ui-quick-marc.quick-marc-holdings-editor.create');
-    const canMoveHoldings = !checkIfUserInCentralTenant(stripes) && stripes.hasPerm('ui-inventory.holdings.move');
+    const canMoveHoldings = !checkIfUserInCentralTenant(stripes) && !noInstanceHoldings && stripes.hasPerm('ui-inventory.holdings.move');
     const canEditMARCRecord = checkIfUserInMemberTenant(stripes) && isShared
       ? this.hasCentralTenantPerm(editBibRecordPerm)
       : stripes.hasPerm(editBibRecordPerm);

--- a/src/ViewInstance.test.js
+++ b/src/ViewInstance.test.js
@@ -96,7 +96,7 @@ history.push = mockPush;
 history.replace = mockReplace;
 const instance = {
   ...instances[0],
-  subjects:['Information society--Political aspects'],
+  subjects:[{ subject: 'Information society--Political aspects' }],
   parentInstances: [],
   childInstances: [],
 };
@@ -210,7 +210,7 @@ const defaultProp = {
     allInstanceItems: {
       reset: mockReset
     },
-    allInstanceHoldings: {},
+    allInstanceHoldings: { other: { totalRecords: 1 } },
     locations: {},
     configs: {
       hasLoaded: true,
@@ -496,6 +496,20 @@ describe('ViewInstance', () => {
           expect(screen.queryByRole('button', { name: 'Move items within an instance' })).not.toBeInTheDocument();
         });
       });
+
+      describe('when instance does not have local holdings', () => {
+        it('should be hidden', () => {
+          const resources = {
+            ...defaultProp.resources,
+            allInstanceHoldings: { other: { totalRecords: 0 } },
+          };
+
+          renderViewInstance({ resources });
+          fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+
+          expect(screen.queryByRole('button', { name: 'Move items within an instance' })).not.toBeInTheDocument();
+        });
+      });
     });
     describe('"Move holdings/items to another instance" action item', () => {
       it('should be rendered', () => {
@@ -520,6 +534,20 @@ describe('ViewInstance', () => {
           checkIfUserInCentralTenant.mockClear().mockReturnValue(true);
 
           renderViewInstance({ stripes });
+          fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+
+          expect(screen.queryByRole('button', { name: 'Move holdings/items to another instance' })).not.toBeInTheDocument();
+        });
+      });
+
+      describe('when instance does not have local holdings', () => {
+        it('should be hidden', () => {
+          const resources = {
+            ...defaultProp.resources,
+            allInstanceHoldings: { other: { totalRecords: 0 } },
+          };
+
+          renderViewInstance({ resources });
           fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
 
           expect(screen.queryByRole('button', { name: 'Move holdings/items to another instance' })).not.toBeInTheDocument();


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
The ‘Move items within an instance’ action is only designed for use with Instances on the currently affiliated tenant. As such, this action should only be displayed if an Instance has Holdings & Items is available on the member tenant that a user currently affiliated with during their session.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Disallow 'Move items within an instance' and 'Move holdings/items to another instance' if no LOCAL Items/Holdings exist

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3073

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
<img width="542" alt="Screenshot 2024-10-16 at 20 33 16" src="https://github.com/user-attachments/assets/8aaad7bd-4249-4467-930e-9eabb5edb1a6">
<img width="538" alt="Screenshot 2024-10-16 at 20 33 26" src="https://github.com/user-attachments/assets/89df6fcb-0b47-47b1-a44d-c88b2fa73f94">
