### PR TITLE
UIIN-3213 Create Inventory settings to configure number of cards in version history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * ECS: Disable opening item details if a user is not affiliated with item's member tenant. Fixes UIIN-3187.
 * Correctly depend on `inflected`. Refs UIIN-3203.
 * Decrease the amount of rerenders in `ConsortialHoldings` component. Fixes UIIN-3196.
+* Create Inventory settings to configure number of cards in version history. Refs UIIN-3213.
 
 ## [12.0.12](https://github.com/folio-org/ui-inventory/tree/v12.0.12) (2025-01-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.11...v12.0.12)

--- a/src/settings/CardsPerVersionHistoryPage/CardsPerVersionHistoryPage.js
+++ b/src/settings/CardsPerVersionHistoryPage/CardsPerVersionHistoryPage.js
@@ -1,0 +1,19 @@
+import { Paneset } from '@folio/stripes/components';
+
+import { CardsPerVersionHistoryPageForm } from './components';
+
+export const CardsPerVersionHistoryPage = () => {
+  const initialValues = {
+    cardsPerPage: 25,
+  };
+
+  return (
+    <Paneset id="cardsPerPage">
+      <CardsPerVersionHistoryPageForm
+        onSubmit={() => {}}
+        onCancel={() => {}}
+        initialValues={initialValues}
+      />
+    </Paneset>
+  );
+};

--- a/src/settings/CardsPerVersionHistoryPage/CardsPerVersionHistoryPage.test.js
+++ b/src/settings/CardsPerVersionHistoryPage/CardsPerVersionHistoryPage.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+
+import { CardsPerVersionHistoryPage } from './CardsPerVersionHistoryPage';
+
+import {
+  renderWithIntl,
+  translationsProperties,
+} from '../../../test/jest/helpers';
+
+jest.mock('./components', () => ({
+  CardsPerVersionHistoryPageForm: jest.fn(() => <div>CardsPerVersionHistoryPageForm</div>),
+}));
+
+describe('CardsPerVersionHistoryPage', () => {
+  const renderCardsPerVersionHistoryPage = () => (renderWithIntl(
+    <MemoryRouter>
+      <CardsPerVersionHistoryPage />
+    </MemoryRouter>,
+    translationsProperties
+  ));
+
+  it('should render the "CardsPerVersionHistoryPageForm" component', () => {
+    renderCardsPerVersionHistoryPage();
+
+    expect(screen.getByText('CardsPerVersionHistoryPageForm')).toBeInTheDocument();
+  });
+});

--- a/src/settings/CardsPerVersionHistoryPage/components/CardsPerVersionHistoryPageForm/CardsPerVersionHistoryPageForm.css
+++ b/src/settings/CardsPerVersionHistoryPage/components/CardsPerVersionHistoryPageForm/CardsPerVersionHistoryPageForm.css
@@ -1,0 +1,3 @@
+.cardsPerPageForm {
+  width: 100%;
+}

--- a/src/settings/CardsPerVersionHistoryPage/components/CardsPerVersionHistoryPageForm/CardsPerVersionHistoryPageForm.js
+++ b/src/settings/CardsPerVersionHistoryPage/components/CardsPerVersionHistoryPageForm/CardsPerVersionHistoryPageForm.js
@@ -1,0 +1,95 @@
+import {
+  useIntl,
+  FormattedMessage,
+} from 'react-intl';
+import { Field } from 'react-final-form';
+
+import stripesFinalForm from '@folio/stripes/final-form';
+import {
+  Select,
+  Pane,
+  Button,
+  PaneFooter,
+  PaneHeader,
+  Row,
+  Col,
+} from '@folio/stripes/components';
+
+import css from './CardsPerVersionHistoryPageForm.css';
+
+const CardsPerVersionHistoryPageForm = ({
+  handleSubmit,
+  pristine,
+  submitting,
+  values,
+  onCancel
+}) => {
+  const intl = useIntl();
+
+  const cardsPerPageOptions = [10, 25, 50, 75, 100];
+
+  const dataOptions = cardsPerPageOptions.map(option => ({
+    label: option,
+    value: option,
+  }));
+
+  const renderHeader = (paneHeaderProps) => {
+    return (
+      <PaneHeader
+        {...paneHeaderProps}
+        dismissible
+        onClose={onCancel}
+        paneTitle={intl.formatMessage({ id: 'ui-inventory.settings.section.cardsPerPage' })}
+      />
+    );
+  };
+
+  const renderFooter = () => {
+    const saveButton = (
+      <Button
+        buttonStyle="primary mega"
+        marginBottom0
+        disabled={(pristine || submitting)}
+        id="routing-list-save-button"
+        type="submit"
+      >
+        <FormattedMessage id="stripes-core.button.save" />
+      </Button>
+    );
+
+    return (
+      <PaneFooter renderEnd={saveButton} />
+    );
+  };
+
+  return (
+    <form
+      id="cards-per-page-form"
+      onSubmit={handleSubmit}
+      className={css.cardsPerPageForm}
+    >
+      <Pane
+        id="cards-per-page-pane"
+        defaultWidth="fill"
+        renderHeader={renderHeader}
+        footer={renderFooter()}
+      >
+        <Row>
+          <Col xs={6}>
+            <Field
+              name="cardsPerPage"
+              label={intl.formatMessage({ id: 'ui-inventory.settings.versionHistory.versionHistoryCardsPerPage' })}
+              component={Select}
+              dataOptions={dataOptions}
+            />
+          </Col>
+        </Row>
+      </Pane>
+    </form>
+  );
+};
+
+export default stripesFinalForm({
+  navigationCheck: true,
+  subscription: { values: true },
+})(CardsPerVersionHistoryPageForm);

