### PR TITLE
UIIN:3146: Update API URI for checkCanBeOpenedInLinkedData manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Display informative error message when editing same instance, holdings, item in two tabs. Fixes UIIN-3127.
 * Display user's name instead of "Unknown user" in "Last updated" field in "Settings" for member tenant. Fixes UIIN-3144.
+* Update Linked data API URL to use the new API path. Fixes UIIN-3146.
 
 ## [12.0.3](https://github.com/folio-org/ui-inventory/tree/v12.0.3) (2024-11-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.2...v12.0.3)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -198,7 +198,7 @@ class ViewInstance extends React.Component {
     },
     checkCanBeOpenedInLinkedData: {
       type: 'okapi',
-      path: 'resource/check/:{id}/supported',
+      path: 'linked-data/inventory-instance/:{id}/import-supported',
       accumulate: true,
       throwErrors: false,
     }


### PR DESCRIPTION
This PR addresses [UIIN-3146](https://folio-org.atlassian.net/browse/UIIN-3146)

## Purpose
The API URI `GET /resource/check/{inventoryId}/supported` has been changed to `GET /linked-data/inventory-instance/{inventoryId}/import-supported` in [mod-linked-data](https://github.com/folio-org/mod-linked-data)  as part of [MODLD-585](https://folio-org.atlassian.net/browse/MODLD-585). This Pull request makes the corresponding change in ui-inventory codebase.

## Approach
Update the API URI in [ViewInstance.js](https://github.com/folio-org/ui-inventory/compare/pjacob/UIIN-3146?expand=1#diff-a962523d8df448cf50db88af841c0c0602e66f93913b469671082cea6cf85667)

## Refs
Related tickets: 
1. [MODLD-585](https://folio-org.atlassian.net/browse/MODLD-585)
2. [UILD-428](https://folio-org.atlassian.net/browse/UILD-428)
