### PR TITLE
UIIN-3205: Add `getCallNumberQuery` function to build a query string based on the call number and its type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Display holdings names in `Consortial holdings` accordion for user without inventory permissions in member tenants. Fixes UIIN-3159.
 * Remove the ability to share local instance when `Inventory: View, create instances` permission is assigned. Fixes UIIN-3166.
 * *BREAKING* Use `browse` `1.5` interface that provides new Call Number Browse endpoints. Refs UIIN-3162.
+* Add `getCallNumberQuery` function to build a query string based on the call number and its type. Refs UIIN-3205.
 
 ## [12.0.7](https://github.com/folio-org/ui-inventory/tree/v12.0.7) (2024-12-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.6...v12.0.7)

--- a/src/components/BrowseResultsList/BrowseResultsList.test.js
+++ b/src/components/BrowseResultsList/BrowseResultsList.test.js
@@ -90,6 +90,12 @@ const mockContext = {
       ],
     },
   ],
+  callNumberBrowseConfig: [
+    {
+      id: 'dewey',
+      typeIds: ['dewey-id', 'lc-id'],
+    },
+  ],
   subjectSources: [{ id: 'sourceId', name: 'sourceName' }],
   subjectTypes: [{ id: 'typeId', name: 'typeName' }],
 };

--- a/src/components/BrowseResultsList/getBrowseResultsFormatter.test.js
+++ b/src/components/BrowseResultsList/getBrowseResultsFormatter.test.js
@@ -3,9 +3,14 @@ import '../../../test/jest/__mock__';
 import { act, screen, fireEvent } from '@folio/jest-config-stripes/testing-library/react';
 import { createMemoryHistory } from 'history';
 import { Router } from 'react-router-dom';
+import queryString from 'query-string';
 
 import { MultiColumnList } from '@folio/stripes-components';
-import { browseModeOptions } from '@folio/stripes-inventory-components';
+import {
+  browseCallNumberOptions,
+  browseModeOptions,
+  queryIndexes,
+} from '@folio/stripes-inventory-components';
 
 import {
   renderWithIntl,
@@ -45,6 +50,13 @@ const data = {
         'id-lc',
         'id-lc-local',
       ],
+    },
+  ],
+  callNumberBrowseConfig: [
+    {
+      id: 'dewey',
+      shelvingAlgorithm: 'dewey',
+      typeIds: ['dewey-id', 'lc-id'],
     },
   ],
   subjectSources: [{ id: 'sourceId1', name: 'sourceName1' }, { id: 'sourceId2', name: 'sourceName2' }],
