### PR TITLE
UIIN-3120: Rename quick-marc routes from `bib` to `bibliographic` and `duplicate` to `derive`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## [13.0.0] (IN PROGRESS)
+
+* *BREAKING* Rename quick-marc routes from `bib` to `bibliographic` and `duplicate` to `derive`. Refs UIIN-3120.
+
 ## [12.0.1] (IN PROGRESS)
 
 * Run `history.replace` once during component mount and update to avoid URL rewriting. Refs UIIN-3099.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/inventory",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "description": "Inventory manager",
   "repository": "folio-org/ui-inventory",
   "publishConfig": {

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -81,8 +81,8 @@ import RequestsReorderButton from './components/ViewInstance/MenuSection/Request
 import { IdReportGenerator } from './reports';
 
 const quickMarcPages = {
-  editInstance: 'edit-bib',
-  duplicateInstance: 'duplicate-bib',
+  editInstance: 'edit-bibliographic',
+  duplicateInstance: 'derive-bibliographic',
   createHoldings: 'create-holdings',
 };
 

--- a/src/ViewInstance.test.js
+++ b/src/ViewInstance.test.js
@@ -898,7 +898,7 @@ describe('ViewInstance', () => {
       it('push function should be called when the user clicks the "Edit MARC bibliographic record" button', async () => {
         renderViewInstance();
         const expectedValue = {
-          pathname: `/inventory/quick-marc/edit-bib/${defaultProp.selectedInstance.id}`,
+          pathname: `/inventory/quick-marc/edit-bibliographic/${defaultProp.selectedInstance.id}`,
           search: 'filters=test1&query=test2&sort=test3&qindex=test',
         };
         fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
@@ -991,7 +991,7 @@ describe('ViewInstance', () => {
       it('push function should be called when the user clicks the "Derive new MARC bibliographic record" button', async () => {
         renderViewInstance({ isShared: false });
         const expectedValue = {
-          pathname: `/inventory/quick-marc/duplicate-bib/${defaultProp.selectedInstance.id}`,
+          pathname: `/inventory/quick-marc/derive-bibliographic/${defaultProp.selectedInstance.id}`,
           search: 'filters=test1&query=test2&sort=test3&qindex=test',
         };
         fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
@@ -1284,7 +1284,7 @@ describe('ViewInstance', () => {
       fireEvent.click(screen.getByRole('button', { name: 'editMARC' }));
 
       expect(mockPush).toHaveBeenLastCalledWith({
-        pathname: `/inventory/quick-marc/edit-bib/${instance.id}`,
+        pathname: `/inventory/quick-marc/edit-bibliographic/${instance.id}`,
         search: 'filters=test1&query=test2&sort=test3&qindex=test&shared=true',
       });
     });

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -508,7 +508,7 @@ class InstancesList extends React.Component {
 
   openCreateMARCRecord = () => {
     const searchParams = new URLSearchParams(this.props.location.search);
-    this.props.goTo(`/inventory/quick-marc/create-bib?${searchParams}`);
+    this.props.goTo(`/inventory/quick-marc/create-bibliographic?${searchParams}`);
   }
 
   copyInstance = (instance) => {

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -715,7 +715,7 @@ describe('InstancesList', () => {
 
           fireEvent.click(button);
 
-          expect(history.push).toHaveBeenCalledWith('/inventory/quick-marc/create-bib?filters=staffSuppress.false&sort=contributors');
+          expect(history.push).toHaveBeenCalledWith('/inventory/quick-marc/create-bibliographic?filters=staffSuppress.false&sort=contributors');
         });
       });
 

--- a/src/components/ViewSource/ViewSource.js
+++ b/src/components/ViewSource/ViewSource.js
@@ -82,7 +82,7 @@ const ViewSource = ({
 
   const redirectToMARCEdit = useCallback(() => {
     const urlId = isHoldingsRecord ? `${instanceId}/${holdingsRecordId}` : instanceId;
-    const pathname = `/inventory/quick-marc/edit-${isHoldingsRecord ? 'holdings' : 'bib'}/${urlId}`;
+    const pathname = `/inventory/quick-marc/edit-${isHoldingsRecord ? 'holdings' : 'bibliographic'}/${urlId}`;
 
     redirectToMarcEditPage(pathname, instance, location, history);
   }, [isHoldingsRecord]);

--- a/src/components/ViewSource/ViewSource.test.js
+++ b/src/components/ViewSource/ViewSource.test.js
@@ -187,7 +187,7 @@ describe('ViewSource', () => {
       fireEvent.click(screen.getByRole('button', { name: 'editMARC' }));
 
       expect(mockPush).toHaveBeenLastCalledWith({
-        pathname: `/inventory/quick-marc/edit-bib/${mockInstance.id}`,
+        pathname: `/inventory/quick-marc/edit-bibliographic/${mockInstance.id}`,
         search: '',
       });
     });
@@ -214,7 +214,7 @@ describe('ViewSource', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Edit MARC bibliographic record' }));
 
         expect(mockPush).toHaveBeenLastCalledWith({
-          pathname: `/inventory/quick-marc/edit-bib/${mockInstance.id}`,
+          pathname: `/inventory/quick-marc/edit-bibliographic/${mockInstance.id}`,
           search: '',
         });
       });


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Rename quick-marc routes from `bib` to `bibliographic` and `duplicate` to `derive` to match MARC types and action names.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Related PRs
https://github.com/folio-org/ui-quick-marc/pull/756

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-3120](https://folio-org.atlassian.net/browse/UIIN-3120)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
https://github.com/user-attachments/assets/e871ab88-bde4-42e3-a73b-c8114f869e23


<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
