### PR TITLE
UIIN-3176: Instance: Suppress action menu and disable buttons when click Change log icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * *BREAKING* Create Inventory settings to configure number of cards in version history. Refs UIIN-3213.
 * Add ‘Set for deletion’ checkbox field to Instance Edit view. Refs UIIN-3190.
 * MARC Bib > View Source > Display Version History pane with an empty Version History component. Refs UIIN-3235.
+* Instance: Suppress action menu and disable buttons when click Change log icon. Refs UIIN-3176.
 
 ## [12.0.12](https://github.com/folio-org/ui-inventory/tree/v12.0.12) (2025-01-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.11...v12.0.12)

--- a/src/Instance/InstanceDetails/InstanceDetails.js
+++ b/src/Instance/InstanceDetails/InstanceDetails.js
@@ -117,13 +117,17 @@ const InstanceDetails = forwardRef(({
               onClick={() => setHelperApp('tags')}
               badgeCount={tags?.length}
               ariaLabel={intl.formatMessage({ id: 'ui-inventory.showTags' })}
+              disabled={isVersionHistoryOpen}
             />
           )
         }
-        <VersionHistoryButton onClick={() => setIsVersionHistoryOpen(true)} />
+        <VersionHistoryButton
+          disabled={isVersionHistoryOpen}
+          onClick={() => setIsVersionHistoryOpen(true)}
+        />
       </PaneMenu>
     );
-  }, [tagsEnabled, tags, intl]);
+  }, [tagsEnabled, tags, intl, isVersionHistoryOpen]);
 
   const updatePrevInstanceId = id => {
     prevInstanceId.current = id;
@@ -199,7 +203,7 @@ const InstanceDetails = forwardRef(({
         appIcon={<AppIcon app="inventory" iconKey="instance" />}
         paneTitle={paneTitle}
         paneSub={paneSubTitle}
-        actionMenu={actionMenu}
+        actionMenu={!isVersionHistoryOpen ? actionMenu : null}
         firstMenu={(
           <PaneCloseLink
             autoFocus={location.state?.isClosingFocused}

--- a/src/Instance/InstanceDetails/InstanceDetails.test.js
+++ b/src/Instance/InstanceDetails/InstanceDetails.test.js
@@ -57,7 +57,7 @@ const mockReferenceData = {
 
 const queryClient = new QueryClient();
 
-const actionMenu = jest.fn();
+const actionMenu = jest.fn(() => <span>Action menu</span>);
 const onClose = jest.fn();
 const tagsEnabled = true;
 
@@ -241,10 +241,24 @@ describe('InstanceDetails', () => {
     });
 
     describe('when click the button', () => {
-      it('should render version history pane', async () => {
+      beforeEach(async () => {
         await act(() => userEvent.click(versionHistoryButton));
+      });
 
+      it('should render version history pane', () => {
         expect(screen.getByRole('region', { name: /version history/i })).toBeInTheDocument();
+      });
+
+      it('should hide action menu', () => {
+        expect(screen.queryByText('Action menu')).not.toBeInTheDocument();
+      });
+
+      it('should disable tags button', () => {
+        expect(screen.getByRole('button', { name: /show tags/i })).toBeDisabled();
+      });
+
+      it('should disable version history button', () => {
+        expect(screen.getByRole('button', { name: /version history/i })).toBeDisabled();
       });
     });
 

--- a/src/Instance/InstanceDetails/InstanceDetails.test.js
+++ b/src/Instance/InstanceDetails/InstanceDetails.test.js
@@ -57,7 +57,7 @@ const mockReferenceData = {
 
 const queryClient = new QueryClient();
 
-const actionMenu = jest.fn(() => <span>Action menu</span>);
+const actionMenu = jest.fn(() => <button type="button">Action menu</button>);
 const onClose = jest.fn();
 const tagsEnabled = true;
 


### PR DESCRIPTION
## Purpose
* On Instance view in Inventory, when you click the 'Version history' icon to open the Version history view in the 4th pane, the following should also occur in the 3rd pane:
- `Actions` menu button disappears
- `Tags` icon become greyed out and unclickable
- `Version history` icon become greyed out and unclickable

## Approach
* Hide/disable buttons when `isVersionHistoryOpen` is true.

## Refs
[UIIN-3176](https://folio-org.atlassian.net/browse/UIIN-3176)

## Screenshots
https://github.com/user-attachments/assets/7d2d1c01-c24f-4f11-81f0-1edbf761d799

