### PR TITLE
UIIN-3235 MARC Bib > View Source > Display Version History pane with an empty Version History component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Add settings options for using number gernerator for item barcode, accession number and call number. Refs UIIN-2557.
 * Change itemNormalizedCallNumbers to itemFullCallNumbers in getCallNumberQuery. Refs UIIN-3234.
 * *BREAKING* Create Inventory settings to configure number of cards in version history. Refs UIIN-3213.
+* MARC Bib > View Source > Display Version History pane with an empty Version History component. Refs UIIN-3235.
 
 ## [12.0.12](https://github.com/folio-org/ui-inventory/tree/v12.0.12) (2025-01-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.11...v12.0.12)

--- a/package.json
+++ b/package.json
@@ -1018,7 +1018,7 @@
           "audit.config.groups.collection.get",
           "audit.config.groups.settings.audit.inventory.collection.get",
           "audit.config.groups.settings.item.put",
-          "audit.config.groups.settings.audit.inventory.item.put"
+          "audit.config.groups.settings.audit.inventory.records.page.size.item.put"
         ],
         "visible": true
       }

--- a/src/components/ViewSource/ViewSource.js
+++ b/src/components/ViewSource/ViewSource.js
@@ -18,6 +18,8 @@ import {
   LoadingView,
   HasCommand,
   checkScope,
+  Paneset,
+  PaneMenu,
 } from '@folio/stripes/components';
 import {
   useCallout,
@@ -31,6 +33,7 @@ import {
   getHeaders,
 } from '@folio/stripes-marc-components';
 
+import { VersionHistory } from '../../views/VersionHistory';
 import ActionItem from '../ActionItem';
 import { useGoBack } from '../../common/hooks';
 import { useQuickExport } from '../../hooks';
@@ -45,6 +48,7 @@ import MARC_TYPES from './marcTypes';
 import { INSTANCE_RECORD_TYPE } from '../../constants';
 
 import styles from './ViewSource.css';
+import { VersionHistoryButton } from '@folio/stripes-acq-components';
 
 const ViewSource = ({
   mutator,
@@ -61,6 +65,7 @@ const ViewSource = ({
   const history = useHistory();
   const callout = useCallout();
   const [isShownPrintPopup, setIsShownPrintPopup] = useState(false);
+  const [isVersionHistoryOpen, setIsVersionHistoryOpen] = useState(false);
   const { exportRecords } = useQuickExport();
   const openPrintPopup = () => setIsShownPrintPopup(true);
   const closePrintPopup = () => setIsShownPrintPopup(false);
@@ -203,6 +208,12 @@ const ViewSource = ({
     );
   }, []);
 
+  const lastMenu = (
+    <PaneMenu>
+      <VersionHistoryButton onClick={() => setIsVersionHistoryOpen(true)} />
+    </PaneMenu>
+  );
+
   if (isMarcLoading || isInstanceLoading) return <LoadingView />;
 
   if (!(marc && instance)) return null;
@@ -231,13 +242,16 @@ const ViewSource = ({
       isWithinScope={checkScope}
       scope={document.body}
     >
-      <div className={styles.viewSource}>
+      <Paneset id="view-source-paneset">
         <MarcView
           paneTitle={paneTitle}
           marcTitle={marcTitle}
           marc={marc}
           onClose={goBack}
           actionMenu={actionMenu}
+          lastMenu={lastMenu}
+          paneWidth="fill"
+          wrapperClass={styles.viewSource}
         />
         {isPrintAvailable && isShownPrintPopup && (
           <PrintPopup
@@ -247,7 +261,12 @@ const ViewSource = ({
             onAfterPrint={closePrintPopup}
           />
         )}
-      </div>
+        {isVersionHistoryOpen && (
+          <VersionHistory
+            onClose={() => setIsVersionHistoryOpen(false)}
+          />
+        )}
+      </Paneset>
     </HasCommand>
   );
 };

--- a/src/components/ViewSource/ViewSource.js
+++ b/src/components/ViewSource/ViewSource.js
@@ -32,6 +32,7 @@ import {
   PrintPopup,
   getHeaders,
 } from '@folio/stripes-marc-components';
+import { VersionHistoryButton } from '@folio/stripes-acq-components';
 
 import { VersionHistory } from '../../views/VersionHistory';
 import ActionItem from '../ActionItem';
@@ -48,7 +49,6 @@ import MARC_TYPES from './marcTypes';
 import { INSTANCE_RECORD_TYPE } from '../../constants';
 
 import styles from './ViewSource.css';
-import { VersionHistoryButton } from '@folio/stripes-acq-components';
 
 const ViewSource = ({
   mutator,

--- a/src/components/ViewSource/ViewSource.test.js
+++ b/src/components/ViewSource/ViewSource.test.js
@@ -230,4 +230,18 @@ describe('ViewSource', () => {
       });
     });
   });
+
+  describe('when clicking on the version history icon', () => {
+    beforeEach(async () => {
+      await act(async () => {
+        await renderWithIntl(getViewSource(), []);
+      });
+    });
+
+    it('should open the version history pane', () => {
+      fireEvent.click(screen.getByLabelText('stripes-acq-components.versionHistory.pane.header'));
+
+      expect(screen.getByText('stripes-acq-components.versionHistory.pane.sub')).toBeInTheDocument();
+    });
+  });
 });

--- a/test/jest/__mock__/stripesMarcComponents.mock.js
+++ b/test/jest/__mock__/stripesMarcComponents.mock.js
@@ -2,13 +2,14 @@ import React from 'react';
 
 jest.mock('@folio/stripes-marc-components', () => ({
   ...jest.requireActual('@folio/stripes-marc-components'),
-  MarcView: jest.fn(({ onClose, marcTitle, actionMenu }) => (
+  MarcView: jest.fn(({ onClose, marcTitle, actionMenu, lastMenu }) => (
     <>
       {marcTitle}
       <button type="button" onClick={onClose}>
         MarcView
       </button>
       {actionMenu({ onToggle: jest.fn() })}
+      {lastMenu}
     </>
   )),
 }));


### PR DESCRIPTION
## Description
MARC Bib > View Source > Display Version History pane with an empty Version History component

Actual implementation with real requests will be done after the AuditLogPane component has been implemented

## Screenshots

https://github.com/user-attachments/assets/0633ecf2-7800-428b-9232-83fbad3e62d0

## Issues
[UIIN-3235](https://folio-org.atlassian.net/browse/UIIN-3235)

## Related PRs
https://github.com/folio-org/stripes-marc-components/pull/38