### PR TITLE
UIIN-3178: Item: Suppress action menu and disable buttons when click Change log icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Add ‘Set for deletion’ checkbox field to Instance Edit view. Refs UIIN-3190.
 * MARC Bib > View Source > Display Version History pane with an empty Version History component. Refs UIIN-3235.
 * MARC Bib - Hide version history icon and settings if audit log feature is disabled. Refs UIIN-3237.
+* Item: Suppress action menu and disable buttons when click Change log icon. Refs UIIN-3178.
 
 ## [12.0.12](https://github.com/folio-org/ui-inventory/tree/v12.0.12) (2025-01-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.11...v12.0.12)

--- a/src/views/ItemView.js
+++ b/src/views/ItemView.js
@@ -1021,10 +1021,13 @@ const ItemView = props => {
           )}
           dismissible
           onClose={onCloseViewItem}
-          actionMenu={getActionMenu}
+          actionMenu={(params) => !isVersionHistoryOpen && getActionMenu(params)}
           lastMenu={(
             <PaneMenu>
-              <VersionHistoryButton onClick={openVersionHistory} />
+              <VersionHistoryButton
+                onClick={openVersionHistory}
+                disabled={isVersionHistoryOpen}
+              />
             </PaneMenu>
           )}
         >

--- a/src/views/ItemView.test.js
+++ b/src/views/ItemView.test.js
@@ -293,39 +293,50 @@ describe('ItemView', () => {
         expect(mockPush).toHaveBeenCalled();
       });
     });
+  });
 
-    describe('Version history component', () => {
-      let versionHistoryButton;
+  describe('Version history component', () => {
+    let versionHistoryButton;
 
-      beforeEach(() => {
-        const { container } = renderWithIntl(<ItemViewSetup />, translationsProperties);
+    beforeEach(() => {
+      const { container } = renderWithIntl(<ItemViewSetup />, translationsProperties);
 
-        versionHistoryButton = container.querySelector('#version-history-btn');
+      versionHistoryButton = container.querySelector('#version-history-btn');
+    });
+
+    it('should render version history button', () => {
+      expect(versionHistoryButton).toBeInTheDocument();
+    });
+
+    describe('when click the button', () => {
+      beforeEach(async () => {
+        await userEvent.click(versionHistoryButton);
       });
 
-      it('should render version history button', () => {
-        expect(versionHistoryButton).toBeInTheDocument();
+      it('should hide action menu', () => {
+        expect(screen.queryByText('Actions')).not.toBeInTheDocument();
       });
 
-      describe('when click the button', () => {
-        it('should render version history pane', async () => {
-          await userEvent.click(versionHistoryButton);
-          expect(screen.getByRole('region', { name: /version history/i })).toBeInTheDocument();
-        });
+      it('should disable version history button', () => {
+        expect(screen.getByRole('button', { name: /version history/i })).toBeDisabled();
       });
 
-      describe('when click the close button', () => {
-        it('should hide the pane', async () => {
-          await userEvent.click(versionHistoryButton);
+      it('should render version history pane', () => {
+        expect(screen.getByRole('region', { name: /version history/i })).toBeInTheDocument();
+      });
+    });
 
-          const versionHistoryPane = await screen.findByRole('region', { name: /version history/i });
-          expect(versionHistoryPane).toBeInTheDocument();
+    describe('when click the close button', () => {
+      it('should hide the pane', async () => {
+        await userEvent.click(versionHistoryButton);
 
-          const closeButton = await within(versionHistoryPane).findByRole('button', { name: /close/i });
-          await userEvent.click(closeButton);
+        const versionHistoryPane = await screen.findByRole('region', { name: /version history/i });
+        expect(versionHistoryPane).toBeInTheDocument();
 
-          expect(screen.queryByRole('region', { name: /version history/i })).not.toBeInTheDocument();
-        });
+        const closeButton = await within(versionHistoryPane).findByRole('button', { name: /close/i });
+        await userEvent.click(closeButton);
+
+        expect(screen.queryByRole('region', { name: /version history/i })).not.toBeInTheDocument();
       });
     });
   });


### PR DESCRIPTION
## Purpose
* On Item view in Inventory, when you click the 'Version history' icon to open the Version history view in the 2nd pane, the following should also occur in the 1st pane:
- Actions menu button disappears
- Version history icon become greyed out and unclickable

## Approach
* Hide/disable buttons when `isVersionHistoryOpen` is true.

## Refs
[UIIN-3178](https://folio-org.atlassian.net/browse/UIIN-3178)

## Screenshots
![image](https://github.com/user-attachments/assets/bf5a2ea6-2844-4145-b928-9f8755307043)

