### PR TITLE
UIIN-3173: Instance: Display all versions in View history fourth pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Add Version history button and Version history pane to details view of Instance. Refs UIIN-3170.
 * Add new ‘Set for deletion’ flag to display on 3rd pane Instance view. Refs UIIN-3191.
 * Add settings options for using number gernerator for item barcode, accession number and call number. Refs UIIN-2557.
+* Instance: Display all versions in View history fourth pane. Refs UIIN-3173.
 
 ## [12.0.12](https://github.com/folio-org/ui-inventory/tree/v12.0.12) (2025-01-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.11...v12.0.12)

--- a/src/Instance/InstanceDetails/InstanceDetails.js
+++ b/src/Instance/InstanceDetails/InstanceDetails.js
@@ -43,11 +43,12 @@ import { InstanceClassificationView } from './InstanceClassificationView';
 import { InstanceRelationshipView } from './InstanceRelationshipView';
 import { InstanceNewHolding } from './InstanceNewHolding';
 import { InstanceAcquisition } from './InstanceAcquisition';
-import HelperApp from '../../components/HelperApp';
-import { VersionHistory } from '../../views/VersionHistory';
 
+import HelperApp from '../../components/HelperApp';
 import { DataContext } from '../../contexts';
 import { ConsortialHoldings } from '../HoldingsList/consortium/ConsortialHoldings';
