### PR TITLE
UIIN-2888: React 19: refactor away from react-dom/test-utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add permission for "Share local instance" option on Member tenants. Refs UIIN-3140.
 * React v19: refactor away from default props for functional components. Refs UIIN-2890.
 * User can edit Source consortium "Holdings sources" in member tenant but not in Consortia manager. Refs UIIN-3147.
+* React 19: refactor away from react-dom/test-utils. Refs UIIN-2888.
 
 ## [12.0.4] (IN PROGRESS)
 

--- a/src/Instance/InstanceEdit/InstanceField/InstanceField.test.js
+++ b/src/Instance/InstanceEdit/InstanceField/InstanceField.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import { act, screen } from '@folio/jest-config-stripes/testing-library/react';
 import { noop, keyBy } from 'lodash';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { act } from 'react-dom/test-utils';
+
 import '../../../../test/jest/__mock__';
 
 import { StripesContext } from '@folio/stripes/core';

--- a/src/Instance/ItemsList/ItemsListContainer.test.js
+++ b/src/Instance/ItemsList/ItemsListContainer.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { act } from 'react-dom/test-utils';
+import { act } from '@folio/jest-config-stripes/testing-library/react';
 
 import '../../../test/jest/__mock__';
 

--- a/src/Instance/ItemsList/tests/ItemsList.test.js
+++ b/src/Instance/ItemsList/tests/ItemsList.test.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { act } from 'react-dom/test-utils';
-import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import { act, screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import '../../../../test/jest/__mock__';
 

--- a/src/components/ViewSource/ViewSource.test.js
+++ b/src/components/ViewSource/ViewSource.test.js
@@ -3,9 +3,9 @@ import {
   BrowserRouter as Router,
   useHistory,
 } from 'react-router-dom';
-import { act } from 'react-dom/test-utils';
 
 import {
+  act,
   screen,
   waitFor,
   fireEvent,
@@ -27,7 +27,6 @@ jest.mock('react-router-dom', () => ({
     push: jest.fn(),
   }),
 }));
-
 jest.mock('../../common/hooks/useGoBack', () => jest.fn());
 jest.mock('../../hooks', () => ({
   ...jest.requireActual('../../hooks'),


### PR DESCRIPTION
## Approach
* Use `act` from `@folio/jest-config-stripes/testing-library/react` instead of `react-dom/test-utils`

## Refs
[UIIN-2888](https://folio-org.atlassian.net/browse/UIIN-2888)
