### PR TITLE
UIIN-3025 Change import of `exportToCsv` from `stripes-util` to `stripes-components`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add "linked-data 1.0" interface to "optionalOkapiInterfaces". Refs UIIN-3166.
 * Fix infinite loading animation after cancel edit/duplicate or 'Save & Close' consortial holdings/items. Fixes UIIN-3167.
 * Remove hover-over text next to "Effective call number" on the Item record detail view. Refs UIIN-3131.
+* Change import of `exportToCsv` from `stripes-util` to `stripes-components`. Refs UIIN-3025.
 
 ## [12.0.8](https://github.com/folio-org/ui-inventory/tree/v12.0.8) (2024-12-24)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.7...v12.0.8)

--- a/src/reports/IdReportGenerator.js
+++ b/src/reports/IdReportGenerator.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import { noop } from 'lodash';
 
-import { exportCsv } from '@folio/stripes/util';
+import { exportToCsv } from '@folio/stripes/components';
 
 import { isTestEnv } from '../utils';
 
@@ -29,7 +29,7 @@ class IdReportGenerator {
       header: false,
       filename: this.getCSVFileName(),
     };
-    const generateReport = !isTestEnv() ? exportCsv : noop;
+    const generateReport = !isTestEnv() ? exportToCsv : noop;
 
     generateReport(parsedRecords, fileTitle);
   }

--- a/src/reports/InTransitItemsReport.js
+++ b/src/reports/InTransitItemsReport.js
@@ -1,4 +1,4 @@
-import { exportCsv } from '@folio/stripes/util';
+import { exportToCsv } from '@folio/stripes/components';
 
 const columns = [
   'barcode',
@@ -92,7 +92,7 @@ class InTransitItemsReport {
     const records = await this.fetchData();
     const parsedRecords = this.parse(records);
 
-    exportCsv(parsedRecords, { onlyFields, filename: 'InTransit' });
+    exportToCsv(parsedRecords, { onlyFields, filename: 'InTransit' });
 
     return parsedRecords;
   }

--- a/src/reports/InTransitItemsReport.test.js
+++ b/src/reports/InTransitItemsReport.test.js
@@ -1,8 +1,8 @@
-import { exportCsv } from '@folio/stripes/util';
+import { exportToCsv } from '@folio/stripes/components';
 import InTransitItemsReport from './InTransitItemsReport';
 
-jest.mock('@folio/stripes/util', () => ({
-  exportCsv: jest.fn(),
+jest.mock('@folio/stripes/components', () => ({
+  exportToCsv: jest.fn(),
 }));
 
 describe('InTransitItemsReport', () => {
@@ -92,13 +92,13 @@ describe('InTransitItemsReport', () => {
     });
   });
   describe('toCSV', () => {
-    it('call exportCsv with the correct arguments', async () => {
+    it('call exportToCsv with the correct arguments', async () => {
       const records = [{ barcode: '123456789' }];
       const parsedRecords = [{ barcode: '123456789' }];
       report.fetchData = jest.fn(() => Promise.resolve(records));
       report.parse = jest.fn(() => parsedRecords);
       await report.toCSV();
-      expect(exportCsv).toHaveBeenCalledWith(parsedRecords, {
+      expect(exportToCsv).toHaveBeenCalledWith(parsedRecords, {
         onlyFields: report.columnsMap,
         filename: 'InTransit',
       });


### PR DESCRIPTION
## Description
`exportCsv` from `stripes-util` is deprecated. Changed imports to use `exportToCsv` from `stripes-components`

## Issues
[UIIN-3025](https://folio-org.atlassian.net/browse/UIIN-3025)