+import { InstanceVersionHistory } from '../InstanceVersionHistory';
+
 import {
   getAccordionState,
   getPublishingInfo,
@@ -328,7 +329,8 @@ const InstanceDetails = forwardRef(({
         </AccordionStatus>
       </Pane>
       {isVersionHistoryOpen && (
-        <VersionHistory
+        <InstanceVersionHistory
+          instanceId={instance?.id}
           onClose={() => setIsVersionHistoryOpen(false)}
         />
       )}

--- a/src/Instance/InstanceVersionHistory/InstanceVersionHistory.js
+++ b/src/Instance/InstanceVersionHistory/InstanceVersionHistory.js
@@ -1,0 +1,103 @@
+import { useContext } from 'react';
+import { useIntl } from 'react-intl';
+import PropTypes from 'prop-types';
+
+import { NoValue } from '@folio/stripes/components';
+import { AuditLogPane } from '@folio/stripes-acq-components';
+
+import { DataContext } from '../../contexts';
+
+import { useInstanceAuditDataQuery } from '../../hooks';
+import { getDateWithTime } from '../../utils';
+
+const InstanceVersionHistory = ({
+  instanceId,
+  onClose,
+}) => {
+  const { formatMessage } = useIntl();
+  const { data, isLoading } = useInstanceAuditDataQuery(instanceId);
+  const referenceData = useContext(DataContext);
+
+  const fieldLabelsMap = {
+    administrativeNotes: formatMessage({ id: 'ui-inventory.administrativeNotes' }),
+    alternativeTitles: formatMessage({ id: 'ui-inventory.alternativeTitles' }),
+    catalogedDate: formatMessage({ id: 'ui-inventory.catalogedDate' }),
+    childInstances: formatMessage({ id: 'ui-inventory.childInstances' }),
+    classifications: formatMessage({ id: 'ui-inventory.classifications' }),
+    contributors: formatMessage({ id: 'ui-inventory.contributors' }),
+    date1: formatMessage({ id: 'ui-inventory.date1' }),
+    date2: formatMessage({ id: 'ui-inventory.date2' }),
+    dateTypeId: formatMessage({ id: 'ui-inventory.dateType' }),
+    deleted: formatMessage({ id: 'ui-inventory.setForDeletion' }),
+    discoverySuppress: formatMessage({ id: 'ui-inventory.discoverySuppressed' }),
+    editions: formatMessage({ id: 'ui-inventory.edition' }),
+    electronicAccess: formatMessage({ id: 'ui-inventory.electronicAccess' }),
+    hrid: formatMessage({ id: 'ui-inventory.instanceHrid' }),
+    identifiers: formatMessage({ id: 'ui-inventory.identifiers' }),
+    instanceFormatIds: formatMessage({ id: 'ui-inventory.instanceFormats' }),
+    instanceTypeId: formatMessage({ id: 'ui-inventory.resourceType' }),
+    indexTitle: formatMessage({ id: 'ui-inventory.indexTitle' }),
+    languages: formatMessage({ id: 'ui-inventory.languages' }),
+    modeOfIssuanceId: formatMessage({ id: 'ui-inventory.modeOfIssuance' }),
+    natureOfContentTermIds: formatMessage({ id: 'ui-inventory.natureOfContentTerms' }),
+    notes: formatMessage({ id: 'ui-inventory.instanceNotes' }),
+    parentInstances: formatMessage({ id: 'ui-inventory.parentInstances' }),
+    physicalDescriptions: formatMessage({ id: 'ui-inventory.physicalDescriptions' }),
+    precedingTitles: formatMessage({ id: 'ui-inventory.precedingTitles' }),
+    previouslyHeld: formatMessage({ id: 'ui-inventory.previouslyHeld' }),
+    publication: formatMessage({ id: 'ui-inventory.publications' }),
+    publicationFrequency: formatMessage({ id: 'ui-inventory.publicationFrequency' }),
+    publicationRange: formatMessage({ id: 'ui-inventory.publicationRange' }),
+    series: formatMessage({ id: 'ui-inventory.seriesStatements' }),
+    source: formatMessage({ id: 'ui-inventory.source' }),
+    staffSuppress: formatMessage({ id: 'ui-inventory.staffSuppressed' }),
+    statisticalCodeIds: formatMessage({ id: 'ui-inventory.statisticalCodes' }),
+    statusId: formatMessage({ id: 'ui-inventory.instanceStatus' }),
+    statusUpdatedDate: formatMessage({ id: 'ui-inventory.instanceStatusUpdatedDate' }),
+    subjects: formatMessage({ id: 'ui-inventory.subjects' }),
+    succeedingTitles: formatMessage({ id: 'ui-inventory.succeedingTitles' }),
+    tagList: formatMessage({ id: 'stripes-smart-components.tags' }),
+    title: formatMessage({ id: 'ui-inventory.instances.columns.title' }),
+  };
+  const fieldFormatter = {
+    alternativeTitleTypeId: value => referenceData.alternativeTitleTypes?.find(type => type.id === value)?.name,
+    classificationTypeId: value => referenceData.classificationTypes?.find(type => type.id === value)?.name,
+    contributorNameTypeId: value => referenceData.contributorNameTypes?.find(contributor => contributor.id === value)?.name,
+    contributorTypeId: value => referenceData.contributorTypes?.find(contributor => contributor.id === value)?.name,
+    contributorTypeText: value => value || <NoValue />,
+    dateTypeId: value => referenceData.instanceDateTypes?.find(type => type.id === value)?.name,
+    identifierTypeId: value => referenceData.identifierTypes?.find(type => type.id === value)?.name,
+    instanceFormatIds: value => referenceData.instanceFormats?.find(format => format.id === value)?.name,
+    instanceNoteTypeId: value => referenceData.instanceNoteTypes?.find(note => note.id === value)?.name,
+    instanceTypeId: value => referenceData.instanceTypes?.find(type => type.id === value)?.name,
+    modeOfIssuanceId: value => referenceData.modesOfIssuance?.find(mode => mode.id === value)?.name,
+    natureOfContentTermIds: value => referenceData.natureOfContentTerms?.find(term => term.id === value)?.name,
+    primary: value => value.toString(),
+    relationshipId: value => referenceData.electronicAccessRelationships?.find(rel => rel.id === value)?.name,
+    sourceId: value => referenceData.subjectSources?.find(source => source.id === value)?.name,
+    staffOnly: value => value.toString(),
+    statisticalCodeIds: value => referenceData.statisticalCodes?.find(code => code.id === value)?.name,
+    statusId: value => referenceData.instanceStatuses?.find(status => status.id === value)?.name,
+    statusUpdatedDate: value => getDateWithTime(value),
+    typeId: value => referenceData.subjectTypes?.find(type => type.id === value)?.name,
+    uri: value => value || <NoValue />,
+  };
+
+
+  return (
+    <AuditLogPane
+      onClose={onClose}
+      isLoading={isLoading}
+      versions={data}
+      fieldLabelsMap={fieldLabelsMap}
+      fieldFormatter={fieldFormatter}
+    />
+  );
+};
+
+InstanceVersionHistory.propTypes = {
+  instanceId: PropTypes.string.isRequired,
+  onClose: PropTypes.func,
+};
+
+export default InstanceVersionHistory;

--- a/src/Instance/InstanceVersionHistory/InstanceVersionHistory.test.js
+++ b/src/Instance/InstanceVersionHistory/InstanceVersionHistory.test.js
@@ -1,0 +1,65 @@
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+
+import {
+  renderWithIntl,
+  translationsProperties,
+} from '../../../test/jest/helpers';
+
+import InstanceVersionHistory from './InstanceVersionHistory';
+import { DataContext } from '../../contexts';
+
+jest.mock('../../hooks', () => ({
+  ...jest.requireActual('../../hooks'),
+  useInstanceAuditDataQuery: () => jest.fn(),
+}));
+
+const queryClient = new QueryClient();
+
+const onCloseMock = jest.fn();
+const instanceId = 'instanceId';
+const mockReferenceData = {
+  alternativeTitleTypes: [],
+  classificationTypes: [],
+  contributorNameTypes: [],
+  contributorTypes: [],
+  instanceDateTypes: [],
+  identifierTypes: [],
+  instanceFormats: [],
+  instanceNoteTypes: [],
+  instanceTypes: [],
+  modesOfIssuance: [],
+  natureOfContentTerms: [],
+  electronicAccessRelationships: [],
+  subjectSources: [],
+  statisticalCodes: [],
+  instanceStatuses: [],
+  subjectTypes:[],
+};
+
+const renderInstanceVersionHistory = () => {
+  const component = (
+    <QueryClientProvider client={queryClient}>
+      <DataContext.Provider value={mockReferenceData}>
+        <InstanceVersionHistory
+          instanceId={instanceId}
+          onClose={onCloseMock}
+        />
+      </DataContext.Provider>
+    </QueryClientProvider>
+  );
+
+  return renderWithIntl(component, translationsProperties);
+};
+
+describe('InstanceVersionHistory', () => {
+  it('should render View history pane', () => {
+    renderInstanceVersionHistory();
+
+    expect(screen.getByText('Version history')).toBeInTheDocument();
+  });
+});
+

--- a/src/Instance/InstanceVersionHistory/index.js
+++ b/src/Instance/InstanceVersionHistory/index.js
@@ -1,0 +1,1 @@
+export { default as InstanceVersionHistory } from './InstanceVersionHistory';

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -5,6 +5,7 @@ export { default as useCallout } from './useCallout';
 export { default as useHoldingItemsQuery } from './useHoldingItemsQuery';
 export { default as useHoldingMutation } from './useHoldingMutation';
 export { default as useHoldingsFromStorage } from './useHoldingsFromStorage';
+export { default as useInstanceAuditDataQuery } from './useInstanceAuditDataQuery';
 export { default as useInstanceMutation } from './useInstanceMutation';
 export { default as useHoldingsQueryByHrids } from './useHoldingsQueryByHrids';
 export { default as useInventoryBrowse } from './useInventoryBrowse';

--- a/src/hooks/useInstanceAuditDataQuery/index.js
+++ b/src/hooks/useInstanceAuditDataQuery/index.js
@@ -1,0 +1,1 @@
+export { default } from './useInstanceAuditDataQuery';

--- a/src/hooks/useInstanceAuditDataQuery/useInstanceAuditDataQuery.js
+++ b/src/hooks/useInstanceAuditDataQuery/useInstanceAuditDataQuery.js
@@ -1,0 +1,26 @@
+import { useQuery } from 'react-query';
+
+import {
+  useNamespace,
+  useOkapiKy,
+} from '@folio/stripes/core';
+
+import { LIMIT_MAX } from '@folio/stripes-inventory-components';
+
+const useInstanceAuditDataQuery = (instanceId) => {
+  const ky = useOkapiKy();
+  const [namespace] = useNamespace({ key: 'instance-audit-data' });
+
+  const { isLoading, data = {} } = useQuery({
+    queryKey: [namespace, instanceId],
+    queryFn: () => ky.get(`audit-data/inventory/instance/${instanceId}`, { searchParams: { limit: LIMIT_MAX } }).json(),
+    enabled: Boolean(instanceId),
+  });
+
+  return {
+    data: data?.inventoryAuditItems || [],
+    isLoading,
+  };
+};
+
+export default useInstanceAuditDataQuery;


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Render View history pane for Inventory instance.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Use `AuditLogane` component to render View history
- Create fieldLabelsMap and fieldFormatter for instance changed fields

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3173

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
<img width="1512" alt="Screenshot 2025-02-24 at 15 53 49" src="https://github.com/user-attachments/assets/f01ed89b-c96f-4fac-aa88-54f7bf2651c9" />
<img width="1512" alt="Screenshot 2025-02-24 at 15 54 06" src="https://github.com/user-attachments/assets/37af8a11-3231-467f-94fc-10e8a5ec4892" />
