### PR TITLE
UIIN-3163 Add `limit=1000` to `subject-sources` request to fetch more subject sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * User can edit Source consortium "Holdings sources" in member tenant but not in Consortia manager. Refs UIIN-3147.
 * React 19: refactor away from react-dom/test-utils. Refs UIIN-2888.
 
+## [12.0.7] (IN PROGRESS)
+
+* Add `limit=1000` to `subject-sources` request to fetch more subject sources. Fixes UIIN-3163.
+
 ## [12.0.5] (IN PROGRESS)
 
 * Display informative error message when editing same instance, holdings, item in two tabs. Fixes UIIN-3127.

--- a/src/providers/DataProvider.js
+++ b/src/providers/DataProvider.js
@@ -195,7 +195,7 @@ DataProvider.manifest = {
   },
   subjectSources: {
     type: 'okapi',
-    path: 'subject-sources?query=cql.allRecords=1 sortby name',
+    path: 'subject-sources?limit=1000&query=cql.allRecords=1 sortby name',
     records: 'subjectSources',
     resourceShouldRefresh: true,
     throwErrors: false,


### PR DESCRIPTION
## Description
By default okapi returns 10 items in a collection and that resulted Subject source facet to have some options to not display subject source names

## Screenshots

https://github.com/user-attachments/assets/6c922dcc-9db9-483d-ac20-3632c5b492e6



## Issues
[UIIN-3163](https://folio-org.atlassian.net/browse/UIIN-3163)