### PR TITLE
UIIN-3112 Suppress edit and delete actions of subject types and sources for 'consortium' source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Browse | Number of titles in Subject browse results does not match the number of instances returned in search. Fixes UIIN-3101.
 * Adjust the URI of a redirect to Linked data editor. Fixes UIIN-3107.
 * Rename "mod-settings.global.*" permissions. Refs UIIN-3109.
+* Suppress edit and delete actions of subject types and sources for `consortium` source. Refs UIIN-3112.
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/src/settings/SubjectSourcesSettings.js
+++ b/src/settings/SubjectSourcesSettings.js
@@ -30,7 +30,7 @@ const SubjectSourcesSettings = (props) => {
   const stripes = useStripes();
 
   const hasPerm = stripes.hasPerm('ui-inventory.settings.subject-sources');
-  const suppress = getSourceSuppressor([RECORD_SOURCE.FOLIO]);
+  const suppress = getSourceSuppressor([RECORD_SOURCE.FOLIO, RECORD_SOURCE.CONSORTIUM]);
 
   return (
     <TitleManager

--- a/src/settings/SubjectTypesSettings.js
+++ b/src/settings/SubjectTypesSettings.js
@@ -26,7 +26,7 @@ const SubjectTypesSettings = (props) => {
   const stripes = useStripes();
 
   const hasPerm = stripes.hasPerm('ui-inventory.settings.subject-types');
-  const suppress = getSourceSuppressor([RECORD_SOURCE.FOLIO]);
+  const suppress = getSourceSuppressor([RECORD_SOURCE.FOLIO, RECORD_SOURCE.CONSORTIUM]);
 
   return (
     <TitleManager


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Records with the `consortium` source are considered shared records and mustn't be editable outside the consortium manager.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Add `consortium` source type for suppression.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3112

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/user-attachments/assets/1bf59bce-cee1-4740-ab7b-ba29b49cb111

