### PR TITLE
UIIN-3114: Display correctly `Mark as ...` action items in Item action menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ and disable fields when "Settings (Inventory): Create, edit and delete HRID hand
 * Add 'replaces' array to refactored ui permissions. Refs UIIN-3110.
 * Update quick-marc permission name. Refs UIIN-3111.
 * ECS: Prevent Item affiliation ownership change if it is attached to a local PO line. Refs UIIN-3105.
+* Display correctly `Mark as ...` action items in Item action menu. Fixes UIIN-3114.
 
 ## [11.0.5](https://github.com/folio-org/ui-inventory/tree/v11.0.5) (2024-08-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.4...v11.0.5)

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -482,7 +482,7 @@ const ItemView = props => {
 
         return (
           <IfPermission
-            perm={`ui-inventory.items.mark-${parameterizedStatus}`}
+            perm={`ui-inventory.items.mark-${parameterizedStatus}.execute`}
             key={parameterizedStatus}
           >
             {actionMenuItem}


### PR DESCRIPTION
## Purpose
* `Mark as ...` action items in Item action menu are not displayed after renaming the permissions.

## Refs
[UIIN-3114](https://folio-org.atlassian.net/browse/UIIN-3114)