### PR TITLE
UIIN-3177: Holdings: Suppress action menu and disable buttons when click Change log icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Add ‘Set for deletion’ checkbox field to Instance Edit view. Refs UIIN-3190.
 * MARC Bib > View Source > Display Version History pane with an empty Version History component. Refs UIIN-3235.
 * MARC Bib - Hide version history icon and settings if audit log feature is disabled. Refs UIIN-3237.
+* Holdings: Suppress action menu and disable buttons when click Change log icon. Refs UIIN-3177.
 
 ## [12.0.12](https://github.com/folio-org/ui-inventory/tree/v12.0.12) (2025-01-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.11...v12.0.12)

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -653,7 +653,10 @@ class ViewHoldingsRecord extends React.Component {
       goTo,
       stripes,
     } = this.props;
-    const { instance } = this.state;
+    const {
+      instance,
+      isVersionHistoryOpen,
+    } = this.state;
 
     if (this.isAwaitingResource()) return <LoadingView />;
 
@@ -968,10 +971,13 @@ class ViewHoldingsRecord extends React.Component {
                     })}
                     dismissible
                     onClose={this.onClose}
-                    actionMenu={this.getPaneHeaderActionMenu}
+                    actionMenu={(params) => !isVersionHistoryOpen && this.getPaneHeaderActionMenu(params)}
                     lastMenu={(
                       <PaneMenu>
-                        <VersionHistoryButton onClick={this.openVersionHistory} />
+                        <VersionHistoryButton
+                          onClick={this.openVersionHistory}
+                          disabled={isVersionHistoryOpen}
+                        />
                       </PaneMenu>
                     )}
                   >

--- a/src/ViewHoldingsRecord.test.js
+++ b/src/ViewHoldingsRecord.test.js
@@ -590,9 +590,19 @@ describe('ViewHoldingsRecord actions', () => {
     });
 
     describe('when click the button', () => {
-      it('should render version history pane', async () => {
+      beforeEach(async () => {
         await userEvent.click(versionHistoryButton);
+      });
 
+      it('should hide action menu', () => {
+        expect(screen.queryByText('Actions')).not.toBeInTheDocument();
+      });
+
+      it('should disable version history button', () => {
+        expect(screen.getByRole('button', { name: /version history/i })).toBeDisabled();
+      });
+
+      it('should render version history pane', async () => {
         expect(screen.getByRole('region', { name: /version history/i })).toBeInTheDocument();
       });
     });

--- a/src/ViewHoldingsRecord.test.js
+++ b/src/ViewHoldingsRecord.test.js
@@ -602,7 +602,7 @@ describe('ViewHoldingsRecord actions', () => {
         expect(screen.getByRole('button', { name: /version history/i })).toBeDisabled();
       });
 
-      it('should render version history pane', async () => {
+      it('should render version history pane', () => {
         expect(screen.getByRole('region', { name: /version history/i })).toBeInTheDocument();
       });
     });


### PR DESCRIPTION
## Purpose
* On Holdings view in Inventory, when you click the 'Version history' icon to open the Version history view in the 2nd pane, the following should also occur in the 1st pane:
- Actions menu button disappears
- Version history icon become greyed out and unclickable

## Approach
* Hide/disable buttons when `isVersionHistoryOpen` is true.

## Refs
[UIIN-3177](https://folio-org.atlassian.net/browse/UIIN-3177)

## Screenshots
![image](https://github.com/user-attachments/assets/8a0f1fcd-daa9-4547-98ae-8cd594c5fd65)

