### PR TITLE
UIIN-3131: Remove hover-over text next to "Effective call number" on the Item record detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add call number browse settings. Refs UIIN-3116.
 * Add "linked-data 1.0" interface to "optionalOkapiInterfaces". Refs UIIN-3166.
 * Fix infinite loading animation after cancel edit/duplicate or 'Save & Close' consortial holdings/items. Fixes UIIN-3167.
+* Remove hover-over text next to "Effective call number" on the Item record detail view. Refs UIIN-3131.
 
 ## [12.0.8](https://github.com/folio-org/ui-inventory/tree/v12.0.8) (2024-12-24)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.7...v12.0.8)

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -1143,11 +1143,6 @@ const ItemView = props => {
                     label={<FormattedMessage id="ui-inventory.effectiveCallNumber" />}
                     value={effectiveCallNumber(item)}
                   />
-                  <InfoPopover
-                    iconSize="medium"
-                    content={<FormattedMessage id="ui-inventory.info.effectiveCallNumber" />}
-                    buttonProps={{ 'data-testid': 'info-icon-effective-call-number' }}
-                  />
                 </Layout>
               </Col>
               <Col xs={7}>

--- a/src/views/ItemView.test.js
+++ b/src/views/ItemView.test.js
@@ -283,7 +283,6 @@ describe('ItemView', () => {
     });
 
     it('should display the information icons', () => {
-      expect(screen.getAllByTestId('info-icon-effective-call-number')[0]).toBeDefined();
       expect(screen.getAllByTestId('info-icon-shelving-order')[0]).toBeDefined();
     });
 

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -867,7 +867,6 @@
   "administrativeNote": "Administrative note",
   "administrativeNotes": "Administrative notes",
   "linkedToMarcAuthority": "Linked to MARC authority",
-  "info.effectiveCallNumber": "This field contains the item call number, which is either inherited from the holdings record, or is the updated call number on the item record. While browsing call numbers, this field will be searched.",
   "info.shelvingOrder": "This field is the normalized form of the call number which determines how the call number is sorted while browsing.",
 
   "shortcut.nextSubfield": "quickMARC only: Move to the next subfield in a text box",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Remove information icon and hover over text next to the field “Effective call number”.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Remove info popover.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3131

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
