### PR TITLE
UIIN-3101: Browse | Number of titles in Subject browse results does not match the number of instances returned in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Refactor ui-inventory permissions. Refs UIIN-3087.
 * Disallow displaying shared instances when find instance modal is open. Refs UIIN-3072.
 * Update permission name after Review and cleanup Module Descriptor for ui-requests. Refs UIIN-3058.
+* Browse | Number of titles in Subject browse results does not match the number of instances returned in search. Fixes UIIN-3101.
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/src/components/BrowseResultsList/BrowseResultsList.test.js
+++ b/src/components/BrowseResultsList/BrowseResultsList.test.js
@@ -358,7 +358,9 @@ describe('BrowseResultsList', () => {
 
         fireEvent.click(screen.getByText(subjectsData[0].value));
 
-        expect(history.location.search).toContain('?filters=shared.true%2Cshared.false%2CtenantId.college');
+        expect(history.location.search).toContain('?filters=searchSubjectSource.sourceId%2C' +
+          'searchSubjectType.typeId%2Cshared.true%2Cshared.false%2C' +
+          'tenantId.college&qindex=subject&query=Trivia%20and%20miscellanea&selectedBrowseResult=true');
       });
     });
   });

--- a/src/components/BrowseResultsList/utils.js
+++ b/src/components/BrowseResultsList/utils.js
@@ -45,6 +45,14 @@ const getExtraFilters = (row, qindex, allFilters) => {
     if (row.authorityId) {
       extraFacets.push(`${FACETS.AUTHORITY_ID}.${row.authorityId}`);
     }
+
+    if (row.sourceId) {
+      extraFacets.push(`${FACETS.SEARCH_SUBJECT_SOURCE}.${row.sourceId}`);
+    }
+
+    if (row.typeId) {
+      extraFacets.push(`${FACETS.SEARCH_SUBJECT_TYPE}.${row.typeId}`);
+    }
   } else if (qindex === browseModeOptions.CONTRIBUTORS) {
     sharedFacetName = FACETS.CONTRIBUTORS_SHARED;
     heldByFacetName = FACETS.CONTRIBUTORS_HELD_BY;


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

Requires https://github.com/folio-org/stripes-inventory-components/pull/91

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
When clicking the subject heading hyperlink in the browse result it navigates to the inventory search result but shows results only by subject heading and not by source or type.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Filter search results by subject source/type if exists.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3101

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
