### PR TITLE
UIIN-3210 Remove hover-over text next to "Shelving order" on the Item record detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * ECS: Disable opening item details if a user is not affiliated with item's member tenant. Fixes UIIN-3187.
 * Correctly depend on `inflected`. Refs UIIN-3203.
 * Decrease the amount of rerenders in `ConsortialHoldings` component. Fixes UIIN-3196.
+* Remove hover-over text next to "Shelving order" on the Item record detail view. Refs UIIN-3210.
 
 ## [12.0.12](https://github.com/folio-org/ui-inventory/tree/v12.0.12) (2025-01-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.11...v12.0.12)

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -47,7 +47,6 @@ import {
   HasCommand,
   collapseAllSections,
   expandAllSections,
-  InfoPopover,
   Layout,
   MenuSection,
   NoValue,
@@ -1271,11 +1270,6 @@ const ItemView = props => {
                       <KeyValue
                         label={<FormattedMessage id="ui-inventory.shelvingOrder" />}
                         value={checkIfElementIsEmpty(itemData.effectiveShelvingOrder)}
-                      />
-                      <InfoPopover
-                        iconSize="medium"
-                        content={<FormattedMessage id="ui-inventory.info.shelvingOrder" />}
-                        buttonProps={{ 'data-testid': 'info-icon-shelving-order' }}
                       />
                     </Layout>
                   </Col>

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -868,7 +868,6 @@
   "administrativeNote": "Administrative note",
   "administrativeNotes": "Administrative notes",
   "linkedToMarcAuthority": "Linked to MARC authority",
-  "info.shelvingOrder": "This field is the normalized form of the call number which determines how the call number is sorted while browsing.",
 
   "shortcut.nextSubfield": "quickMARC only: Move to the next subfield in a text box",
   "shortcut.prevSubfield": "quickMARC only: Move to the previous subfield in a text box",


### PR DESCRIPTION
## Description
Today, “Shelving order” appears as a field on the item record detail view with hover over text indicating that the value is used for sorting in call number browse. However, In call number browse refactor effort, the shelving order is no longer being used to sort. Therefore, we need to remove the popover because it is inaccurate. 

## Screenshots
![image](https://github.com/user-attachments/assets/629411f6-48ec-4f2c-90de-7fe044ee932e)


## Issues
[UIIN-3210](https://folio-org.atlassian.net/browse/UIIN-3210)