### PR TITLE
UIIN-3106: Add 'linked-data' interface to 'optionalOkapiInterfaces'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add call number browse settings. Refs UIIN-3116.
 * Remove the ability to share local instance when `Inventory: View, create instances` permission is assigned. Fixes UIIN-3166.
 * Display holdings names in `Consortial holdings` accordion for user without inventory permissions in member tenants. Fixes UIIN-3159
+* Add "linked-data 1.0" interface to "optionalOkapiInterfaces". Refs UIIN-3166.
 
 ## [12.0.7](https://github.com/folio-org/ui-inventory/tree/v12.0.7) (2024-12-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.6...v12.0.7)

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
       "orders-storage.settings": "1.0",
       "organizations.organizations": "1.0",
       "pieces": "3.0",
-      "titles": "1.2"
+      "titles": "1.2",
+      "linked-data": "1.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
<!--
[UIIN-3106](https://folio-org.atlassian.net/browse/UIIN-3106)
-->

## Purpose
Inventory UI makes API call to the following API in linked-data module
[GET linked-data/inventory-instance/:{id}/import-supported](https://github.com/folio-org/mod-linked-data/blob/master/descriptors/ModuleDescriptor-template.json#L95)

Per [stripes documentation](https://github.com/folio-org/stripes/blob/8790eaaccc2fa58f5500570f5bdc6a47c7a53ff3/doc/dev-guide.md), the optional interfaces that UI module uses should be declared in `optionalOkapiInterfaces` section of package.json file. 

Purpose of this PR is to update `optionalOkapiInterfaces` section of the package.json with the following
`"linked-data": "1.0"`
