### PR TITLE
[UIIN-3097] "Something went wrong" screen when opening shared FOLIO/MARC instances in Inventory on member tenant

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1083,8 +1083,8 @@ export const flattenCentralTenantPermissions = (centralTenantPermissions) => {
   return new Set(centralTenantPermissions?.reduce((acc, currentPermission) => {
     return [
       ...acc,
-      currentPermission.permissionName,
-      ...currentPermission.subPermissions,
+      currentPermission?.permissionName,
+      currentPermission ? {...currentPermission.subPermissions} : null,
     ];
   }, []));
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1084,7 +1084,7 @@ export const flattenCentralTenantPermissions = (centralTenantPermissions) => {
     return [
       ...acc,
       currentPermission?.permissionName,
-      currentPermission ? { ...currentPermission.subPermissions } : null,
+      ...currentPermission?.subPermissions,
     ];
   }, []));
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1084,7 +1084,7 @@ export const flattenCentralTenantPermissions = (centralTenantPermissions) => {
     return [
       ...acc,
       currentPermission?.permissionName,
-      currentPermission ? {...currentPermission.subPermissions} : null,
+      currentPermission ? { ...currentPermission.subPermissions } : null,
     ];
   }, []));
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1084,7 +1084,7 @@ export const flattenCentralTenantPermissions = (centralTenantPermissions) => {
     return [
       ...acc,
       currentPermission?.permissionName,
-      ...currentPermission?.subPermissions,
+      ...(currentPermission?.subPermissions || [])
     ];
   }, []));
 };


### PR DESCRIPTION
- Fix [UIIN-3097](https://folio-org.atlassian.net/browse/UIIN-3097) by adding null safety on `currentPermission` object to prevent error screen.