### PR TITLE
UIIN-3113: ECS | Instance details pane does not contain all tenants when user does not have affiliations / permissions in all tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Run `history.replace` once during component mount and update to avoid URL rewriting. Refs UIIN-3099.
 * ECS | "FOLIO/MARC-shared" source is displayed in manually shared instance record. Fixes UIIN-3115.
 * Allow user to move item to another holdings associated with another instance. Fixes UIIN-3102.
+* ECS | Instance details pane does not contain all tenants when user does not have affiliations / permissions in all tenants. Fixes UIIN-3113.
 
 ## [12.0.0](https://github.com/folio-org/ui-inventory/tree/v12.0.0) (2024-10-31)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v11.0.5...v12.0.0)

--- a/src/hooks/useMemberTenantHoldings/useMemberTenantHoldings.js
+++ b/src/hooks/useMemberTenantHoldings/useMemberTenantHoldings.js
@@ -11,10 +11,14 @@ const useMemberTenantHoldings = (instance, tenantId, userTenantPermissions) => {
   const { holdingsRecords: expandedHoldings, isLoading: isExpandedHoldingsLoading } = useInstanceHoldingsQuery(instance?.id, { tenantId, enabled: canViewHoldings });
   const { holdings: limitedHoldings, isLoading: isLimitedHoldingsLoading } = useConsortiumHoldings(instance?.id, tenantId, { enabled: !canViewHoldings });
 
-  const holdings = useMemo(() => expandedHoldings || limitedHoldings || [],
-    [expandedHoldings, limitedHoldings, isExpandedHoldingsLoading, isLimitedHoldingsLoading]);
-  const isLoading = useMemo(() => isExpandedHoldingsLoading || isLimitedHoldingsLoading,
-    [isExpandedHoldingsLoading, isLimitedHoldingsLoading]);
+  const holdings = useMemo(
+    () => (expandedHoldings?.length ? expandedHoldings : limitedHoldings?.length ? limitedHoldings : []),
+    [expandedHoldings, limitedHoldings, isExpandedHoldingsLoading, isLimitedHoldingsLoading],
+  );
+  const isLoading = useMemo(
+    () => isExpandedHoldingsLoading || isLimitedHoldingsLoading,
+    [isExpandedHoldingsLoading, isLimitedHoldingsLoading],
+  );
 
   return {
     holdings,


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Consortial holdings accordion is empty for shared instance if a user does not have affiliations/permissions.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Fix checking of empty holdings array for limited holdings info.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3113
## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