--- a/src/settings/CardsPerVersionHistoryPage/components/CardsPerVersionHistoryPageForm/CardsPerVersionHistoryPageForm.js
+++ b/src/settings/CardsPerVersionHistoryPage/components/CardsPerVersionHistoryPageForm/CardsPerVersionHistoryPageForm.js
@@ -3,6 +3,7 @@ import {
   FormattedMessage,
 } from 'react-intl';
 import { Field } from 'react-final-form';
+import PropTypes from 'prop-types';
 
 import stripesFinalForm from '@folio/stripes/final-form';
 import {
@@ -17,11 +18,17 @@ import {
 
 import css from './CardsPerVersionHistoryPageForm.css';
 
+const propTypes = {
+  handleSubmit: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  pristine: PropTypes.bool,
+  submitting: PropTypes.bool,
+};
+
 const CardsPerVersionHistoryPageForm = ({
   handleSubmit,
   pristine,
   submitting,
-  values,
   onCancel
 }) => {
   const intl = useIntl();
@@ -88,6 +95,8 @@ const CardsPerVersionHistoryPageForm = ({
     </form>
   );
 };
+
+CardsPerVersionHistoryPageForm.propTypes = propTypes;
 
 export default stripesFinalForm({
   navigationCheck: true,

--- a/src/settings/CardsPerVersionHistoryPage/components/CardsPerVersionHistoryPageForm/CardsPerVersionHistoryPageForm.test.js
+++ b/src/settings/CardsPerVersionHistoryPage/components/CardsPerVersionHistoryPageForm/CardsPerVersionHistoryPageForm.test.js
@@ -1,0 +1,83 @@
+import { MemoryRouter } from 'react-router-dom';
+
+import {
+  fireEvent,
+  screen,
+} from '@folio/jest-config-stripes/testing-library/react';
+
+import CardsPerVersionHistoryPageForm from './CardsPerVersionHistoryPageForm';
+
+import {
+  renderWithIntl,
+  translationsProperties,
+} from '../../../../../test/jest/helpers';
+
+const mockOnSubmit = jest.fn();
+const mockOnCancel = jest.fn();
+const initialValues = {
+  cardsPerPage: 25,
+};
+
+const labels = {
+  cardsPerPageSelect: 'Cards to display per page on Version history',
+  saveButton: 'Save',
+};
+
+describe('CardsPerVersionHistoryPageForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderCardsPerVersionHistoryPageForm = (props = {}) => (renderWithIntl(
+    <MemoryRouter>
+      <CardsPerVersionHistoryPageForm
+        onSubmit={mockOnSubmit}
+        onCancel={mockOnCancel}
+        initialValues={initialValues}
+        {...props}
+      />
+    </MemoryRouter>,
+    translationsProperties
+  ));
+
+  describe('when the form is pristine', () => {
+    beforeEach(() => {
+      renderCardsPerVersionHistoryPageForm();
+    });
+
+    it('should display initial value', () => {
+      expect(screen.getByLabelText(labels.cardsPerPageSelect)).toHaveValue('25');
+    });
+
+    it('should disable the save button', () => {
+      expect(screen.getByRole('button', { name: labels.saveButton })).toBeDisabled();
+    });
+  });
+
+  describe('when the form is not pristine', () => {
+    beforeEach(() => {
+      renderCardsPerVersionHistoryPageForm();
+
+      fireEvent.change(screen.getByLabelText(labels.cardsPerPageSelect), { target: { value: 50 } });
+    });
+
+    it('should display a new value', () => {
+      expect(screen.getByLabelText(labels.cardsPerPageSelect)).toHaveValue('50');
+    });
+
+    it('should enable the save button', () => {
+      expect(screen.getByRole('button', { name: labels.saveButton })).toBeEnabled();
+    });
+
+    describe('when clicking on save', () => {
+      it('should call onSubmit', () => {
+        fireEvent.click(screen.getByRole('button', { name: labels.saveButton }));
+
+        expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+        expect(mockOnSubmit.mock.calls[0][0]).toEqual(expect.objectContaining({
+          cardsPerPage: '50',
+        }));
+      });
+    });
+  });
+});

--- a/src/settings/CardsPerVersionHistoryPage/components/CardsPerVersionHistoryPageForm/index.js
+++ b/src/settings/CardsPerVersionHistoryPage/components/CardsPerVersionHistoryPageForm/index.js
@@ -1,0 +1,1 @@
+export { default as CardsPerVersionHistoryPageForm } from './CardsPerVersionHistoryPageForm';

--- a/src/settings/CardsPerVersionHistoryPage/components/index.js
+++ b/src/settings/CardsPerVersionHistoryPage/components/index.js
@@ -1,0 +1,1 @@
+export * from './CardsPerVersionHistoryPageForm';

--- a/src/settings/CardsPerVersionHistoryPage/index.js
+++ b/src/settings/CardsPerVersionHistoryPage/index.js
@@ -1,0 +1,1 @@
+export { CardsPerVersionHistoryPage as default } from './CardsPerVersionHistoryPage';

--- a/src/settings/InventorySettings/InventorySettings.js
+++ b/src/settings/InventorySettings/InventorySettings.js
@@ -105,7 +105,7 @@ const InventorySettings = (props) => {
             route: 'cardsPerPage',
             label: <FormattedMessage id="ui-inventory.settings.section.cardsPerPage" />,
             component: CardsPerVersionHistoryPage,
-            perm: '',
+            perm: 'ui-inventory.settings.displaySettings',
           },
         ],
       },

