### PR TITLE
UIIN-3144: Display user's name instead of `Unknown user` in Last updated field in `Settings` for member tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## [12.0.3] (IN PROGRESS)
 
 * Display informative error message when editing same instance, holdings, item in two tabs. Fixes UIIN-3127.
+* Display user's name instaed of "Unknown user" in "Last updated" field in "Settings" for member tenant. Fixes UIIN-3144.
 
 ## [12.0.2](https://github.com/folio-org/ui-inventory/tree/v12.0.2) (2024-11-22)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.1...v12.0.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ## [12.0.3] (IN PROGRESS)
 
 * Display informative error message when editing same instance, holdings, item in two tabs. Fixes UIIN-3127.
-* Display user's name instaed of "Unknown user" in "Last updated" field in "Settings" for member tenant. Fixes UIIN-3144.
+* Display user's name instead of "Unknown user" in "Last updated" field in "Settings" for member tenant. Fixes UIIN-3144.
 
 ## [12.0.2](https://github.com/folio-org/ui-inventory/tree/v12.0.2) (2024-11-22)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.1...v12.0.2)

--- a/package.json
+++ b/package.json
@@ -314,7 +314,8 @@
           "inventory-storage.subject-sources.item.post",
           "inventory-storage.subject-sources.item.put",
           "inventory-storage.subject-sources.item.delete",
-          "settings.inventory.enabled"
+          "settings.inventory.enabled",
+          "users.collection.get"
         ],
         "visible": true
       },
@@ -327,7 +328,8 @@
           "inventory-storage.subject-types.item.post",
           "inventory-storage.subject-types.item.put",
           "inventory-storage.subject-types.item.delete",
-          "settings.inventory.enabled"
+          "settings.inventory.enabled",
+          "users.collection.get"
         ],
         "visible": true
       },
@@ -439,7 +441,8 @@
           "inventory-storage.ill-policies.item.get",
           "inventory-storage.ill-policies.item.post",
           "inventory-storage.ill-policies.item.put",
-          "settings.inventory.enabled"
+          "settings.inventory.enabled",
+          "users.collection.get"
         ],
         "visible": true
       },
@@ -466,7 +469,8 @@
           "inventory-storage.call-number-types.item.get",
           "inventory-storage.call-number-types.item.post",
           "inventory-storage.call-number-types.item.put",
-          "settings.inventory.enabled"
+          "settings.inventory.enabled",
+          "users.collection.get"
         ],
         "visible": true
       },
@@ -509,7 +513,8 @@
           "inventory-storage.holdings-sources.item.get",
           "inventory-storage.holdings-sources.item.post",
           "inventory-storage.holdings-sources.item.put",
-          "settings.inventory.enabled"
+          "settings.inventory.enabled",
+          "users.collection.get"
         ],
         "visible": true
       },
@@ -546,7 +551,8 @@
           "configuration.entries.collection.get",
           "inventory-storage.hrid-settings.item.get",
           "inventory-storage.hrid-settings.item.put",
-          "settings.inventory.enabled"
+          "settings.inventory.enabled",
+          "users.collection.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Added `users.collection.get` to `subPermissions` in order to get users list when the following permissions are assigned separately:
**Settings (Inventory): Create, edit, delete subject sources**
**Settings (Inventory): Create, edit, delete subject types**
**Settings (Inventory): Create, edit, delete ILL policies**
**Settings (Inventory): Create, edit, delete call number types**
**Settings (Inventory): Create, edit, delete holdings sources**
**Settings (Inventory): Create, edit and delete HRID handling**

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-3144](https://folio-org.atlassian.net/browse/UIIN-3144)
