### PR TITLE
[UIIN-3140] Add missing permission definition for sharing local instance 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * ECS | Instance details pane does not contain all tenants when user does not have affiliations / permissions in all tenants. Fixes UIIN-3113.
 * *BREAKING* Rename quick-marc routes from `bib` to `bibliographic` and `duplicate` to `derive`. Refs UIIN-3120.
 * *BREAKING* Provide necessary props for browse lookup facets. Remove the facets state reset functionality. Refs UIIN-3099.
+* Add permission for "Share local instance" option on Member tenants. Refs UIIN-3140.
 
 ## [12.0.2] (IN PROGRESS)
 * Display informative error message when editing same instance, holdings, item in two tabs. Fixes UIIN-3127.

--- a/package.json
+++ b/package.json
@@ -646,7 +646,8 @@
           "ui-inventory.instance.view",
           "inventory.instances.item.post",
           "inventory-storage.instances.item.post",
-          "browse.contributors.instances.collection.get"
+          "browse.contributors.instances.collection.get",
+          "consortia.inventory.local.sharing-instances.execute"
         ],
         "visible": true
       },


### PR DESCRIPTION
- Fixes [UIIN-3140](https://folio-org.atlassian.net/browse/UIIN-3140) "Share local instance" option is not present on Member tenants with permission
- Added `consortia.inventory.local.sharing-instances.execute` permission under `ui-inventory.instance.create`
- Application already designed to respond to permission here: https://github.com/folio-org/ui-inventory/blob/c0f11762327ab1521c29d71d4ae6390fb46ca401/src/ViewInstance.js#L759