### PR TITLE
UIIN-3102: The item cannot be moved to another holdings associated with another instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Run `history.replace` once during component mount and update to avoid URL rewriting. Refs UIIN-3099.
 * ECS | "FOLIO/MARC-shared" source is displayed in manually shared instance record. Fixes UIIN-3115.
-* The item cannot be moved to another holdings associated with another instance. Fixes UIIN-3102.
+* Allow user to move item to another holdings associated with another instance. Fixes UIIN-3102.
 
 ## [12.0.0](https://github.com/folio-org/ui-inventory/tree/v12.0.0) (2024-10-31)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.5...v12.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Run `history.replace` once during component mount and update to avoid URL rewriting. Refs UIIN-3099.
 * ECS | "FOLIO/MARC-shared" source is displayed in manually shared instance record. Fixes UIIN-3115.
+* The item cannot be moved to another holdings associated with another instance. Fixes UIIN-3102.
 
 ## [12.0.0](https://github.com/folio-org/ui-inventory/tree/v12.0.0) (2024-10-31)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.5...v12.0.0)

--- a/src/Instance/MoveHoldingContext/MoveHoldingContext.js
+++ b/src/Instance/MoveHoldingContext/MoveHoldingContext.js
@@ -8,6 +8,7 @@ import {
 } from 'react';
 import { DragDropContext } from 'react-beautiful-dnd';
 import { useIntl } from 'react-intl';
+import isEmpty from 'lodash/isEmpty';
 
 import {
   Loading,
@@ -172,6 +173,13 @@ const MoveHoldingContext = ({
   }, [setIsModalOpen]);
 
   const checkHasMultiplePOLsOrHoldings = async (holdingIds = []) => {
+    if (isEmpty(holdingIds)) {
+      return {
+        hasLinkedPOLs: false,
+        poLineHoldingIds: [],
+      };
+    }
+
     try {
       const { poLines = [] } = await ky.get(LINES_API, {
         searchParams: {
@@ -181,7 +189,7 @@ const MoveHoldingContext = ({
       }).json();
 
       return {
-        hasLinkedPOLs:  poLines.length > 1 || poLines[0]?.locations?.length > 1,
+        hasLinkedPOLs: poLines.length > 1 || poLines[0]?.locations?.length > 1,
         poLineHoldingIds: getPOLineHoldingIds(poLines, holdingIds),
       };
     } catch (error) {
@@ -219,7 +227,7 @@ const MoveHoldingContext = ({
 
     const holdingIdsToMove = uniq([...poLineHoldingIds, ...holdingIdsFromSelection]);
 
-    setMovingItems(holdingIdsToMove);
+    setMovingItems(isHolding || hasLinkedPOLs ? holdingIdsToMove : items);
     setHasLinkedPOLsOrHoldings(hasLinkedPOLs);
     setSelectedHoldingIds(holdingIdsToMove);
     setIsModalOpen(true);


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
* The item should be moved to the holdings of another instance and displayed in the "Holdings" accordion, but the message **"1 item has been successfully moved."** appeared and the item was not actually moved.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* If user moves holdings then set to `movingItems` holdings ids, otherwise - items ids.
* Check if `holdingIds` is empty in `checkHasMultiplePOLsOrHoldings` function. Previously, when `holdingIds` was empty, it returned all the PO lines not related to current instance. 

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-3102](https://folio-org.atlassian.net/browse/UIIN-3102)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/user-attachments/assets/2a526b28-cd7a-4f50-a570-89735cedc2cb


