### PR TITLE
UIIN-3058: Update permission name after Review and cleanup Module Descriptor for ui-requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * ECS: Item affiliation cannot be changed when it is attached to a local order. Refs UIIN-3063.
 * Refactor ui-inventory permissions. Refs UIIN-3087.
 * Disallow displaying shared instances when find instance modal is open. Refs UIIN-3072.
+* Update permission name after Review and cleanup Module Descriptor for ui-requests. Refs UIIN-3058.
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -748,7 +748,7 @@ class ViewInstance extends React.Component {
 
     const canCentralTenantCreateOrder = checkIfUserInCentralTenant(stripes) && checkIfCentralOrderingIsActive(centralOrdering);
     const canCreateOrder = (!checkIfUserInCentralTenant(stripes) && stripes.hasInterface('orders') && stripes.hasPerm('ui-inventory.instance.order.create')) || canCentralTenantCreateOrder;
-    const canReorder = stripes.hasPerm('ui-requests.reorderQueue');
+    const canReorder = stripes.hasPerm('ui-requests.reorderQueue.execute');
     const canExportMarc = stripes.hasPerm('ui-data-export.edit');
     const canAccessLinkedDataOptions = stripes.hasPerm(LINKED_DATA_EDITOR_PERM);
     const isSourceLinkedData = isLinkedDataSource(source);

--- a/src/components/ViewInstance/MenuSection/RequestsReorderButton.js
+++ b/src/components/ViewInstance/MenuSection/RequestsReorderButton.js
@@ -23,7 +23,7 @@ const RequestsReorderButton = ({
   }
 
   return (
-    <IfPermission perm="ui-requests.reorderQueue">
+    <IfPermission perm="ui-requests.reorderQueue.execute">
       <Button
         to={getInstanceQueueReorderLink(requestId, instanceId)}
         buttonStyle="dropdownItem"

--- a/src/components/ViewInstance/MenuSection/RequestsReorderButton.test.js
+++ b/src/components/ViewInstance/MenuSection/RequestsReorderButton.test.js
@@ -79,7 +79,7 @@ describe('RequestsReorderButton', () => {
       });
 
       it('should check for permission to reorder requests queue', () => {
-        const expectedResult = { perm: 'ui-requests.reorderQueue' };
+        const expectedResult = { perm: 'ui-requests.reorderQueue.execute' };
 
         expect(IfPermission).toHaveBeenCalledWith(expect.objectContaining(expectedResult), {});
       });


### PR DESCRIPTION
## Purpose
Update permission name after Review and cleanup Module Descriptor for ui-requests

## Approach 
Consistency update permission with ui-checkout ( https://folio-org.atlassian.net/browse/UIREQ-1156 )
Permissions renamed in according with Permissions naming convention ( https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/156368925/Permissions+naming+convention )

## Refs
https://issues.folio.org/browse/UIIN-3058