### PR TITLE
UIIN-3110: Add 'replaces' array to refactored ui permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Update permission name after Review and cleanup Module Descriptor for ui-requests. Refs UIIN-3058.
 * Browse | Number of titles in Subject browse results does not match the number of instances returned in search. Fixes UIIN-3101.
 * Adjust the URI of a redirect to Linked data editor. Fixes UIIN-3107.
+* Add 'replaces' array to refactored ui permissions. Refs UIIN-3110.
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
       {
         "permissionName": "ui-inventory.all",
         "displayName": "Inventory: All permissions",
+        "replaces": ["ui-inventory.all-permissions.TEMPORARY"],
         "description": "Some subperms to support enabling/using the Inventory app",
         "subPermissions": [
           "ui-plugin-create-inventory-records.create",
@@ -180,6 +181,7 @@
       {
         "permissionName": "ui-inventory.settings.material-types",
         "displayName": "Settings (Inventory): Create, edit, delete material types",
+        "replaces": ["ui-inventory.settings.materialtypes"],
         "subPermissions": [
           "inventory-storage.material-types.collection.get",
           "inventory-storage.material-types.item.delete",
@@ -194,6 +196,7 @@
       {
         "permissionName": "ui-inventory.settings.loan-types",
         "displayName": "Settings (Inventory): Create, edit, delete loan types",
+        "replaces": ["ui-inventory.settings.loantypes"],
         "subPermissions": [
           "inventory-storage.loan-types.collection.get",
           "inventory-storage.loan-types.item.delete",
@@ -660,6 +663,7 @@
       {
         "permissionName": "ui-inventory.instance.order.create",
         "displayName": "Inventory: Create order from instance",
+        "replaces": ["ui-inventory.instance.createOrder"],
         "subPermissions": [
           "ui-inventory.instance.view",
           "acquisitions-units.memberships.collection.get",
@@ -722,6 +726,7 @@
       {
         "permissionName": "ui-inventory.item.mark-as-missing.execute",
         "displayName": "Inventory: View, create, edit, mark missing items",
+        "replaces": ["ui-inventory.item.markasmissing"],
         "subPermissions": [
           "ui-inventory.item.edit",
           "inventory.items.item.mark-missing.post"
@@ -779,6 +784,7 @@
       {
         "permissionName": "ui-inventory.instance.staff-suppressed-records.view",
         "displayName": "Inventory: Enable staff suppress facet",
+        "replaces": ["ui-inventory.instance.view-staff-suppressed-records"],
         "subPermissions": [
           "ui-inventory.instance.view"
         ],
@@ -787,6 +793,7 @@
       {
         "permissionName": "ui-inventory.instance.set-records-for-deletion.execute",
         "displayName": "Inventory: Set records for deletion",
+        "replaces": ["ui-inventory.instance.set-deletion-and-staff-suppress"],
         "subPermissions": [
           "ui-inventory.instance.view",
           "source-storage.records.update"
@@ -853,6 +860,7 @@
       {
         "permissionName": "ui-inventory.items.mark-withdrawn.execute",
         "displayName": "Inventory: Mark items withdrawn",
+        "replaces": ["ui-inventory.items.mark-items-withdrawn"],
         "subPermissions": [
           "inventory.items.item.mark-withdrawn.post"
         ],
@@ -861,6 +869,7 @@
       {
         "permissionName": "ui-inventory.items.mark-intellectual-item.execute",
         "displayName": "Inventory: Mark items intellectual item",
+        "replaces": ["ui-inventory.items.mark-intellectual-item"],
         "subPermissions": [
           "inventory.items.item.mark-intellectual-item.post"
         ],
@@ -869,6 +878,7 @@
       {
         "permissionName": "ui-inventory.items.mark-restricted.execute",
         "displayName": "Inventory: Mark items restricted",
+        "replaces": ["ui-inventory.items.mark-restricted"],
         "subPermissions": [
           "inventory.items.item.mark-restricted.post"
         ],
@@ -877,6 +887,7 @@
       {
         "permissionName": "ui-inventory.items.mark-unknown.execute",
         "displayName": "Inventory: Mark items unknown",
+        "replaces": ["ui-inventory.items.mark-unknown"],
         "subPermissions": [
           "inventory.items.item.mark-unknown.post"
         ],
@@ -885,6 +896,7 @@
       {
         "permissionName": "ui-inventory.items.mark-unavailable.execute",
         "displayName": "Inventory: Mark items unavailable",
+        "replaces": ["ui-inventory.items.mark-unavailable"],
         "subPermissions": [
           "inventory.items.item.mark-unavailable.post"
         ],
@@ -893,6 +905,7 @@
       {
         "permissionName": "ui-inventory.items.mark-long-missing.execute",
         "displayName": "Inventory: Mark items long missing",
+        "replaces": ["ui-inventory.items.mark-long-missing"],
         "subPermissions": [
           "inventory.items.item.mark-long-missing.post"
         ],
@@ -901,6 +914,7 @@
       {
         "permissionName": "ui-inventory.items.mark-in-process-non-requestable.execute",
         "displayName": "Inventory: Mark items in process (non-requestable)",
+        "replaces": ["ui-inventory.items.mark-in-process-non-requestable"],
         "subPermissions": [
           "inventory.items.item.mark-in-process-non-requestable.post"
         ],
@@ -909,6 +923,7 @@
       {
         "permissionName": "ui-inventory.items.mark-in-process.execute",
         "displayName": "Inventory: Mark items in process",
+        "replaces": ["ui-inventory.items.mark-in-process"],
         "subPermissions": [
           "inventory.items.item.mark-in-process.post"
         ],
@@ -917,6 +932,7 @@
       {
         "permissionName": "ui-inventory.items.in-transit-report.create",
         "displayName": "Inventory: Create and download In transit items report",
+        "replaces": ["ui-inventory.items.create-in-transit-report"],
         "subPermissions": [
           "circulation.inventory.items-in-transit-report.get"
         ],


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
To add missing 'replaces' array to refactored ui permissions.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Add `replaces` to `package.json` for replaces UI permissions

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3110

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
