### PR TITLE
UIIN-3167: Fix errors after cancel edit/duplicate or 'Save & Close' consortial holdings/items 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Remove the ability to share local instance when `Inventory: View, create instances` permission is assigned. Fixes UIIN-3166.
 * Display holdings names in `Consortial holdings` accordion for user without inventory permissions in member tenants. Fixes UIIN-3159
 * Add "linked-data 1.0" interface to "optionalOkapiInterfaces". Refs UIIN-3166.
+* Fix infinite loading animation after cancel edit/duplicate or 'Save & Close' consortial holdings/items. Fixes UIIN-3167.
 
 ## [12.0.7](https://github.com/folio-org/ui-inventory/tree/v12.0.7) (2024-12-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.6...v12.0.7)

--- a/src/Holding/DuplicateHolding/DuplicateHolding.js
+++ b/src/Holding/DuplicateHolding/DuplicateHolding.js
@@ -28,6 +28,7 @@ const DuplicateHolding = ({
     state: {
       backPathname: locationState,
       tenantFrom,
+      initialTenantId,
     } = {},
   },
   referenceTables,
@@ -72,12 +73,13 @@ const DuplicateHolding = ({
     history.push({
       pathname: locationState?.backPathname ?? `/inventory/view/${instanceId}`,
       search,
+      state: { initialTenantId },
     });
   }, [search, instanceId]);
 
   const onCancel = useCallback(async () => {
-    await switchAffiliation(stripes, tenantFrom, goBack);
-  }, [stripes, tenantFrom, goBack]);
+    await switchAffiliation(stripes, initialTenantId, goBack);
+  }, [stripes, initialTenantId, goBack]);
 
   const onSubmit = useCallback(holdingValues => (
     mutateHolding(holdingValues)

--- a/src/Holding/EditHolding/EditHolding.js
+++ b/src/Holding/EditHolding/EditHolding.js
@@ -17,10 +17,7 @@ import {
 } from '../../hooks';
 import HoldingsForm from '../../edit/holdings/HoldingsForm';
 import withLocation from '../../withLocation';
-import {
-  parseHttpError,
-  switchAffiliation,
-} from '../../utils';
+import { parseHttpError } from '../../utils';
 
 const EditHolding = ({
   goTo,
@@ -35,7 +32,7 @@ const EditHolding = ({
     search,
     state: {
       backPathname: locationState,
-      tenantFrom,
+      initialTenantId,
     } = {},
   } = location;
   const stripes = useStripes();
@@ -59,16 +56,13 @@ const EditHolding = ({
     history.push({
       pathname: locationState?.backPathname ?? `/inventory/view/${instanceId}/${holdingId}`,
       search,
+      state: { initialTenantId },
     });
   }, [search, instanceId, holdingId]);
 
-  const onCancel = useCallback(async () => {
-    await switchAffiliation(stripes, tenantFrom, goBack);
-  }, [stripes, tenantFrom, goBack]);
-
-  const onSuccess = useCallback(async () => {
+  const onSuccess = useCallback(() => {
     if (!keepEditing.current) {
-      await switchAffiliation(stripes, tenantFrom, goBack);
+      goBack();
     } else {
       refetchHolding();
     }
@@ -80,7 +74,7 @@ const EditHolding = ({
         values={{ hrid: holding?.hrid }}
       />,
     });
-  }, [switchAffiliation, stripes, tenantFrom, goBack, refetchHolding, holding, callout]);
+  }, [goBack, refetchHolding, holding, callout]);
 
   const onError = async error => {
     const parsedError = await parseHttpError(error.response);
@@ -107,7 +101,7 @@ const EditHolding = ({
         location={location}
         initialValues={holding}
         onSubmit={onSubmit}
-        onCancel={onCancel}
+        onCancel={goBack}
         okapi={stripes.okapi}
         instance={instance}
         referenceTables={referenceTables}

--- a/src/Instance/ItemsList/ItemBarcode.js
+++ b/src/Instance/ItemsList/ItemBarcode.js
@@ -52,7 +52,7 @@ const ItemBarcode = ({
       search,
       state: {
         tenantTo: tenantId,
-        tenantFrom: stripes.okapi.tenant,
+        initialTenantId: stripes.okapi.tenant,
       },
     });
 

--- a/src/Instance/utils.js
+++ b/src/Instance/utils.js
@@ -56,6 +56,7 @@ export const navigateToHoldingsViewPage = (history, location, instance, holding,
     state: {
       tenantTo,
       tenantFrom,
+      initialTenantId: tenantFrom,
     },
   });
 };

--- a/src/Item/DuplicateItem/DuplicateItem.js
+++ b/src/Item/DuplicateItem/DuplicateItem.js
@@ -82,7 +82,10 @@ const DuplicateItem = ({
     history.push({
       pathname: `/inventory/view/${instanceId}/${holdingId}/${itemId}`,
       search: location.search,
-      state: { tenantTo: stripes.okapi.tenant },
+      state: {
+        tenantTo: stripes.okapi.tenant,
+        initialTenantId: location?.state?.initialTenantId,
+      },
     });
   }, [location.search, instanceId, holdingId, itemId]);
 

--- a/src/Item/EditItem/EditItem.js
+++ b/src/Item/EditItem/EditItem.js
@@ -18,7 +18,7 @@ import {
 } from '../../common';
 import ItemForm from '../../edit/items/ItemForm';
 import useCallout from '../../hooks/useCallout';
-import { parseHttpError, switchAffiliation } from '../../utils';
+import { parseHttpError } from '../../utils';
 import {
   useItem,
   useItemMutation,
@@ -49,18 +49,16 @@ const EditItem = ({
     history.push({
       pathname: `/inventory/view/${instanceId}/${holdingId}/${itemId}`,
       search: location.search,
-      state: { tenantTo: stripes.okapi.tenant },
+      state: {
+        tenantTo: stripes.okapi.tenant,
+        initialTenantId: location?.state?.initialTenantId,
+      },
     });
   }, [location.search, instanceId, holdingId, itemId]);
 
-  const onCancel = useCallback(async () => {
-    await switchAffiliation(stripes, location?.state?.tenantFrom, goBack);
-  }, [stripes, location?.state?.tenantFrom, goBack]);
-
-
-  const onSuccess = useCallback(async () => {
+  const onSuccess = useCallback(() => {
     if (!keepEditing.current) {
-      await switchAffiliation(stripes, location?.state?.tenantFrom, goBack);
+      goBack();
     } else {
       refetchItem();
     }
@@ -72,7 +70,7 @@ const EditItem = ({
         values={{ hrid: item.hrid }}
       />,
     });
-  }, [switchAffiliation, stripes, location, goBack, refetchItem, callout, item]);
+  }, [goBack, refetchItem, callout, item]);
 
   const onError = async error => {
     const parsedError = await parseHttpError(error.response);
@@ -129,7 +127,7 @@ const EditItem = ({
         key={holding.id}
         initialValues={item}
         onSubmit={onSubmit}
-        onCancel={onCancel}
+        onCancel={goBack}
         okapi={stripes.okapi}
         instance={instance}
         holdingsRecord={holding}

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -250,7 +250,7 @@ class ViewHoldingsRecord extends React.Component {
       stripes,
       location,
     } = this.props;
-    const tenantFrom = location?.state?.tenantFrom || stripes.okapi.tenant;
+    const tenantFrom = location?.state?.initialTenantId || stripes.okapi.tenant;
 
     await switchAffiliation(stripes, tenantFrom, this.goToInstanceView);
   }
@@ -264,17 +264,15 @@ class ViewHoldingsRecord extends React.Component {
       location,
       id,
       holdingsrecordid,
-      stripes,
+      initialTenantId,
     } = this.props;
-
-    const tenantFrom = location?.state?.tenantFrom || stripes.okapi.tenant;
 
     history.push({
       pathname: `/inventory/edit/${id}/${holdingsrecordid}`,
       search: location.search,
       state: {
         backPathname: location.pathname,
-        tenantFrom,
+        initialTenantId,
       },
     });
   }
@@ -288,9 +286,10 @@ class ViewHoldingsRecord extends React.Component {
       id,
       holdingsrecordid,
       stripes,
+      initialTenantId,
     } = this.props;
 
-    const tenantFrom = location?.state?.tenantFrom || stripes.okapi.tenant;
+    const tenantFrom = stripes.okapi.tenant;
 
     history.push({
       pathname: `/inventory/copy/${id}/${holdingsrecordid}`,
@@ -298,6 +297,7 @@ class ViewHoldingsRecord extends React.Component {
       state: {
         backPathname: location.pathname,
         tenantFrom,
+        initialTenantId,
       },
     });
   }
@@ -641,10 +641,8 @@ class ViewHoldingsRecord extends React.Component {
       referenceTables,
       goTo,
       stripes,
-      location,
     } = this.props;
     const { instance } = this.state;
-    const tenantFrom = location?.state?.tenantFrom || stripes.okapi.tenant;
 
     if (this.isAwaitingResource()) return <LoadingView />;
 
@@ -957,9 +955,7 @@ class ViewHoldingsRecord extends React.Component {
                     updatedDate: getDate(holdingsRecord?.metadata?.updatedDate),
                   })}
                   dismissible
-                  onClose={async () => {
-                    await switchAffiliation(stripes, tenantFrom, this.onClose);
-                  }}
+                  onClose={this.onClose}
                   actionMenu={this.getPaneHeaderActionMenu}
                 >
                   <Row center="xs">
@@ -1390,6 +1386,7 @@ ViewHoldingsRecord.propTypes = {
   goTo: PropTypes.func.isRequired,
   isInstanceShared: PropTypes.bool,
   onUpdateOwnership: PropTypes.func,
+  initialTenantId: PropTypes.string,
 };
 
 export default flowRight(

--- a/src/ViewHoldingsRecord.test.js
+++ b/src/ViewHoldingsRecord.test.js
@@ -132,6 +132,7 @@ const defaultProps = {
       tenantFrom: 'testTenantFromId',
     }
   },
+  initialTenantId: 'initialTenantId',
 };
 
 const queryClient = new QueryClient();
@@ -246,7 +247,7 @@ describe('ViewHoldingsRecord actions', () => {
         search: defaultProps.location.search,
         state: {
           backPathname: defaultProps.location.pathname,
-          tenantFrom: 'testTenantFromId',
+          initialTenantId: 'initialTenantId',
         },
       };
       renderViewHoldingsRecord();
@@ -274,7 +275,8 @@ describe('ViewHoldingsRecord actions', () => {
         search: defaultProps.location.search,
         state: {
           backPathname: defaultProps.location.pathname,
-          tenantFrom: 'testTenantFromId',
+          tenantFrom: 'diku',
+          initialTenantId: 'initialTenantId',
         },
       };
 

--- a/src/routes/ItemRoute.js
+++ b/src/routes/ItemRoute.js
@@ -26,6 +26,7 @@ const ItemRoute = props => {
           {...props}
           isInstanceShared={instance?.shared}
           tenantTo={state?.tenantTo || okapi.tenant}
+          initialTenantId={state?.initialTenantId || okapi.tenant}
           referenceTables={data}
         />
       )}
@@ -39,7 +40,6 @@ ItemRoute.propTypes = {
   location: PropTypes.object,
   resources: PropTypes.object,
   stripes: PropTypes.object,
-  tenantFrom: PropTypes.string,
   history: PropTypes.object,
 };
 

--- a/src/routes/ViewHoldingRoute.js
+++ b/src/routes/ViewHoldingRoute.js
@@ -25,6 +25,7 @@ const ViewHoldingRoute = () => {
       id={instanceId}
       isInstanceShared={instance?.shared}
       tenantTo={state?.tenantTo || okapi.tenant}
+      initialTenantId={state?.initialTenantId || okapi.tenant}
       referenceTables={referenceTables}
       holdingsrecordid={holdingsrecordid}
       onUpdateOwnership={updateOwnership}

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -144,6 +144,7 @@ const ItemView = props => {
     },
     goTo,
     isInstanceShared,
+    initialTenantId,
   } = props;
 
   const ky = useOkapiKy();
@@ -176,13 +177,16 @@ const ItemView = props => {
   const onClickEditItem = e => {
     if (e) e.preventDefault();
 
-    const tenantFrom = location?.state?.tenantFrom || stripes.okapi.tenant;
+    const tenantFrom = stripes.okapi.tenant;
     const { id, holdingsrecordid, itemid } = match.params;
 
     history.push({
       pathname: `/inventory/edit/${id}/${holdingsrecordid}/${itemid}`,
       search: location.search,
-      state: { tenantFrom }
+      state: {
+        tenantFrom,
+        initialTenantId,
+      }
     });
   };
 
@@ -200,7 +204,7 @@ const ItemView = props => {
   };
 
   const onCloseViewItem = async () => {
-    const tenantFrom = location?.state?.tenantFrom || stripes.okapi.tenant;
+    const tenantFrom = location?.state?.initialTenantId || stripes.okapi.tenant;
 
     await switchAffiliation(stripes, tenantFrom, () => goBack(tenantFrom));
   };
@@ -212,12 +216,15 @@ const ItemView = props => {
 
   const onCopy = () => {
     const { itemid, id, holdingsrecordid } = match.params;
-    const tenantFrom = location?.state?.tenantFrom || stripes.okapi.tenant;
+    const tenantFrom = stripes.okapi.tenant;
 
     history.push({
       pathname: `/inventory/copy/${id}/${holdingsrecordid}/${itemid}`,
       search: location.search,
-      state: { tenantFrom },
+      state: {
+        tenantFrom,
+        initialTenantId,
+      },
     });
   };
 
@@ -1938,6 +1945,7 @@ ItemView.propTypes = {
   match: PropTypes.object.isRequired,
   history: PropTypes.object.isRequired,
   isInstanceShared: PropTypes.bool,
+  initialTenantId: PropTypes.string,
 };
 
 export default flowRight(


### PR DESCRIPTION
## Purpose
* Remove errors after cancel edit/duplicate or 'Save & Close' consortial holdings/items.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Add `initialTenantId` prop in order to have the ability to return to the initial tenant after cancelling edit/duplicate holdings/items.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-3167](https://folio-org.atlassian.net/browse/UIIN-3167)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
### Cancel edit/duplicate holdings
https://github.com/user-attachments/assets/feba3f64-daed-41ae-a873-7c5606f518a2

### Cancel edit/duplicate items
https://github.com/user-attachments/assets/4da5917f-2adf-4f94-8758-71f26fc4b17e

### Edit/duplicate holdings
https://github.com/user-attachments/assets/723ed14c-da36-48a2-bffd-1db6e69af614

### Edit/duplicate items
https://github.com/user-attachments/assets/67d35a62-b068-49a0-a6af-1d4fe8e33073