### PR TITLE
UIIN-3105: ECS: Prevent Item affiliation ownership change if it is attached to a local PO line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Adjust the URI of a redirect to Linked data editor. Fixes UIIN-3107.
 * Rename "mod-settings.global.*" permissions. Refs UIIN-3109.
 * Suppress edit and delete actions of subject types and sources for `consortium` source. Refs UIIN-3112.
+* ECS: Prevent Item affiliation ownership change if it is attached to a local PO line. Refs UIIN-3105.
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -41,6 +41,7 @@ import {
   Icon,
   ConfirmationModal,
   Modal,
+  ModalFooter,
   MessageBanner,
   checkScope,
   HasCommand,
@@ -65,6 +66,7 @@ import {
   checkIfUserInCentralTenant,
   checkIfUserInMemberTenant,
   stripesConnect,
+  useOkapiKy,
 } from '@folio/stripes/core';
 
 import { requestsStatusString } from '../Instance/ViewRequests/utils';
@@ -144,6 +146,8 @@ const ItemView = props => {
     isInstanceShared,
   } = props;
 
+  const ky = useOkapiKy();
+
   const [itemMissingModal, setItemMissingModal] = useState(false);
   const [itemWithdrawnModal, setItemWithdrawnModal] = useState(false);
   const [confirmDeleteItemModal, setConfirmDeleteItemModal] = useState(false);
@@ -152,6 +156,7 @@ const ItemView = props => {
   const [isUpdateOwnershipModalOpen, setIsUpdateOwnershipModalOpen] = useState(false);
   const [cannotDeleteItemModalMessageId, setCannotDeleteItemModalMessageId] = useState('');
   const [isConfirmUpdateOwnershipModalOpen, setIsConfirmUpdateOwnershipModalOpen] = useState(false);
+  const [isLinkedLocalOrderLineModalOpen, setIsLinkedLocalOrderLineModalOpen] = useState(false);
   const [updateOwnershipData, setUpdateOwnershipData] = useState({});
   const [tenants, setTenants] = useState([]);
   const [targetTenant, setTargetTenant] = useState({});
@@ -279,6 +284,31 @@ const ItemView = props => {
     setIsConfirmUpdateOwnershipModalOpen(true);
   };
 
+  const hideLinkedOrderLineModal = () => {
+    setIsLinkedLocalOrderLineModalOpen(false);
+  };
+
+  const openLinkedOrderLineModal = () => {
+    setIsLinkedLocalOrderLineModalOpen(true);
+  };
+
+  const handleUpdateOwnership = () => {
+    const { purchaseOrderLineIdentifier } = itemsResource.records[0] || {};
+
+    if (purchaseOrderLineIdentifier) {
+      return ky
+        .get(`orders/order-lines/${purchaseOrderLineIdentifier}`)
+        .json()
+        .then(() => {
+          openLinkedOrderLineModal();
+        }).catch(error => {
+          openUpdateOwnershipModal();
+        });
+    } else {
+      return openUpdateOwnershipModal();
+    }
+  };
+
   const handleSubmitUpdateOwnership = (tenantId, targetLocation, holdingId) => {
     setUpdateOwnershipData({
       tenantId,
@@ -369,7 +399,7 @@ const ItemView = props => {
     const updateOwnershipButton = (
       <ActionItem
         id="clickable-update-ownership-item"
-        onClickHandler={openUpdateOwnershipModal}
+        onClickHandler={handleUpdateOwnership}
         icon="profile"
         messageId="ui-inventory.updateOwnership"
       />
@@ -537,7 +567,7 @@ const ItemView = props => {
     }
   };
 
-  const handleUpdateOwnership = async () => {
+  const onConfirmHandleUpdateOwnership = async () => {
     const { targetLocation, tenantId, holdingId } = updateOwnershipData;
     const newTenant = stripes.user.user.tenants.find(tenant => tenant.id === tenantId);
     const item = itemsResource.records[0] || {};
@@ -984,10 +1014,28 @@ const ItemView = props => {
                 }}
               />
             }
-            onConfirm={handleUpdateOwnership}
+            onConfirm={onConfirmHandleUpdateOwnership}
             onCancel={hideConfirmUpdateOwnershipModal}
             confirmLabel={<FormattedMessage id="ui-inventory.confirm" />}
           />
+          <Modal
+            id="linked-local-order-line-confirmation-modal"
+            open={isLinkedLocalOrderLineModalOpen}
+            label={<FormattedMessage id="ui-inventory.hasLinkedLocalOrderLine.modal.heading" />}
+            footer={(
+              <ModalFooter>
+                <Button
+                  buttonStyle="primary"
+                  onClick={hideLinkedOrderLineModal}
+                  marginBottom0
+                >
+                  <FormattedMessage id="stripes-core.button.continue" />
+                </Button>
+              </ModalFooter>
+              )}
+          >
+            <FormattedMessage id="ui-inventory.hasLinkedLocalOrderLine.modal.message" />
+          </Modal>
           <Modal
             data-testid="missing-confirmation-modal"
             data-test-missingConfirmation-modal

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -301,7 +301,7 @@ const ItemView = props => {
         .json()
         .then(() => {
           openLinkedOrderLineModal();
-        }).catch(error => {
+        }).catch(() => {
           openUpdateOwnershipModal();
         });
     } else {

--- a/src/views/ItemView.test.js
+++ b/src/views/ItemView.test.js
@@ -351,6 +351,32 @@ describe('ItemView', () => {
           });
         });
 
+        it('should display Linked order lines modal', async () => {
+          renderWithIntl(
+            <ItemViewSetup
+              resources={{
+                ...defaultProps.resources,
+                itemsResource: {
+                  ...defaultProps.resources.itemsResource,
+                  records: [{
+                    ...defaultProps.resources.itemsResource.records[0],
+                    purchaseOrderLineIdentifier: 'POL-1',
+                  }]
+                },
+              }}
+            />, translationsProperties
+          );
+
+          const updateOwnershipBtn = await screen.findByText('Update ownership');
+          fireEvent.click(updateOwnershipBtn);
+
+          const hasLocalPOLMessage = await screen.findByText('Linked order line');
+          expect(hasLocalPOLMessage).toBeInTheDocument();
+
+          fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+          expect(screen.queryByText('Linked order line')).not.toBeInTheDocument();
+        });
+
         describe('when an error was occured', () => {
           it('should show an error message', async () => {
             useHoldingMutation.mockClear().mockReturnValue({ mutateHolding: mockMutate });


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
[UIIN-3105](https://folio-org.atlassian.net/browse/UIIN-3105): ECS: Prevent Item affiliation ownership change if it is attached to a local PO line
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

https://github.com/user-attachments/assets/90d4bb3d-fac6-4599-a528-9b9a29f76992


## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
