### PR TITLE
UIIN-3099: Run `history.replace` once during component mount and update to avoid URL rewriting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## [12.0.1] (IN PROGRESS)
+
+* Run `history.replace` once during component mount and update to avoid URL rewriting. Refs UIIN-3099.
+
 ## [12.0.0](https://github.com/folio-org/ui-inventory/tree/v12.0.0) (2024-10-31)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.5...v12.0.0)
 

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -222,9 +222,9 @@ class InstancesList extends React.Component {
   componentDidMount() {
     const {
       history,
+      location: _location,
       getParams,
       data,
-      updateLocation,
     } = this.props;
 
     const params = getParams();
@@ -250,17 +250,20 @@ class InstancesList extends React.Component {
 
     this.processLastSearchTermsOnMount();
 
-    this.applyDefaultStaffSuppressFilter();
+    const searchParams = new URLSearchParams(_location.search);
 
-    if (params.sort !== defaultSort) {
-      updateLocation({ sort: defaultSort }, { replace: true });
+    const isStaffSuppressFilterChanged = this.applyDefaultStaffSuppressFilter(searchParams);
+
+    if (params.sort !== defaultSort || isStaffSuppressFilterChanged) {
+      searchParams.set('sort', defaultSort);
+      this.redirectToSearchParams(searchParams);
     }
   }
 
   componentDidUpdate(prevProps) {
     const {
       data,
-      updateLocation,
+      location,
       segment,
     } = this.props;
     const sortBy = this.getSortFromParams();
@@ -281,13 +284,18 @@ class InstancesList extends React.Component {
       setItem(`${this.props.namespace}.${this.props.segment}.lastOpenRecord`, null);
     }
 
+    const searchParams = new URLSearchParams(location.search);
+
+    let isStaffSuppressFilterChanged = false;
+
     if (prevProps.segment !== this.props.segment) {
-      this.applyDefaultStaffSuppressFilter();
+      isStaffSuppressFilterChanged = this.applyDefaultStaffSuppressFilter(searchParams);
     }
 
-    // it is missing after reset button is hit
-    if (!sortBy) {
-      updateLocation({ sort: data.displaySettings.defaultSort }, { replace: true });
+    // `sort` is missing after reset button is hit
+    if (!sortBy || isStaffSuppressFilterChanged) {
+      searchParams.set('sort', data.displaySettings.defaultSort);
+      this.redirectToSearchParams(searchParams);
     }
   }
 
@@ -324,14 +332,10 @@ class InstancesList extends React.Component {
     });
   }
 
-  applyDefaultStaffSuppressFilter = () => {
-    const { location } = this.props;
-
+  applyDefaultStaffSuppressFilter = (searchParams) => {
     if (JSON.parse(sessionStorage.getItem(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY))) {
-      return;
+      return false;
     }
-
-    const searchParams = new URLSearchParams(location.search);
 
     const filters = searchParams.get('filters');
 
@@ -342,9 +346,8 @@ class InstancesList extends React.Component {
       const newFiltersValue = addFilter(filters, staffSuppressFalse);
 
       searchParams.set('filters', newFiltersValue);
-      this.redirectToSearchParams(searchParams);
 
-      return;
+      return true;
     }
 
     const isStaffSuppressFilterAvailable = this.props.stripes.hasPerm('ui-inventory.instance.staff-suppressed-records.view');
@@ -354,8 +357,11 @@ class InstancesList extends React.Component {
       const newFiltersValue = replaceFilter(filters, staffSuppressTrue, staffSuppressFalse);
 
       searchParams.set('filters', newFiltersValue);
-      this.redirectToSearchParams(searchParams);
+
+      return true;
     }
+
+    return false;
   }
 
   getInstanceIdFromLocation = (location) => {

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -206,11 +206,11 @@ describe('InstancesList', () => {
 
         renderInstancesList({ segment: 'instances' });
 
-        await waitFor(() => expect(history.replace).toHaveBeenCalledWith({
+        expect(history.replace).toHaveBeenLastCalledWith({
           pathname: '/',
-          search: 'filters=staffSuppress.false',
+          search: 'filters=staffSuppress.false&sort=contributors',
           state: undefined,
-        }));
+        });
       });
     });
 
@@ -231,11 +231,11 @@ describe('InstancesList', () => {
             },
           });
 
-          await waitFor(() => expect(history.replace).toHaveBeenCalledWith({
+          expect(history.replace).toHaveBeenLastCalledWith({
             pathname: '/',
-            search: 'filters=staffSuppress.false',
+            search: 'filters=staffSuppress.false&sort=contributors',
             state: undefined,
-          }));
+          });
         });
       });
     });
@@ -315,7 +315,7 @@ describe('InstancesList', () => {
 
           await waitFor(() => expect(history.replace).toHaveBeenCalledWith({
             pathname: '/',
-            search: 'segment=holdings&filters=staffSuppress.false',
+            search: 'segment=holdings&filters=staffSuppress.false&sort=contributors',
             state: undefined,
           }));
         });
@@ -361,7 +361,11 @@ describe('InstancesList', () => {
             },
           });
 
-          expect(history.replace).toHaveBeenLastCalledWith('/inventory?filters=staffSuppress.false&sort=relevance');
+          expect(history.replace).toHaveBeenLastCalledWith({
+            pathname: '/inventory',
+            search: 'filters=staffSuppress.false&sort=relevance',
+            state: undefined,
+          });
         });
       });
 
@@ -518,7 +522,11 @@ describe('InstancesList', () => {
         fireEvent.change(screen.getByRole('textbox', { name: 'Search' }), { target: { value: 'test' } });
         fireEvent.click(screen.getByRole('button', { name: 'Reset all' }));
 
-        expect(history.replace).toHaveBeenLastCalledWith('/?filters=staffSuppress.false&sort=relevance');
+        expect(history.replace).toHaveBeenLastCalledWith({
+          pathname: '/',
+          search: 'filters=staffSuppress.false&sort=relevance',
+          state: undefined,
+        });
       });
     });
 


### PR DESCRIPTION

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Send `staffSuppress` filter and `sort` value in URL at the same time to avoid rewriting during mount and update.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
Set the necessary search params in `const searchParams = new URLSearchParams(location.search);` and only then do `history.replace`.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-3099](https://folio-org.atlassian.net/browse/UIIN-3099)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots



https://github.com/user-attachments/assets/d398121c-3e41-4e63-af83-8fe94a55a6c0


<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
