### PR TITLE
UIIN-3092: Include current location into redirects to Linked data editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * ECS - Disallow 'Move items within an instance' and 'Move holdings/items to another instance' if no LOCAL Items/Holdings exist. Refs UIIN-3073.
 * *BREAKING* Update sub permissions in the `package.json` and upgrade `source-storage-records` to `3.3` and `data-import-converter-storage` to `1.5`. Refs UIIN-3086.
 * *BREAKING* Bump `stripes` to `v9.2.0` for Ramsons release. Refs UIIN-2961.
+* Include current location into redirects to Linked data editor. Refs UIIN-3092.
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -783,18 +783,28 @@ class ViewInstance extends React.Component {
 
     const navigateToLinkedDataEditor = () => {
       const selectedIdentifier = instance.identifiers?.find(({ value }) => value.includes(LINKED_DATA_ID_PREFIX))?.value;
+      const currentLocationState = {
+        state: {
+          from: {
+            pathname: history?.location?.pathname,
+            search: history?.location?.search,
+          },
+        },
+      };
 
       if (!selectedIdentifier) {
         if (!canBeOpenedInLinkedData) return;
 
         history.push({
           pathname: `${LINKED_DATA_RESOURCES_ROUTE}/external/${instance.id}/edit`,
+          ...currentLocationState,
         });
       } else {
         const identifierLiteral = selectedIdentifier?.replace(LINKED_DATA_ID_PREFIX, '');
 
         history.push({
           pathname: `${LINKED_DATA_RESOURCES_ROUTE}/${identifierLiteral}/edit`,
+          ...currentLocationState,
         });
       }
     };


### PR DESCRIPTION
Extend the functionality of UIIN-3051 by including current location information into redirects to Linked data editor, allowing navigation back to the Inventory.

https://folio-org.atlassian.net/browse/UIIN-3092