### PR TITLE
UIIN-3198: Display Shared facet when user opens 'Move holdings/items to another instance' modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix infinite loading animation after cancel edit/duplicate or 'Save & Close' consortial holdings/items. Fixes UIIN-3167.
 * Remove hover-over text next to "Effective call number" on the Item record detail view. Refs UIIN-3131.
 * Change import of `exportToCsv` from `stripes-util` to `stripes-components`. Refs UIIN-3025.
+* Display `Shared` facet when user opens "Move holdings/items to another instance" modal. Refs UIIN-3198.
 
 ## [12.0.8](https://github.com/folio-org/ui-inventory/tree/v12.0.8) (2024-12-24)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.7...v12.0.8)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -1232,7 +1232,6 @@ class ViewInstance extends React.Component {
                   onSelect={this.selectInstance}
                   onClose={this.toggleFindInstancePlugin}
                   withTrigger={false}
-                  suppressSharedFacet
                 />
               )
             }


### PR DESCRIPTION
## Purpose
* Allow to display of SHARED Instances when selecting the ‘Move To’ Instance location when invoking 'Move holdings/items to another instance' action

## Approach
* Removed flag `suppressSharedFacet`

## Refs
[UIIN-3198](https://folio-org.atlassian.net/browse/UIIN-3198)

## Screenshots

### Before
https://github.com/user-attachments/assets/19e66c40-fd43-4317-a93d-408b54bd7f52

### After
https://github.com/user-attachments/assets/9c2ff4bd-7380-4db4-93c1-54eda858f33b