### PR TITLE
UIIN-3159: Display holdings names in `Consortial holdings` accordion for user without inventory permissions in member tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * User can edit Source consortium "Holdings sources" in member tenant but not in Consortia manager. Refs UIIN-3147.
 * React 19: refactor away from react-dom/test-utils. Refs UIIN-2888.
 * Add call number browse settings. Refs UIIN-3116.
+* Display holdings names in `Consortial holdings` accordion for user without inventory permissions in member tenants. Fixes UIIN-3159
 
 ## [12.0.7](https://github.com/folio-org/ui-inventory/tree/v12.0.7) (2024-12-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.6...v12.0.7)

--- a/src/Instance/HoldingsList/consortium/LimitedHolding/LimitedHolding.js
+++ b/src/Instance/HoldingsList/consortium/LimitedHolding/LimitedHolding.js
@@ -30,6 +30,7 @@ const LimitedHolding = ({
   instance,
   holding,
   tenantId,
+  locationName,
   userTenantPermissions,
   pathToAccordionsState,
 }) => {
@@ -56,7 +57,7 @@ const LimitedHolding = ({
 
   const accordionLabel = (
     <HoldingAccordionLabel
-      location=" "
+      location={locationName}
       holding={holding}
     />
   );
@@ -105,6 +106,7 @@ LimitedHolding.propTypes = {
   instance: PropTypes.object.isRequired,
   holding: PropTypes.object.isRequired,
   tenantId: PropTypes.string.isRequired,
+  locationName: PropTypes.string.isRequired,
   userTenantPermissions: PropTypes.arrayOf(PropTypes.object).isRequired,
   pathToAccordionsState: PropTypes.arrayOf(PropTypes.string),
 };

--- a/src/Instance/HoldingsList/consortium/LimitedHoldingsList/LimitedHoldingsList.js
+++ b/src/Instance/HoldingsList/consortium/LimitedHoldingsList/LimitedHoldingsList.js
@@ -1,5 +1,7 @@
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 
+import { DataContext } from '../../../../contexts';
 import { LimitedHolding } from '../LimitedHolding';
 
 const LimitedHoldingsList = ({
@@ -9,12 +11,15 @@ const LimitedHoldingsList = ({
   userTenantPermissions,
   pathToAccordionsState,
 }) => {
+  const { locationsById } = useContext(DataContext);
+
   return holdings.map((holding, i) => (
     <LimitedHolding
       key={`${holding.id}_${i}`}
       instance={instance}
       holding={holding}
       tenantId={tenantId}
+      locationName={locationsById[holding.permanentLocationId].name}
       userTenantPermissions={userTenantPermissions}
       pathToAccordionsState={pathToAccordionsState}
     />


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
* Holdings locations in **Consortial holdings** accordion should be displayed regardless of user permissions and affiliations.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Get location's name from the global context, where are stored all the user's locations.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-3159](https://folio-org.atlassian.net/browse/UIIN-3159)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
### Before
![image](https://github.com/user-attachments/assets/129be316-c070-4cd6-b987-b504a95c1266)

### After
![image](https://github.com/user-attachments/assets/c62abc77-8984-4ce3-89a1-407e40094bff)