### PR TITLE
UIIN-3107: Change URI of a redirect to Linked data editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Disallow displaying shared instances when find instance modal is open. Refs UIIN-3072.
 * Update permission name after Review and cleanup Module Descriptor for ui-requests. Refs UIIN-3058.
 * Browse | Number of titles in Subject browse results does not match the number of instances returned in search. Fixes UIIN-3101.
+* Adjust the URI of a redirect to Linked data editor. Fixes UIIN-3107.
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -796,7 +796,7 @@ class ViewInstance extends React.Component {
         if (!canBeOpenedInLinkedData) return;
 
         history.push({
-          pathname: `${LINKED_DATA_RESOURCES_ROUTE}/external/${instance.id}/edit`,
+          pathname: `${LINKED_DATA_RESOURCES_ROUTE}/external/${instance.id}/preview`,
           ...currentLocationState,
         });
       } else {


### PR DESCRIPTION
Change URI of a redirect to Linked data editor for supported MARC resources from `.../edit` to `.../preview` to support the changed scope of relevant tickets.

https://folio-org.atlassian.net/browse/UIIN-3107