### PR TITLE
UIIN-3194: Detail view of created Instance record is not loaded after saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * ECS: Disable opening item details if a user is not affiliated with item's member tenant. Fixes UIIN-3187.
 * Display failure message during `Update Ownership` action when Item contains Local reference data. Fixes UIIN-3195.
 * Correctly depend on `inflected`. Refs UIIN-3203.
+* Detail view of created Instance record is not loaded after saving. Fixes UIIN-3194.
 
 ## [12.0.10](https://github.com/folio-org/ui-inventory/tree/v12.0.10) (2025-01-20)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.9...v12.0.10)

--- a/src/common/hooks/useSearchInstanceByIdQuery/useSearchInstanceByIdQuery.js
+++ b/src/common/hooks/useSearchInstanceByIdQuery/useSearchInstanceByIdQuery.js
@@ -1,19 +1,36 @@
 import { useQuery } from 'react-query';
 
 import {
-  useOkapiKy,
   useNamespace,
+  useOkapiKy,
 } from '@folio/stripes/core';
 
-const useSearchInstanceByIdQuery = (instanceId) => {
+const NO_RECORDS_FOUND_ERROR = 'No records found';
+
+const useSearchInstanceByIdQuery = (instanceId, { enabled = true } = {}) => {
   const ky = useOkapiKy();
   const [namespace] = useNamespace({ key: 'search-instance' });
+
+  const queryFn = async () => {
+    const response = await ky.get(`search/instances?query=id==${instanceId}`).json();
+
+    if (response.totalRecords === 0) {
+      throw new Error(NO_RECORDS_FOUND_ERROR); // this triggers the retry mechanism
+    }
+    return response;
+  };
 
   const { refetch, isLoading, data = {} } = useQuery(
     {
       queryKey: [namespace, instanceId],
-      queryFn: () => ky.get(`search/instances?query=id==${instanceId}`).json(),
-      enabled: Boolean(instanceId),
+      queryFn,
+      enabled: Boolean(enabled && instanceId),
+      retry: (failureCount, error) => {
+        if (failureCount >= 3) return false; // stop after 3 attempts
+        if (error.message === NO_RECORDS_FOUND_ERROR) return true; // retry if no records
+        return false; // stop retrying on other errors
+      },
+      retryDelay: () => 3000,
     },
   );
 

--- a/src/common/hooks/useSearchInstanceByIdQuery/useSearchInstanceByIdQuery.test.js
+++ b/src/common/hooks/useSearchInstanceByIdQuery/useSearchInstanceByIdQuery.test.js
@@ -4,7 +4,7 @@ import {
 } from 'react-query';
 import {
   renderHook,
-  act,
+  waitFor,
 } from '@folio/jest-config-stripes/testing-library/react';
 import { useOkapiKy } from '@folio/stripes/core';
 
@@ -23,23 +23,23 @@ const wrapper = ({ children }) => (
 const instanceId = 'instanceId';
 
 describe('useSearchInstanceByIdQuery', () => {
-  it('should fetch instance', async () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch instance successfully', async () => {
     useOkapiKy.mockClear().mockReturnValue({
-      get: () => ({
-        json: () => ({
-          instances: [{
-            id: instanceId,
-          }]
+      get: jest.fn(() => ({
+        json: jest.fn().mockResolvedValue({
+          totalRecords: 1,
+          instances: [{ id: instanceId }],
         }),
-      }),
+      })),
     });
 
     const { result } = renderHook(() => useSearchInstanceByIdQuery(instanceId), { wrapper });
 
-    await act(() => {
-      return !result.current.isLoading;
-    });
-
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.instance.id).toBe(instanceId);
   });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Detail view of created Instance record is not loaded after saving. White screen displays in the third pane.
The problem is not reproduced consistently. GET to ‘/search/instances’ returns 0 records right after Instance creation. But instance is actually created.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Make a pre-call to mod-search only if a user is in consortium mode to get info about the instance's tenant and shared status, otherwise make a call right to mod-inventory
- If a user is in consortium mode and mod-search returns the result with empty data even if the instance was successfully created, then make 3 attempts until there is filled data with a 3-second delay.
- Update unit tests
 
## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3194

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
