### PR TITLE
UIIN-3137: Set default sorting to URL in `componentDidMount` and `componentDidUpdate` if it is missing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * React v19: refactor away from default props for functional components. Refs UIIN-2890.
 * User can edit Source consortium "Holdings sources" in member tenant but not in Consortia manager. Refs UIIN-3147.
 
+## [12.0.5] (IN PROGRESS)
+
+* Set default sorting to URL in componentDidMount and componentDidUpdate if it is missing. Fixes UIIN-3137.
+
 ## [12.0.4] (IN PROGRESS)
 
 * Display informative error message when editing same instance, holdings, item in two tabs. Fixes UIIN-3127.

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -182,7 +182,6 @@ class InstancesList extends React.Component {
       replace: PropTypes.func,
     }),
     getLastBrowse: PropTypes.func.isRequired,
-    getLastSearch: PropTypes.func.isRequired,
     getLastSearchOffset: PropTypes.func.isRequired,
     storeLastSearch: PropTypes.func.isRequired,
     storeLastSearchOffset: PropTypes.func.isRequired,
@@ -251,9 +250,14 @@ class InstancesList extends React.Component {
     const searchParams = new URLSearchParams(_location.search);
 
     const isStaffSuppressFilterChanged = this.applyDefaultStaffSuppressFilter(searchParams);
+    let isSortingUpdated = false;
 
-    if (params.sort !== defaultSort || isStaffSuppressFilterChanged) {
+    if (!params.sort) {
+      isSortingUpdated = true;
       searchParams.set('sort', defaultSort);
+    }
+
+    if (isSortingUpdated || isStaffSuppressFilterChanged) {
       this.redirectToSearchParams(searchParams);
     }
   }
@@ -287,14 +291,19 @@ class InstancesList extends React.Component {
     const searchParams = new URLSearchParams(location.search);
 
     let isStaffSuppressFilterChanged = false;
+    let isSortingUpdated = false;
 
     if (prevProps.segment !== this.props.segment) {
       isStaffSuppressFilterChanged = this.applyDefaultStaffSuppressFilter(searchParams);
     }
 
     // `sort` is missing after reset button is hit
-    if (!sortBy || isStaffSuppressFilterChanged) {
+    if (!sortBy) {
+      isSortingUpdated = true;
       searchParams.set('sort', data.displaySettings.defaultSort);
+    }
+
+    if (isSortingUpdated || isStaffSuppressFilterChanged) {
       this.redirectToSearchParams(searchParams);
     }
 
@@ -390,33 +399,13 @@ class InstancesList extends React.Component {
   processLastSearchTermsOnMount = () => {
     const {
       getParams,
-      location,
       parentMutator,
       getLastSearchOffset,
-      getLastSearch,
-      storeLastSearch,
       segment: currentSegment,
     } = this.props;
     const params = getParams();
     const lastSearchOffset = getLastSearchOffset(currentSegment);
     const offset = params.selectedBrowseResult === 'true' ? 0 : lastSearchOffset;
-
-    // Remove the sort option on mount from last searches, as the sort option from Settings should be used
-    // until it is changed there or via the result headers or actions.
-    const storeLastSearchWithoutSortParam = (search, segment) => {
-      const searchParams = new URLSearchParams(search);
-      searchParams.delete('sort');
-      storeLastSearch(`?${searchParams.toString()}`, segment);
-    };
-
-    Object.values(segments).forEach(segment => {
-      if (segment === currentSegment) {
-        storeLastSearchWithoutSortParam(location.search, currentSegment);
-      } else {
-        const lastSegmentSearch = getLastSearch(segment);
-        storeLastSearchWithoutSortParam(lastSegmentSearch, segment);
-      }
-    });
 
     parentMutator.resultOffset.replace(offset);
   }

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -291,27 +291,8 @@ describe('InstancesList', () => {
     });
 
     describe('when the component is mounted', () => {
-      it('should write location.search to the session storage and delete "sort" from all stored searches', () => {
-        history.push({ search: '?qindex=title&query=book&sort=title' });
-
-        const getLastSearch = jest.fn(segment => {
-          if (segment === segments.holdings) return '?query=foo&segment=holdings&sort=title';
-          if (segment === segments.items) return '?query=foo&segment=items&sort=title';
-          return '?qindex=title&query=book&sort=title';
-        });
-
-        renderInstancesList({
-          segment: segments.instances,
-          getLastSearch,
-        });
-
-        expect(mockStoreLastSearch).toHaveBeenNthCalledWith(1, '?qindex=title&query=book', segments.instances);
-        expect(mockStoreLastSearch).toHaveBeenNthCalledWith(2, '?query=foo&segment=holdings', segments.holdings);
-        expect(mockStoreLastSearch).toHaveBeenNthCalledWith(3, '?query=foo&segment=items', segments.items);
-      });
-
       describe('and sort parameter does not match the one selected in Settings', () => {
-        it('should call history.replace with sort parameter from Settings', () => {
+        it('should not be replaced', () => {
           jest.spyOn(history, 'replace');
 
           history.push('/inventory?filters=staffSuppress.false&sort=title');
@@ -329,11 +310,33 @@ describe('InstancesList', () => {
             },
           });
 
-          expect(history.replace).toHaveBeenLastCalledWith({
-            pathname: '/inventory',
-            search: 'filters=staffSuppress.false&sort=relevance',
-            state: undefined,
+          expect(history.replace).not.toHaveBeenLastCalledWith(expect.objectContaining({
+            search: expect.stringContaining('sort=relevance'),
+          }));
+        });
+      });
+
+      describe('and sort parameter is missing', () => {
+        it('should call history.replace with the default sort parameter', () => {
+          jest.spyOn(history, 'replace');
+
+          history.push('/inventory?filters=staffSuppress.false');
+
+          renderInstancesList({
+            data: {
+              ...data,
+              query: {
+                query: '',
+              },
+              displaySettings: {
+                defaultSort: SORT_OPTIONS.RELEVANCE,
+              },
+            },
           });
+
+          expect(history.replace).toHaveBeenLastCalledWith(expect.objectContaining({
+            search: expect.stringContaining('sort=relevance'),
+          }));
         });
       });
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Use default sorting only if it is not present in the URL (reset button pressed or sorting manually removed).
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
- `componentDidMount`: if `sort` option is not present (manually removed), add it to `searchParams`;
- `componentDidUpdate`: if `sort` option is not present (reset button hit), add it to `searchParams`.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-3137](https://folio-org.atlassian.net/browse/UIIN-3137)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots

https://github.com/user-attachments/assets/f76c8a0d-7ca4-4861-8f99-1a9d946c2ffa



<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
