### PR TITLE
UIIN-3188: ECS - Allow 'Move holdings/items to another instance' if instance is shared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix infinite loading animation after cancel edit/duplicate or 'Save & Close' consortial holdings/items. Fixes UIIN-3167.
 * Remove hover-over text next to "Effective call number" on the Item record detail view. Refs UIIN-3131.
 * Change import of `exportToCsv` from `stripes-util` to `stripes-components`. Refs UIIN-3025.
+* ECS - Allow 'Move holdings/items to another instance' if instance is shared. Refs UIIN-3188.
 
 ## [12.0.8](https://github.com/folio-org/ui-inventory/tree/v12.0.8) (2024-12-24)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.7...v12.0.8)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -840,7 +840,7 @@ class ViewInstance extends React.Component {
     );
 
     const showQuickMarcMenuSection = isSourceMARC && (canCreateMARCHoldings || canEditMARCRecord || canDeriveMARCRecord);
-    const canMoveHoldingsItemsToAnotherInstance = (canMoveItems || canMoveHoldings) && !isShared;
+    const canMoveHoldingsItemsToAnotherInstance = canMoveItems || canMoveHoldings;
 
     // the `identifier` is responsible for displaying the plugin `copyright-permissions-checker`
     if (!showInventoryMenuSection && !showQuickMarcMenuSection && !identifier) {


### PR DESCRIPTION
## Purpose
* Allow to display of ‘Move holdings/items to another instance' action on Instances that are ‘SHARED’.

## Approach
* Removed `!isShared` condition from `canMoveHoldingsItemsToAnotherInstance` 

## Refs
[UIIN-3188](https://folio-org.atlassian.net/browse/UIIN-3188)

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/3247150c-ce7b-4d05-8d22-bd158ecc4193)

### After
![image](https://github.com/user-attachments/assets/f352d052-30e7-4b58-93bc-771c7929b640)