@@ -92,19 +104,16 @@ describe('getBrowseResultsFormatter', () => {
     };
     const contentData = [
       {
-        fullCallNumber: 'A 1958 A 8050',
-        callNumber: 'A 1958 A 8050',
-        shelfKey: '41958 A 48050',
+        fullCallNumber: 'CALL',
         isAnchor: true,
-        totalRecords: 1,
-        instance: { id: 'ce9dd893-c812-49d5-8973-d55d018894c4', title: 'Test title' },
+        totalRecords: 0,
       },
       {
-        fullCallNumber: 'AAA',
-        callNumber: 'AAA',
-        shelfKey: '123456',
+        fullCallNumber: 'CALL SUF',
+        callNumber: 'CALL',
+        callNumberPrefix: 'PRE',
+        callNumberSuffix: 'SUF',
         totalRecords: 2,
-        instance: { id: 'ce9dd893-c812-49d5-8973-d55d018894c4', title: 'Test title 2' },
       },
     ];
     const [anchorRecord, nonAnchorRecord] = contentData;
@@ -120,10 +129,10 @@ describe('getBrowseResultsFormatter', () => {
       renderCallNumberList();
 
       // Anchor row
-      expect(screen.getByText(anchorRecord.callNumber).tagName.toLowerCase()).toBe('strong');
-      expect(screen.getByText(anchorRecord.totalRecords).tagName.toLowerCase()).toBe('strong');
+      expect(screen.getByText('would be here').tagName.toLowerCase()).toBe('strong');
+      expect(screen.getByText('CALL').tagName.toLowerCase()).not.toBe('strong');
       // Default row
-      expect(screen.getByText(nonAnchorRecord.callNumber).tagName.toLowerCase()).not.toBe('strong');
+      expect(screen.getByText('PRE CALL SUF').tagName.toLowerCase()).not.toBe('strong');
       expect(screen.getByText(nonAnchorRecord.totalRecords).tagName.toLowerCase()).not.toBe('strong');
     });
 
@@ -134,14 +143,33 @@ describe('getBrowseResultsFormatter', () => {
       expect(screen.getByText(missedMatchText)).toBeInTheDocument();
     });
 
-    it('should navigate to instance "Search" page when target column was clicked', async () => {
+    it('should not navigate to any page when anchor is clicked', async () => {
       renderCallNumberList();
 
       expect(history.location.pathname).toEqual(BROWSE_INVENTORY_ROUTE);
 
-      await act(async () => fireEvent.click(screen.getByText(anchorRecord.callNumber)));
+      await act(async () => fireEvent.click(screen.getByText(anchorRecord.fullCallNumber)));
 
-      expect(history.location.pathname).toEqual(INVENTORY_ROUTE);
+      expect(history.location.pathname).toEqual(BROWSE_INVENTORY_ROUTE);
+    });
+
+    describe('when call number title is clicked', () => {
+      it('should navigate to the instance "Search" page', async () => {
+        const { getByText } = renderCallNumberList({
+          formatter: getBrowseResultsFormatter({
+            data,
+            browseOption: browseCallNumberOptions.DEWEY,
+          }),
+        });
+
+        const query = queryString.stringify({
+          selectedBrowseResult: true,
+          qindex: queryIndexes.QUERY_SEARCH,
+          query: 'itemNormalizedCallNumbers="PRE CALL SUF" and (item.effectiveCallNumberComponents.typeId=="dewey-id" or item.effectiveCallNumberComponents.typeId=="lc-id")',
+        });
+
+        expect(getByText('PRE CALL SUF').href).toContain(`${INVENTORY_ROUTE}?${query}`);
+      });
     });
   });
 

--- a/src/components/BrowseResultsList/utils.js
+++ b/src/components/BrowseResultsList/utils.js
@@ -103,6 +103,14 @@ export const getFullCallNumber = (row) => {
   return fullCallNumber;
 };
 
+/**
+ * Constructs a query string for browsing call numbers based on the provided parameters.
+ *
+ * @param {string} qindex - The query index indicating the type of browse (e.g., callNumbers, dewey, lc).
+ * @param {Object} data - The data object containing configuration for call number browsing.
+ * @param {Object} row - The row object containing details of the item being browsed.
+ * @returns {string} - The constructed query string for browsing call numbers.
+ */
 const getCallNumberQuery = (qindex, data, row) => {
   const fullCallNumber = getFullCallNumber(row);
 

--- a/src/components/BrowseResultsList/utils.js
+++ b/src/components/BrowseResultsList/utils.js
@@ -5,9 +5,9 @@ import {
   browseClassificationOptions,
   browseModeOptions,
   browseClassificationIndexToId,
+  browseCallNumberIndexToId,
   FACETS,
   queryIndexes,
-  segments,
 } from '@folio/stripes-inventory-components';
 
 export const isRowPreventsClick = (row, browseOption) => {
@@ -103,9 +103,37 @@ export const getFullCallNumber = (row) => {
   return fullCallNumber;
 };
 
+const getCallNumberQuery = (qindex, data, row) => {
+  const fullCallNumber = getFullCallNumber(row);
+
+  const isCallNumberBrowse = Object.values(browseCallNumberOptions).includes(qindex);
+
+  if (!isCallNumberBrowse) {
+    return '';
+  }
+
+  let query = `itemNormalizedCallNumbers="${fullCallNumber}"`;
+
+  const callNumberBrowseConfigId = browseCallNumberIndexToId[qindex];
+
+  const callNumberBrowseTypes = data?.callNumberBrowseConfig
+    .find(config => config.id === callNumberBrowseConfigId)?.typeIds;
+
+  const callNumberBrowseTypesQuery = callNumberBrowseTypes
+    ?.map(typeId => `item.effectiveCallNumberComponents.typeId=="${typeId}"`)
+    .join(' or ');
+
+  if (callNumberBrowseTypesQuery) {
+    query += ` and (${callNumberBrowseTypesQuery})`;
+  }
+
+  return query;
+};
+
 export const getSearchParams = (row, qindex, allFilters, data) => {
   const filters = getExtraFilters(row, qindex, allFilters);
   const classificationQuery = getClassificationQuery(qindex, data, row);
+  const callNumberQuery = getCallNumberQuery(qindex, data, row);
 
   const classificationOption = {
     qindex: queryIndexes.QUERY_SEARCH,
@@ -113,12 +141,9 @@ export const getSearchParams = (row, qindex, allFilters, data) => {
     ...filters,
   };
 
-  const fullCallNumber = getFullCallNumber(row);
-
   const callNumberOption = {
-    qindex: queryIndexes.ITEM_NORMALIZED_CALL_NUMBERS,
-    query: fullCallNumber,
-    segment: segments.items,
+    qindex: queryIndexes.QUERY_SEARCH,
+    query: callNumberQuery,
     ...filters,
   };
 

--- a/src/components/InstanceFiltersBrowse/instanceFiltersBrowse.test.js
+++ b/src/components/InstanceFiltersBrowse/instanceFiltersBrowse.test.js
@@ -46,6 +46,7 @@ const data = {
   locations: [],
   consortiaTenants,
   classificationBrowseConfig: [],
+  callNumberBrowseConfig: [],
 };
 
 const query = {
@@ -149,16 +150,6 @@ describe('InstanceFiltersBrowse', () => {
   });
 
   describe('When callNumber browseType was selected', () => {
-    it('should call onClear handler if clear btn is clicked', () => {
-      renderInstanceFilters();
-      fireEvent.click(screen.getByLabelText('Clear selected Effective location (item) filters'));
-
-      expect(mockOnChange).toHaveBeenCalledWith({
-        name: FACETS.EFFECTIVE_LOCATION,
-        values: [],
-      });
-    });
-
     it('should display "Held By" facet accordion', () => {
       const { getByRole } = renderInstanceFilters({
         data,

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -17,3 +17,4 @@ export { default as useLocalStorageItems } from './useLocalStorageItems';
 export * from './useQuickExport';
 export * from '@folio/stripes-inventory-components/lib/queries/useInstanceDateTypes';
 export * from './useCallNumberTypesQuery';
+export * from './useCallNumberBrowseConfig';

--- a/src/hooks/useCallNumberBrowseConfig/index.js
+++ b/src/hooks/useCallNumberBrowseConfig/index.js
@@ -1,0 +1,1 @@
+export * from './useCallNumberBrowseConfig';

--- a/src/hooks/useCallNumberBrowseConfig/useCallNumberBrowseConfig.js
+++ b/src/hooks/useCallNumberBrowseConfig/useCallNumberBrowseConfig.js
@@ -1,0 +1,35 @@
+import { useQuery } from 'react-query';
+
+import {
+  useNamespace,
+  useOkapiKy,
+  useStripes,
+} from '@folio/stripes/core';
+import {
+  CQL_FIND_ALL,
+  LIMIT_MAX,
+} from '@folio/stripes-inventory-components';
+
+const useCallNumberBrowseConfig = () => {
+  const stripes = useStripes();
+  const [namespace] = useNamespace({ key: 'call-number-browse-config' });
+  const centralTenantId = stripes.user.user?.consortium?.centralTenantId;
+  const ky = useOkapiKy({ tenant: centralTenantId });
+
+  const { data, isFetching } = useQuery(
+    [namespace],
+    () => ky.get('browse/config/instance-call-number', {
+      searchParams: {
+        limit: LIMIT_MAX,
+        query: CQL_FIND_ALL,
+      },
+    }).json(),
+  );
+
+  return {
+    callNumberBrowseConfig: data?.configs || [],
+    isCallNumberConfigLoading: isFetching,
+  };
+};
+
+export { useCallNumberBrowseConfig };

--- a/src/hooks/useCallNumberBrowseConfig/useCallNumberBrowseConfig.test.js
+++ b/src/hooks/useCallNumberBrowseConfig/useCallNumberBrowseConfig.test.js
@@ -1,0 +1,42 @@
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+
+import {
+  renderHook,
+  act,
+} from '@folio/jest-config-stripes/testing-library/react';
+import { useOkapiKy } from '@folio/stripes/core';
+
+import { useCallNumberBrowseConfig } from './useCallNumberBrowseConfig';
+
+const queryClient = new QueryClient();
+
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+describe('useCallNumberBrowseConfig', () => {
+  beforeEach(() => {
+    useOkapiKy.mockClear().mockReturnValue({
+      get: () => ({
+        json: jest.fn().mockResolvedValue({ configs: [{ id: 'dewey' }] }),
+      }),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch config', async () => {
+    const { result } = renderHook(useCallNumberBrowseConfig, { wrapper });
+
+    await act(() => !result.current.isCallNumberConfigLoading);
+
+    expect(result.current.callNumberBrowseConfig).toEqual([{ id: 'dewey' }]);
+  });
+});

--- a/src/providers/DataProvider.js
+++ b/src/providers/DataProvider.js
@@ -5,7 +5,10 @@ import keyBy from 'lodash/keyBy';
 import { stripesConnect } from '@folio/stripes/core';
 import { useCommonData } from '@folio/stripes-inventory-components';
 
-import { useClassificationBrowseConfig } from '../hooks';
+import {
+  useCallNumberBrowseConfig,
+  useClassificationBrowseConfig,
+} from '../hooks';
 import { DataContext } from '../contexts';
 
 // Provider which loads dictionary data used in various places in ui-inventory.
@@ -18,9 +21,12 @@ const DataProvider = ({
 
   const { commonData, isCommonDataLoading } = useCommonData();
   const { classificationBrowseConfig, isLoading: isBrowseConfigLoading } = useClassificationBrowseConfig();
+  const { callNumberBrowseConfig, isCallNumberConfigLoading } = useCallNumberBrowseConfig();
+
+  const areOtherDataLoading = isCommonDataLoading || isBrowseConfigLoading || isCallNumberConfigLoading;
 
   const isLoading = useMemo(() => {
-    if (isCommonDataLoading || isBrowseConfigLoading) {
+    if (areOtherDataLoading) {
       return true;
     }
     // eslint-disable-next-line guard-for-in
@@ -33,7 +39,7 @@ const DataProvider = ({
     }
 
     return false;
-  }, [resources, manifest, isCommonDataLoading, isBrowseConfigLoading]);
+  }, [resources, manifest, areOtherDataLoading]);
 
   const data = useMemo(() => {
     const loadedData = {
@@ -57,6 +63,7 @@ const DataProvider = ({
     loadedData.holdingsSourcesByName = keyBy(commonData.holdingsSources, 'name');
     loadedData.instanceRelationshipTypesById = keyBy(instanceRelationshipTypes, 'id');
     loadedData.classificationBrowseConfig = classificationBrowseConfig;
+    loadedData.callNumberBrowseConfig = callNumberBrowseConfig;
 
     return loadedData;
   }, [
@@ -64,6 +71,7 @@ const DataProvider = ({
     manifest,
     commonData,
     classificationBrowseConfig,
+    callNumberBrowseConfig,
   ]);
 
   if (isLoading) {

--- a/src/providers/DataProvider.test.js
+++ b/src/providers/DataProvider.test.js
@@ -5,11 +5,15 @@ import { resources } from '../../test/fixtures/DataProviders';
 
 import DataProvider from './DataProvider';
 import { DataContext } from '../contexts';
-import { useClassificationBrowseConfig } from '../hooks';
+import {
+  useCallNumberBrowseConfig,
+  useClassificationBrowseConfig,
+} from '../hooks';
 
 jest.mock('../hooks', () => ({
   ...jest.requireActual('../hooks'),
   useClassificationBrowseConfig: jest.fn(),
+  useCallNumberBrowseConfig: jest.fn(),
 }));
 
 const commonData = {
@@ -63,6 +67,17 @@ useClassificationBrowseConfig.mockReturnValue({
   isLoading: false,
 });
 
+const callNumberBrowseConfig = [{
+  id: 'dewey',
+  shelvingAlgorithm: 'dewey',
+  typeIds: ['dewey-id', 'lc-id'],
+}];
+
+useCallNumberBrowseConfig.mockReturnValue({
+  callNumberBrowseConfig,
+  isCallNumberConfigLoading: false,
+});
+
 const mockPassedData = jest.fn();
 
 const Children = () => (
@@ -84,6 +99,7 @@ describe('DataProvider', () => {
     expect(mockPassedData).toHaveBeenCalledWith({
       ...commonData,
       classificationBrowseConfig,
+      callNumberBrowseConfig,
       ...Object.keys(resources).reduce((acc, name) => ({ ...acc, [name]: resources[name].records }), {}),
       identifierTypesById: {
         'identifierTypes-1': {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Description
In order to only return instances with the call number and call number type selected from call number browse settings, we need to use "Query search". When a user clicks on a call number title, they should be redirected to the Search page with a "Query search" option. It should have a call number query that takes into account the selected call number types.

The tests will pass after [PR](https://github.com/folio-org/stripes-inventory-components/pull/104) is merged, I didn't mock constants because tests will not catch the issue related to them if the constants become incorrect.

<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
Build a query in `getCallNumberQuery`. Take selected call number types from `useCallNumberBrowseConfig`.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-3205](https://folio-org.atlassian.net/browse/UIIN-3205)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots

https://github.com/user-attachments/assets/3b89f0a9-bdb7-4db5-bbbb-7c5a3e55e4f7




<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
