### PR TITLE
UIIN-3234: Change `itemNormalizedCallNumbers` to `itemFullCallNumbers` in `getCallNumberQuery`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Add Version history button and Version history pane to details view of Instance. Refs UIIN-3170.
 * Add new ‘Set for deletion’ flag to display on 3rd pane Instance view. Refs UIIN-3191.
 * Add settings options for using number gernerator for item barcode, accession number and call number. Refs UIIN-2557.
+* Change itemNormalizedCallNumbers to itemFullCallNumbers in getCallNumberQuery. Refs UIIN-3234.
 
 ## [12.0.12](https://github.com/folio-org/ui-inventory/tree/v12.0.12) (2025-01-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.11...v12.0.12)

--- a/src/components/BrowseResultsList/getBrowseResultsFormatter.test.js
+++ b/src/components/BrowseResultsList/getBrowseResultsFormatter.test.js
@@ -165,7 +165,7 @@ describe('getBrowseResultsFormatter', () => {
         const query = queryString.stringify({
           selectedBrowseResult: true,
           qindex: queryIndexes.QUERY_SEARCH,
-          query: 'itemNormalizedCallNumbers="PRE CALL SUF" and (item.effectiveCallNumberComponents.typeId=="dewey-id" or item.effectiveCallNumberComponents.typeId=="lc-id")',
+          query: 'itemFullCallNumbers="PRE CALL SUF" and (item.effectiveCallNumberComponents.typeId=="dewey-id" or item.effectiveCallNumberComponents.typeId=="lc-id")',
         });
 
         expect(getByText('PRE CALL SUF').href).toContain(`${INVENTORY_ROUTE}?${query}`);

--- a/src/components/BrowseResultsList/utils.js
+++ b/src/components/BrowseResultsList/utils.js
@@ -120,7 +120,7 @@ const getCallNumberQuery = (qindex, data, row) => {
     return '';
   }
 
-  let query = `itemNormalizedCallNumbers="${fullCallNumber}"`;
+  let query = `itemFullCallNumbers="${fullCallNumber}"`;
 
   const callNumberBrowseConfigId = browseCallNumberIndexToId[qindex];
 


### PR DESCRIPTION

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Search the same number of Instances, specified in the Browse “Number of titles” column. 
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
Use `itemFullCallNumbers` instead of `itemNormalizedCallNumbers`. `itemNormalizedCallNumbers` uses the right truncation during the search while `itemFullCallNumbers` does an exact match.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-3234](https://folio-org.atlassian.net/browse/UIIN-3234)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
