### PR TITLE
Revert "UIIN-3137: Add the `isSearchToggleHitInBrowse` flag to the history state to use in the condition that specifies whether to use the default sort on mount."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 * Display informative error message when editing same instance, holdings, item in two tabs. Fixes UIIN-3127.
 * Display user's name instead of "Unknown user" in "Last updated" field in "Settings" for member tenant. Fixes UIIN-3144.
 * Update Linked data API URL to use the new API path. Fixes UIIN-3146.
-* Add the `isSearchToggleHitInBrowse` flag to the history state to use in the condition that specifies whether to use the default sort on mount.  Fixes UIIN-3137.
 
 ## [12.0.3](https://github.com/folio-org/ui-inventory/tree/v12.0.3) (2024-11-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.2...v12.0.3)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -225,7 +225,6 @@ class InstancesList extends React.Component {
       data,
     } = this.props;
 
-    const { isSearchToggleHitInBrowse } = _location.state || {};
     const params = getParams();
     const defaultSort = data.displaySettings.defaultSort;
 
@@ -252,16 +251,9 @@ class InstancesList extends React.Component {
     const searchParams = new URLSearchParams(_location.search);
 
     const isStaffSuppressFilterChanged = this.applyDefaultStaffSuppressFilter(searchParams);
-    let isSortingChanged = false;
 
-    // don't set the default sort when redirecting from Browse search by hitting the Search toggle,
-    // the previously selected sort option should be used (it will be taken from session storage).
-    if (params.sort !== defaultSort && !isSearchToggleHitInBrowse) {
-      isSortingChanged = true;
+    if (params.sort !== defaultSort || isStaffSuppressFilterChanged) {
       searchParams.set('sort', defaultSort);
-    }
-
-    if (isSortingChanged || isStaffSuppressFilterChanged) {
       this.redirectToSearchParams(searchParams);
     }
   }

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -314,13 +314,7 @@ describe('InstancesList', () => {
         it('should call history.replace with sort parameter from Settings', () => {
           jest.spyOn(history, 'replace');
 
-          history.push({
-            pathname: '/inventory',
-            search: '?filters=staffSuppress.false&sort=title',
-            state: {
-              isSearchToggleHitInBrowse: false,
-            },
-          });
+          history.push('/inventory?filters=staffSuppress.false&sort=title');
 
           renderInstancesList({
             segment: 'instances',
@@ -335,41 +329,10 @@ describe('InstancesList', () => {
             },
           });
 
-          expect(history.replace).toHaveBeenLastCalledWith(expect.objectContaining({
-            search: expect.stringContaining('sort=relevance'),
-          }));
-        });
-
-        describe('and redirection from Browse search by pressing Search toggle', () => {
-          it('should not call history.replace with sort parameter from Settings', () => {
-            jest.spyOn(history, 'replace');
-
-            history.push({
-              pathname: '/inventory',
-              search: '?filters=staffSuppress.false&sort=title',
-              state: {
-                isSearchToggleHitInBrowse: true,
-              },
-            });
-
-            const defaultSort = SORT_OPTIONS.RELEVANCE;
-
-            renderInstancesList({
-              segment: segments.instances,
-              data: {
-                ...data,
-                query: {
-                  query: '',
-                },
-                displaySettings: {
-                  defaultSort,
-                },
-              },
-            });
-
-            expect(history.replace).not.toHaveBeenLastCalledWith(expect.objectContaining({
-              search: expect.stringContaining(`sort=${defaultSort}`),
-            }));
+          expect(history.replace).toHaveBeenLastCalledWith({
+            pathname: '/inventory',
+            search: 'filters=staffSuppress.false&sort=relevance',
+            state: undefined,
           });
         });
       });

--- a/src/views/BrowseInventory/BrowseInventory.js
+++ b/src/views/BrowseInventory/BrowseInventory.js
@@ -197,9 +197,6 @@ const BrowseInventory = () => {
         >
           <SearchModeNavigation
             search={getLastSearch()}
-            state={{
-              isSearchToggleHitInBrowse: true,
-            }}
           />
 
           <SingleSearchForm

--- a/src/views/BrowseInventory/BrowseInventory.test.js
+++ b/src/views/BrowseInventory/BrowseInventory.test.js
@@ -142,17 +142,11 @@ describe('BrowseInventory', () => {
 
   it('should have search prop in SearchModeNavigation component', () => {
     const search = '?qindex=title&query=book&sort=title';
-    const state = {
-      isSearchToggleHitInBrowse: true,
-    };
 
     mockGetLastSearch.mockClear().mockImplementation(() => search);
     renderBrowseInventory();
 
-    expect(SearchModeNavigation).toHaveBeenCalledWith({
-      search,
-      state,
-    }, {});
+    expect(SearchModeNavigation).toHaveBeenCalledWith({ search }, {});
     mockGetLastSearch.mockRestore();
   });
 


### PR DESCRIPTION
Reverts folio-org/ui-inventory#2682