### PR TITLE
UIIN-3172: Add Version history button and Version history pane to details view of Item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * ECS: Disable opening item details if a user is not affiliated with item's member tenant. Fixes UIIN-3187.
 * Correctly depend on `inflected`. Refs UIIN-3203.
 * Decrease the amount of rerenders in `ConsortialHoldings` component. Fixes UIIN-3196.
+* Add Version history button and Version history pane to details view of Item. Refs UIIN-3172.
 
 ## [12.0.12](https://github.com/folio-org/ui-inventory/tree/v12.0.12) (2025-01-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.11...v12.0.12)

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -169,15 +169,8 @@ const ItemView = props => {
   const intl = useIntl();
   const calloutContext = useContext(CalloutContext);
   const accordionStatusRef = useRef();
-  const paneTitleRef = useRef();
   const { mutateHolding } = useHoldingMutation(targetTenant?.id);
   const { updateOwnership } = useUpdateOwnership(UPDATE_OWNERSHIP_API.ITEMS);
-
-  useEffect(() => {
-    if (paneTitleRef.current) {
-      paneTitleRef.current.focus();
-    }
-  }, [isVersionHistoryOpen]);
 
   useEffect(() => {
     if (checkIfUserInMemberTenant(stripes)) {
@@ -1756,7 +1749,6 @@ const ItemView = props => {
         {isVersionHistoryOpen && (
           <VersionHistory
             onClose={() => setIsSetVersionHistoryOpen(false)}
-            paneTitleRef={paneTitleRef}
           />
         )}
       </Paneset>

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -119,7 +119,7 @@ import {
   useHoldingMutation,
   useUpdateOwnership,
 } from '../hooks';
-import VersionHistory from './VersionHistory/VersionHistory';
+import { VersionHistory } from './VersionHistory';
 
 export const requestStatusFiltersString = map(REQUEST_OPEN_STATUSES, requestStatus => `requestStatus.${requestStatus}`).join(',');
 
@@ -1030,7 +1030,11 @@ const ItemView = props => {
           dismissible
           onClose={onCloseViewItem}
           actionMenu={getActionMenu}
-          lastMenu={<PaneMenu><VersionHistoryButton onClick={openVersionHistory} /></PaneMenu>}
+          lastMenu={(
+            <PaneMenu>
+              <VersionHistoryButton onClick={openVersionHistory} />
+            </PaneMenu>
+          )}
         >
           <UpdateItemOwnershipModal
             isOpen={isUpdateOwnershipModalOpen}

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -69,6 +69,8 @@ import {
   useOkapiKy,
 } from '@folio/stripes/core';
 
+import { VersionHistoryButton } from '@folio/stripes-acq-components';
+import { PaneMenu } from '@folio/stripes-components';
 import { requestsStatusString } from '../Instance/ViewRequests/utils';
 
 import ModalContent from '../components/ModalContent';
@@ -117,6 +119,7 @@ import {
   useHoldingMutation,
   useUpdateOwnership,
 } from '../hooks';
+import VersionHistory from './VersionHistory/VersionHistory';
 
 export const requestStatusFiltersString = map(REQUEST_OPEN_STATUSES, requestStatus => `requestStatus.${requestStatus}`).join(',');
 
@@ -161,12 +164,20 @@ const ItemView = props => {
   const [updateOwnershipData, setUpdateOwnershipData] = useState({});
   const [tenants, setTenants] = useState([]);
   const [targetTenant, setTargetTenant] = useState({});
+  const [isVersionHistoryOpen, setIsSetVersionHistoryOpen] = useState(false);
 
   const intl = useIntl();
   const calloutContext = useContext(CalloutContext);
   const accordionStatusRef = useRef();
+  const paneTitleRef = useRef();
   const { mutateHolding } = useHoldingMutation(targetTenant?.id);
   const { updateOwnership } = useUpdateOwnership(UPDATE_OWNERSHIP_API.ITEMS);
+
+  useEffect(() => {
+    if (paneTitleRef.current) {
+      paneTitleRef.current.focus();
+    }
+  }, [isVersionHistoryOpen]);
 
   useEffect(() => {
     if (checkIfUserInMemberTenant(stripes)) {
@@ -621,6 +632,10 @@ const ItemView = props => {
   const temporaryHoldingsLocation = locationsById[holdingsRecord?.temporaryLocationId];
   const tagsEnabled = !tagSettings?.records?.length || tagSettings?.records?.[0]?.value === 'true';
 
+  const openVersionHistory = useCallback(() => {
+    setIsSetVersionHistoryOpen(true);
+  }, []);
+
   const refLookup = (referenceTable, id) => {
     const ref = (referenceTable && id) ? referenceTable.find(record => record.id === id) : {};
 
@@ -984,7 +999,8 @@ const ItemView = props => {
       <Paneset isRoot>
         <Pane
           data-test-item-view-page
-          defaultWidth="100%"
+          defaultWidth="fill"
+          id="item-view-pane"
           appIcon={(
             <AppIcon
               app="inventory"
@@ -1014,6 +1030,7 @@ const ItemView = props => {
           dismissible
           onClose={onCloseViewItem}
           actionMenu={getActionMenu}
+          lastMenu={<PaneMenu><VersionHistoryButton onClick={openVersionHistory} /></PaneMenu>}
         >
           <UpdateItemOwnershipModal
             isOpen={isUpdateOwnershipModalOpen}
@@ -1732,6 +1749,12 @@ const ItemView = props => {
             </AccordionSet>
           </AccordionStatus>
         </Pane>
+        {isVersionHistoryOpen && (
+          <VersionHistory
+            onClose={() => setIsSetVersionHistoryOpen(false)}
+            paneTitleRef={paneTitleRef}
+          />
+        )}
       </Paneset>
     </HasCommand>
   );

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -52,6 +52,7 @@ import {
   MenuSection,
   NoValue,
   TextLink,
+  PaneMenu,
 } from '@folio/stripes/components';
 
 import {
@@ -70,7 +71,6 @@ import {
 } from '@folio/stripes/core';
 
 import { VersionHistoryButton } from '@folio/stripes-acq-components';
-import { PaneMenu } from '@folio/stripes-components';
 import { requestsStatusString } from '../Instance/ViewRequests/utils';
 
 import ModalContent from '../components/ModalContent';

--- a/src/views/ItemView.test.js
+++ b/src/views/ItemView.test.js
@@ -322,9 +322,10 @@ describe('ItemView', () => {
         it('should hide the pane', async () => {
           await userEvent.click(versionHistoryButton);
 
-          expect(screen.getByRole('region', { name: /version history/i })).toBeInTheDocument();
+          const versionHistoryPane = await screen.findByRole('region', { name: /version history/i });
+          expect(versionHistoryPane).toBeInTheDocument();
 
-          const closeButton = screen.getByRole('button', { name: /close version history/i });
+          const closeButton = await within(versionHistoryPane).findByRole('button', { name: /close/i });
           await userEvent.click(closeButton);
 
           expect(screen.queryByRole('region', { name: /version history/i })).not.toBeInTheDocument();

--- a/src/views/ItemView.test.js
+++ b/src/views/ItemView.test.js
@@ -8,6 +8,7 @@ import {
   fireEvent,
   within,
 } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { runAxeTest } from '@folio/stripes-testing';
 
 import '../../test/jest/__mock__';
@@ -294,6 +295,40 @@ describe('ItemView', () => {
         fireEvent.click(document.querySelector('[aria-label="Close "]'));
 
         expect(mockPush).toHaveBeenCalled();
+      });
+    });
+
+    describe('Version history component', () => {
+      let versionHistoryButton;
+
+      beforeEach(() => {
+        const { container } = renderWithIntl(<ItemViewSetup />, translationsProperties);
+
+        versionHistoryButton = container.querySelector('#version-history-btn');
+      });
+
+      it('should render version history button', () => {
+        expect(versionHistoryButton).toBeInTheDocument();
+      });
+
+      describe('when click the button', () => {
+        it('should render version history pane', async () => {
+          await userEvent.click(versionHistoryButton);
+          expect(screen.getByRole('region', { name: /version history/i })).toBeInTheDocument();
+        });
+      });
+
+      describe('when click the close button', () => {
+        it('should hide the pane', async () => {
+          await userEvent.click(versionHistoryButton);
+
+          expect(screen.getByRole('region', { name: /version history/i })).toBeInTheDocument();
+
+          const closeButton = screen.getByRole('button', { name: /close version history/i });
+          await userEvent.click(closeButton);
+
+          expect(screen.queryByRole('region', { name: /version history/i })).not.toBeInTheDocument();
+        });
       });
     });
   });

--- a/src/views/VersionHistory/VersionHistory.js
+++ b/src/views/VersionHistory/VersionHistory.js
@@ -1,27 +1,34 @@
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
 
-import { Pane } from '@folio/stripes/components';
+import {
+  VersionHistoryPane,
+  VersionViewContextProvider,
+} from '@folio/stripes-acq-components';
 
-const VersionHistory = ({ onClose, paneTitleRef }) => {
+const VersionHistory = ({ onClose }) => {
   return (
-    <Pane
-      id="version-history-pane"
-      defaultWidth="20%"
-      onClose={onClose}
-      paneTitle={<FormattedMessage id="ui-inventory.versionHistory.paneTitle" />}
-      dismissible
-      paneTitleRef={paneTitleRef}
+    <VersionViewContextProvider
+      snapshotPath=""
+      versions={[]}
+      versionId={null}
     >
-      {/* TODO: Create here the list of version history cards in scope of https://folio-org.atlassian.net/browse/UIIN-3175 */}
-      <span>Versions</span>
-    </Pane>
+      <VersionHistoryPane
+        currentVersion={null}
+        id="inventory"
+        isLoading={false}
+        onClose={onClose}
+        onSelectVersion={() => {}}
+        snapshotPath=""
+        labelsMap={{}}
+        versions={[]}
+        hiddenFields={[]}
+      />
+    </VersionViewContextProvider>
   );
 };
 
 VersionHistory.propTypes = {
   onClose: PropTypes.func,
-  paneTitleRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 };
 
 

--- a/src/views/VersionHistory/VersionHistory.js
+++ b/src/views/VersionHistory/VersionHistory.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 
 import { Pane } from '@folio/stripes/components';
-
 
 const VersionHistory = ({ onClose, paneTitleRef }) => {
   return (
@@ -9,10 +9,11 @@ const VersionHistory = ({ onClose, paneTitleRef }) => {
       id="version-history-pane"
       defaultWidth="20%"
       onClose={onClose}
-      paneTitle="Version history"
+      paneTitle={<FormattedMessage id="ui-inventory.versionHistory.paneTitle" />}
       dismissible
       paneTitleRef={paneTitleRef}
     >
+      {/* TODO: Create here the list of version history cards in scope of https://folio-org.atlassian.net/browse/UIIN-3175 */}
       <span>Versions</span>
     </Pane>
   );

--- a/src/views/VersionHistory/VersionHistory.js
+++ b/src/views/VersionHistory/VersionHistory.js
@@ -1,0 +1,27 @@
+import PropTypes from 'prop-types';
+
+import { Pane } from '@folio/stripes/components';
+
+
+const VersionHistory = ({ onClose, paneTitleRef }) => {
+  return (
+    <Pane
+      id="version-history-pane"
+      defaultWidth="20%"
+      onClose={onClose}
+      paneTitle="Version history"
+      dismissible
+      paneTitleRef={paneTitleRef}
+    >
+      <span>Versions</span>
+    </Pane>
+  );
+};
+
+VersionHistory.propTypes = {
+  onClose: PropTypes.func,
+  paneTitleRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+};
+
+
+export default VersionHistory;

--- a/src/views/VersionHistory/index.js
+++ b/src/views/VersionHistory/index.js
@@ -1,0 +1,1 @@
+export { default as VersionHistory } from './VersionHistory';

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -879,5 +879,7 @@
   "settings.section.displaySettings": "Display settings",
   "settings.displaySettings.defaultSort": "Default sort",
 
-  "instance.linked.id": "Linked instance ID - {id}"
+  "instance.linked.id": "Linked instance ID - {id}",
+
+  "versionHistory.paneTitle": "Version history"
 }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
* Add Version history button and Version history pane to details view of Item.
* The list of version history cards will be created in scope of [UIIN-3175](https://folio-org.atlassian.net/browse/UIIN-3175).

## Approach
* Created `VersionHistory` component and use it in `ItemView` component.
* Added `VersionHistoryButton` as `lastMenu` for item view pane.

## Refs
[UIIN-3172](https://folio-org.atlassian.net/browse/UIIN-3172)

## Screenshots
![image](https://github.com/user-attachments/assets/b9e61d8f-49e1-4a94-9f76-14d129d10493)