### PR TITLE
UIIN-3127: Display informative error message when editing same instance, holdings, item in two tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * ECS | Instance details pane does not contain all tenants when user does not have affiliations / permissions in all tenants. Fixes UIIN-3113.
 * *BREAKING* Rename quick-marc routes from `bib` to `bibliographic` and `duplicate` to `derive`. Refs UIIN-3120.
 * *BREAKING* Provide necessary props for browse lookup facets. Remove the facets state reset functionality. Refs UIIN-3099.
+* Display informative error message when editing same instance, holdings, item in two tabs. Fixes UIIN-3127.
 
 ## [12.0.1](https://github.com/folio-org/ui-inventory/tree/v12.0.1) (2024-11-15)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.0...v12.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * ECS | Instance details pane does not contain all tenants when user does not have affiliations / permissions in all tenants. Fixes UIIN-3113.
 * *BREAKING* Rename quick-marc routes from `bib` to `bibliographic` and `duplicate` to `derive`. Refs UIIN-3120.
 * *BREAKING* Provide necessary props for browse lookup facets. Remove the facets state reset functionality. Refs UIIN-3099.
+
+## [12.0.2] (IN PROGRESS)
 * Display informative error message when editing same instance, holdings, item in two tabs. Fixes UIIN-3127.
 
 ## [12.0.1](https://github.com/folio-org/ui-inventory/tree/v12.0.1) (2024-11-15)

--- a/src/utils.js
+++ b/src/utils.js
@@ -702,7 +702,7 @@ export const parseHttpError = async httpError => {
   let jsonError = {};
 
   try {
-    if (contentType === 'text/plain') {
+    if (contentType.includes('text/plain')) {
       jsonError.message = await httpError.text();
     } else {
       jsonError = await httpError.json();


### PR DESCRIPTION
## Purpose
* Remove **409: Server communication problem. Please try again** error message when optimistic locking error is occured. Show optimistic locking banner instead.

## Approach
* On Eureka environment `Content-type` is `text/plain; charset=UTF-8`. So, we need to add more flexible check for `Content-type`, using `includes` insted of `===`

## Refs
[UIIN-3127](https://folio-org.atlassian.net/browse/UIIN-3127)