### PR TITLE
UIIN-3115: ECS | "FOLIO/MARC-shared" source is displayed in manually shared instance record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## [12.0.1] (IN PROGRESS)
+
+* ECS | "FOLIO/MARC-shared" source is displayed in manually shared instance record. Fixes UIIN-3115.
+
 ## [12.0.0](https://github.com/folio-org/ui-inventory/tree/v12.0.0) (2024-10-31)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.5...v12.0.0)
 

--- a/src/common/hooks/useInstance.js
+++ b/src/common/hooks/useInstance.js
@@ -3,18 +3,23 @@ import {
   useMemo,
 } from 'react';
 
+import { useStripes } from '@folio/stripes/core';
+
 import useSearchInstanceByIdQuery from './useSearchInstanceByIdQuery';
 import useInstanceQuery from './useInstanceQuery';
 
 const useInstance = (id) => {
+  const stripes = useStripes();
+  const centralTenantId = stripes.user.user?.consortium?.centralTenantId;
+
   const {
     refetch: refetchSearch,
     isLoading: isSearchInstanceByIdLoading,
     instance: _instance,
   } = useSearchInstanceByIdQuery(id);
 
-  const instanceTenantId = _instance?.tenantId;
   const isShared = _instance?.shared;
+  const instanceTenantId = isShared ? centralTenantId : _instance?.tenantId;
 
   const {
     refetch: refetchInstance,
@@ -26,7 +31,7 @@ const useInstance = (id) => {
   } = useInstanceQuery(
     id,
     { tenantId: instanceTenantId },
-    { enabled: Boolean(id && !isSearchInstanceByIdLoading) }
+    { enabled: Boolean(id && !isSearchInstanceByIdLoading && instanceTenantId) }
   );
 
   const instance = useMemo(


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
After instance sharing, the user gets an instance shadow copy instead of a shared instance. It happens because mod-search returned a response with `shared: true` but `tenantId: memberTenant` instead of the central tenant.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Check if instance is shared, if so - make the next request to mod-inventory with `x-okapi-tenant: centralTenant`

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3115

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
