### PR TITLE
UIIN-3093: Use `ResetProvider` to subscribe and publish the reset event and unsubscribe from it after a segment switch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * ECS - Disallow 'Move items within an instance' and 'Move holdings/items to another instance' if no LOCAL Items/Holdings exist. Refs UIIN-3073.
 * *BREAKING* Update sub permissions in the `package.json` and upgrade `source-storage-records` to `3.3` and `data-import-converter-storage` to `1.5`. Refs UIIN-3086.
 * *BREAKING* Bump `stripes` to `v9.2.0` for Ramsons release. Refs UIIN-2961.
+* Use `ResetProvider` to subscribe and publish the reset event and unsubscribe from it after a segment switch. Refs UIIN-3093.
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -60,6 +60,7 @@ import {
   SEARCH_COLUMN_NAMES,
   getSearchResultsFormatter,
   SEARCH_COLUMN_MAPPINGS,
+  withReset,
 } from '@folio/stripes-inventory-components';
 
 import { withSingleRecordImport } from '..';
@@ -149,7 +150,9 @@ class InstancesList extends React.Component {
     data: PropTypes.object,
     parentResources: PropTypes.object,
     parentMutator: PropTypes.object,
+    publishOnReset: PropTypes.func.isRequired,
     disableRecordCreation: PropTypes.bool,
+    unsubscribeFromReset: PropTypes.func.isRequired,
     updateLocation: PropTypes.func.isRequired,
     goTo: PropTypes.func.isRequired,
     getParams: PropTypes.func.isRequired,
@@ -544,12 +547,16 @@ class InstancesList extends React.Component {
   }
 
   handleSearchSegmentChange = (segment) => {
-    const { namespace } = this.props;
+    const {
+      namespace,
+      unsubscribeFromReset,
+    } = this.props;
 
     deleteFacetStates(namespace);
     this.refocusOnInputSearch(segment);
     this.setState({ selectedRows: {} });
     sessionStorage.setItem(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY, false);
+    unsubscribeFromReset();
   }
 
   onSearchModeSwitch = () => {
@@ -1122,7 +1129,10 @@ class InstancesList extends React.Component {
   };
 
   handleResetAll = () => {
-    const { namespace } = this.props;
+    const {
+      namespace,
+      publishOnReset,
+    } = this.props;
 
     this.setState({
       selectedRows: {},
@@ -1131,6 +1141,7 @@ class InstancesList extends React.Component {
     resetFacetStates({ namespace });
     this.inputRef.current.focus();
     sessionStorage.setItem(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY, false);
+    publishOnReset();
   }
 
   handleSelectedRecordsModalSave = selectedRecords => {
@@ -1527,4 +1538,5 @@ export default withNamespace(flowRight(
   injectIntl,
   withLocation,
   withSingleRecordImport,
+  withReset,
 )(stripesConnect(InstancesList)));

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -48,6 +48,9 @@ const mockItemsByQuery = jest.fn().mockResolvedValue([{
 const mockRecordsToExportIDs = jest.fn().mockResolvedValue([{
   id: 'UUID',
 }]);
+const mockUnsubscribeFromReset = jest.fn();
+const mockPublishOnReset = jest.fn();
+
 const spyOnIsUserInConsortiumMode = jest.spyOn(utils, 'isUserInConsortiumMode');
 const spyOnCheckIfUserInCentralTenant = jest.spyOn(require('@folio/stripes/core'), 'checkIfUserInCentralTenant');
 
@@ -89,6 +92,20 @@ jest.mock('@folio/stripes/core', () => ({
   TitleManager: ({ page }) => (
     <div>{page}</div>
   ),
+}));
+
+jest.mock('@folio/stripes-inventory-components', () => ({
+  ...jest.requireActual('@folio/stripes-inventory-components'),
+  withReset: (Comp) => (props) => (
+    <Comp
+      {...props}
+      unsubscribeFromReset={mockUnsubscribeFromReset}
+      publishOnReset={mockPublishOnReset}
+    />
+  ),
+  deleteFacetStates: jest.fn(),
+  resetFacetStates: jest.fn(),
+  buildSearchQuery: jest.fn(),
 }));
 
 const data = {
@@ -242,6 +259,14 @@ describe('InstancesList', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Holdings' }));
 
         expect(deleteFacetStates).toHaveBeenCalledWith('@folio/inventory');
+      });
+
+      it('should unsubscribe from reset event', () => {
+        renderInstancesList();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Holdings' }));
+
+        expect(mockUnsubscribeFromReset).toHaveBeenCalled();
       });
     });
 
@@ -461,6 +486,14 @@ describe('InstancesList', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Reset all' }));
 
         expect(resetFacetStates).toHaveBeenCalledWith({ namespace: '@folio/inventory' });
+      });
+
+      it('should publish the reset event', () => {
+        renderInstancesList();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Reset all' }));
+
+        expect(mockPublishOnReset).toHaveBeenCalled();
       });
 
       it('should call history.replace to add the default sort query parameter from inventory settings', () => {

--- a/src/routes/InstancesRoute.js
+++ b/src/routes/InstancesRoute.js
@@ -8,6 +8,7 @@ import {
   renderFilters,
   segments,
   withSearchErrors,
+  ResetProvider,
 } from '@folio/stripes-inventory-components';
 
 import withLocation from '../withLocation';
@@ -67,27 +68,29 @@ class InstancesRoute extends React.Component {
     return (
       <DataContext.Consumer>
         {data => (
-          <InstancesView
-            parentResources={parentResources}
-            parentMutator={mutator}
-            data={{ ...data, query }}
-            onSelectRow={onSelectRow}
-            disableRecordCreation={disableRecordCreation}
-            renderFilters={renderFilters({
-              data,
-              query,
-              onFilterChange: this.handleFilterChange,
-            })}
-            segment={segment}
-            searchableIndexes={indexes}
-            getLastSearch={getLastSearch}
-            getLastBrowse={getLastBrowse}
-            getLastSearchOffset={getLastSearchOffset}
-            storeLastSearch={storeLastSearch}
-            storeLastSearchOffset={storeLastSearchOffset}
-            storeLastSegment={storeLastSegment}
-            isRequestUrlExceededLimit={isRequestUrlExceededLimit}
-          />
+          <ResetProvider>
+            <InstancesView
+              parentResources={parentResources}
+              parentMutator={mutator}
+              data={{ ...data, query }}
+              onSelectRow={onSelectRow}
+              disableRecordCreation={disableRecordCreation}
+              renderFilters={renderFilters({
+                data,
+                query,
+                onFilterChange: this.handleFilterChange,
+              })}
+              segment={segment}
+              searchableIndexes={indexes}
+              getLastSearch={getLastSearch}
+              getLastBrowse={getLastBrowse}
+              getLastSearchOffset={getLastSearchOffset}
+              storeLastSearch={storeLastSearch}
+              storeLastSearchOffset={storeLastSearchOffset}
+              storeLastSegment={storeLastSegment}
+              isRequestUrlExceededLimit={isRequestUrlExceededLimit}
+            />
+          </ResetProvider>
         )}
       </DataContext.Consumer>
     );

--- a/test/jest/helpers/Harness.js
+++ b/test/jest/helpers/Harness.js
@@ -8,6 +8,7 @@ import {
 } from 'react-query';
 
 import { CalloutContext } from '@folio/stripes/core';
+import { ResetProvider } from '@folio/stripes-inventory-components';
 
 import translations from '../../../translations/ui-inventory/en';
 import prefixKeys from './prefixKeys';
@@ -42,7 +43,9 @@ const Harness = ({
           defaultRichTextElements={defaultRichTextElements}
           messages={allTranslations}
         >
-          {children}
+          <ResetProvider>
+            {children}
+          </ResetProvider>
         </IntlProvider>
       </CalloutContext.Provider>
     </QueryClientProvider>


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Date filters: Clear dates after pressing the reset search button even if values are invalid.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Related PRs
https://github.com/folio-org/stripes-smart-components/pull/1527
https://github.com/folio-org/stripes-inventory-components/pull/83

## Approach
Use `ResetProvider` to publish the reset event from the `InstancesList` file and subscribe to it in filters. Use `nativeChangeFieldValue` to clear dates in filters.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-3093](https://folio-org.atlassian.net/browse/UIIN-3093)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots

https://github.com/user-attachments/assets/ca890dd9-6021-431c-8dc9-bee7946d1293




<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