--- a/src/settings/InventorySettings/InventorySettings.js
+++ b/src/settings/InventorySettings/InventorySettings.js
@@ -45,6 +45,7 @@ import ClassificationBrowseSettings from '../ClassificationBrowseSettings';
 import SubjectSourcesSettings from '../SubjectSourcesSettings';
 import SubjectTypesSettings from '../SubjectTypesSettings';
 import DisplaySettings from '../DisplaySettings';
+import CardsPerVersionHistoryPage from '../CardsPerVersionHistoryPage';
 import CallNumberBrowseSettings from '../CallNumberBrowseSettings';
 import {
   flattenCentralTenantPermissions,
@@ -94,6 +95,17 @@ const InventorySettings = (props) => {
             label: <FormattedMessage id="ui-inventory.settings.section.displaySettings" />,
             component: DisplaySettings,
             perm: 'ui-inventory.settings.displaySettings',
+          },
+        ],
+      },
+      {
+        label: <FormattedMessage id="ui-inventory.settings.heading.versionHistory" />,
+        pages: [
+          {
+            route: 'cardsPerPage',
+            label: <FormattedMessage id="ui-inventory.settings.section.cardsPerPage" />,
+            component: CardsPerVersionHistoryPage,
+            perm: '',
           },
         ],
       },

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -876,6 +876,9 @@
   "shortcut.editMARC.noPermission": "You do not have permission to edit the record.",
 
   "settings.heading.general": "General",
+  "settings.heading.versionHistory": "Version history",
+  "settings.section.cardsPerPage": "Cards per page",
+  "settings.versionHistory.versionHistoryCardsPerPage": "Cards to display per page on Version history",
   "settings.section.displaySettings": "Display settings",
   "settings.displaySettings.defaultSort": "Default sort",
 


### PR DESCRIPTION
## Description
Create Inventory settings to configure number of cards in version history

This ticket will be split into 2 parts: one for react component and another for hooks to fetch/save data

This is the react components PR.
The new setting will exist under a new group "Version history"
Two new components are added: `<CardsPerVersionHistoryPage>` and `<CardsPerVersionHistoryPageForm>`

`<CardsPerVersionHistoryPageForm>` defines the form, and `<CardsPerVersionHistoryPage>` uses it and with the second PR will handle the requests logic via hooks.

## Screenshots

## Issues
[UIIN-3213](https://folio-org.atlassian.net/browse/UIIN-3213)