### PR TITLE
UIIN-3095: Display location when navigating to another member tenant’s holdings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## [12.0.1] (IN PROGRESS)
+
+* Display location when navigating to another member tenant’s holdings. Fixes UIIN-3095.
+
 ## [12.0.0] (IN PROGRESS)
 
 * Remove unused code related to auto-open record detail view. Refs UIIN-2819.

--- a/src/Instance/ItemsList/ItemsList.js
+++ b/src/Instance/ItemsList/ItemsList.js
@@ -18,7 +18,10 @@ import {
   MultiColumnList,
   MCLPagingTypes,
 } from '@folio/stripes/components';
-import { itemStatuses, useLocationsQuery } from '@folio/stripes-inventory-components';
+import {
+  itemStatuses,
+  useLocationsQuery,
+} from '@folio/stripes-inventory-components';
 
 import { useStripes } from '@folio/stripes/core';
 import {
@@ -171,7 +174,10 @@ const ItemsList = ({
 }) => {
   const stripes = useStripes();
   const { boundWithHoldings: holdings, isLoading } = useBoundWithHoldings(items, tenantId);
-  const { locations: tenantLocations } = useLocationsQuery({ enabled: tenantId !== stripes.okapi.tenant, tenantId });
+  const { locations: tenantLocations } = useLocationsQuery({
+    enabled: tenantId !== stripes.okapi.tenant,
+    tenantId,
+  });
   const { locationsById } = useContext(DataContext);
   const holdingsMapById = keyBy(holdings, 'id');
   const intl = useIntl();

--- a/src/Instance/ItemsList/ItemsList.js
+++ b/src/Instance/ItemsList/ItemsList.js
@@ -18,8 +18,9 @@ import {
   MultiColumnList,
   MCLPagingTypes,
 } from '@folio/stripes/components';
-import { itemStatuses } from '@folio/stripes-inventory-components';
+import { itemStatuses, useLocationsQuery } from '@folio/stripes-inventory-components';
 
+import { useStripes } from '@folio/stripes/core';
 import {
   DEFAULT_ITEM_TABLE_SORTBY_FIELD,
   ITEM_TABLE_PAGE_AMOUNT,
@@ -168,7 +169,10 @@ const ItemsList = ({
   isBarcodeAsHotlink,
   tenantId,
 }) => {
+  const stripes = useStripes();
   const { boundWithHoldings: holdings, isLoading } = useBoundWithHoldings(items, tenantId);
+  const { locations: tenantLocations } = useLocationsQuery({ enabled: tenantId !== stripes.okapi.tenant, tenantId });
+  const { locationsById } = useContext(DataContext);
   const holdingsMapById = keyBy(holdings, 'id');
   const intl = useIntl();
   const [itemsSorting, setItemsSorting] = useState({
@@ -177,7 +181,10 @@ const ItemsList = ({
   });
   const [records, setRecords] = useState([]);
 
-  const { locationsById } = useContext(DataContext);
+  const allLocationsById = {
+    ...keyBy(tenantLocations, 'id'),
+    ...locationsById,
+  };
   const pagingCanGoPrevious = offset > 0;
   const pagingCanGoNext = offset < total && total - offset > ITEM_TABLE_PAGE_AMOUNT;
 
@@ -189,7 +196,7 @@ const ItemsList = ({
   const formatter = useMemo(
     () => getFormatter(
       intl,
-      locationsById,
+      allLocationsById,
       holdingsMapById,
       selectItemsForDrag,
       isItemsDragSelected,

--- a/src/providers/DataProvider.js
+++ b/src/providers/DataProvider.js
@@ -13,10 +13,11 @@ import { DataContext } from '../contexts';
 const DataProvider = ({
   children,
   resources,
+  stripes,
 }) => {
   const { manifest } = DataProvider;
 
-  const { commonData, isCommonDataLoading } = useCommonData();
+  const { commonData, isCommonDataLoading } = useCommonData(stripes.okapi.tenant);
   const { classificationBrowseConfig, isLoading: isBrowseConfigLoading } = useClassificationBrowseConfig();
 
   const isLoading = useMemo(() => {
@@ -79,6 +80,7 @@ const DataProvider = ({
 
 DataProvider.propTypes = {
   resources: PropTypes.object.isRequired,
+  stripes: PropTypes.object.isRequired,
   children: PropTypes.object,
 };
 


### PR DESCRIPTION
## Purpose
* Display location when user navigates to another member tenant’s holdings.
* Display location in **Effective location** column for the list of the items.

## Approach
* Call `useLocationsQuery` hook only when user view other member tenant's items (using `enabled`).
* Pass `tenantId` parameter to `useCommonData` hook to get correct data.

## Refs
[UIIN-3095](https://folio-org.atlassian.net/browse/UIIN-3095)

## Screenshots

### Before
https://github.com/user-attachments/assets/64e494eb-9dd3-4322-8eee-8f0eeda93df6

### After
https://github.com/user-attachments/assets/005d5c6a-90a2-4f12-a911-e69518ac2636