### PR TITLE
UIIN-3161 Handle `null` `typeIds` in `browse/config/instance-classification` response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * User can edit Source consortium "Holdings sources" in member tenant but not in Consortia manager. Refs UIIN-3147.
 * React 19: refactor away from react-dom/test-utils. Refs UIIN-2888.
 
+## [12.0.7] (IN PROGRESS)
+
+* Handle `null` `typeIds` in `browse/config/instance-classification` response. Fixes UIIN-3161.
+
 ## [12.0.5] (IN PROGRESS)
 
 * Display informative error message when editing same instance, holdings, item in two tabs. Fixes UIIN-3127.

--- a/src/components/BrowseResultsList/utils.js
+++ b/src/components/BrowseResultsList/utils.js
@@ -87,7 +87,7 @@ const getClassificationQuery = (qindex, data, row) => {
     .find(config => config.id === classificationBrowseConfigId)?.typeIds;
 
   const classificationBrowseTypesQuery = classificationBrowseTypes
-    .map(typeId => `classifications.classificationTypeId=="${typeId}"`)
+    ?.map(typeId => `classifications.classificationTypeId=="${typeId}"`)
     .join(' or ');
 
   if (classificationBrowseTypesQuery) {


### PR DESCRIPTION
## Description
Handle `null` `typeIds` in `browse/config/instance-classification` response. This can happend after a migration.

## Screenshots

https://github.com/user-attachments/assets/0867cc5b-1071-4eb0-a62f-f69cec889f94


## Issues
[UIIN-3161](https://folio-org.atlassian.net/browse/UIIN-3161)