### PR TITLE
UIIN-3254: Use the name `CALL_NUMBERS_SHARED` for the `Shared` facet instead of `SHARED`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Instance: Suppress action menu and disable buttons when click Change log icon. Refs UIIN-3176.
 * Holdings: Suppress action menu and disable buttons when click Change log icon. Refs UIIN-3177.
 * Item: Suppress action menu and disable buttons when click Change log icon. Refs UIIN-3178.
+* Use the name CALL_NUMBERS_SHARED for the Shared facet instead of SHARED. Fixes UIIN-3254.
 
 ## [12.0.12](https://github.com/folio-org/ui-inventory/tree/v12.0.12) (2025-01-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.11...v12.0.12)

--- a/src/components/BrowseResultsList/BrowseResultsList.test.js
+++ b/src/components/BrowseResultsList/BrowseResultsList.test.js
@@ -157,13 +157,13 @@ describe('BrowseResultsList', () => {
   });
 
   describe.each([
-    { searchOption: browseCallNumberOptions.CALL_NUMBERS, shared: FACETS.SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
-    { searchOption: browseCallNumberOptions.DEWEY, shared: FACETS.SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
-    { searchOption: browseCallNumberOptions.LIBRARY_OF_CONGRESS, shared: FACETS.SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
-    { searchOption: browseCallNumberOptions.LOCAL, shared: FACETS.SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
-    { searchOption: browseCallNumberOptions.NATIONAL_LIBRARY_OF_MEDICINE, shared: FACETS.SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
-    { searchOption: browseCallNumberOptions.OTHER, shared: FACETS.SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
-    { searchOption: browseCallNumberOptions.SUPERINTENDENT, shared: FACETS.SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
+    { searchOption: browseCallNumberOptions.CALL_NUMBERS, shared: FACETS.CALL_NUMBERS_SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
+    { searchOption: browseCallNumberOptions.DEWEY, shared: FACETS.CALL_NUMBERS_SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
+    { searchOption: browseCallNumberOptions.LIBRARY_OF_CONGRESS, shared: FACETS.CALL_NUMBERS_SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
+    { searchOption: browseCallNumberOptions.LOCAL, shared: FACETS.CALL_NUMBERS_SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
+    { searchOption: browseCallNumberOptions.NATIONAL_LIBRARY_OF_MEDICINE, shared: FACETS.CALL_NUMBERS_SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
+    { searchOption: browseCallNumberOptions.OTHER, shared: FACETS.CALL_NUMBERS_SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
+    { searchOption: browseCallNumberOptions.SUPERINTENDENT, shared: FACETS.CALL_NUMBERS_SHARED, heldBy: FACETS.CALL_NUMBERS_HELD_BY },
   ])('when the search option is $searchOption and the Shared and/or HeldBy facets are selected', ({ searchOption, shared, heldBy }) => {
     describe('and the user clicks on a record in the list', () => {
       it('should be navigated to the Search lookup with those filters', async () => {

--- a/src/components/BrowseResultsList/utils.js
+++ b/src/components/BrowseResultsList/utils.js
@@ -59,7 +59,7 @@ const getExtraFilters = (row, qindex, allFilters) => {
 
     extraFacets.push(`${FACETS.SEARCH_CONTRIBUTORS}.${row.contributorNameTypeId}`);
   } else if (Object.values(browseCallNumberOptions).includes(qindex)) {
-    sharedFacetName = FACETS.SHARED;
+    sharedFacetName = FACETS.CALL_NUMBERS_SHARED;
     heldByFacetName = FACETS.CALL_NUMBERS_HELD_BY;
   } else if (Object.values(browseClassificationOptions).includes(qindex)) {
     sharedFacetName = FACETS.CLASSIFICATION_SHARED;

--- a/src/components/InstanceFiltersBrowse/InstanceFiltersBrowse.js
+++ b/src/components/InstanceFiltersBrowse/InstanceFiltersBrowse.js
@@ -32,7 +32,7 @@ const InstanceFiltersBrowse = props => {
   const qindex = query.qindex;
 
   const initialFacetStates = {
-    [FACETS.SHARED]: false,
+    [FACETS.CALL_NUMBERS_SHARED]: false,
     [FACETS.CALL_NUMBERS_HELD_BY]: false,
     [FACETS.CLASSIFICATION_SHARED]: false,
     [FACETS.CONTRIBUTORS_SHARED]: false,
@@ -88,7 +88,7 @@ const InstanceFiltersBrowse = props => {
       )}
       {Object.values(browseCallNumberOptions).includes(qindex) && (
         <>
-          {renderSharedFacet(FACETS.SHARED)}
+          {renderSharedFacet(FACETS.CALL_NUMBERS_SHARED)}
           {renderHeldByFacet(FACETS.CALL_NUMBERS_HELD_BY)}
           <EffectiveLocationFacet
             name={FACETS.CALL_NUMBERS_EFFECTIVE_LOCATION}

--- a/src/components/InstanceFiltersBrowse/instanceFiltersBrowse.test.js
+++ b/src/components/InstanceFiltersBrowse/instanceFiltersBrowse.test.js
@@ -108,13 +108,7 @@ describe('InstanceFiltersBrowse', () => {
         },
       });
 
-      fireEvent.click(screen.getByLabelText('Clear selected Shared filters'));
-
       expect(getByRole('heading', { name: 'Shared' })).toBeInTheDocument();
-      expect(mockOnChange).toHaveBeenCalledWith({
-        name: 'shared',
-        values: [],
-      });
     });
   });
 
@@ -139,13 +133,7 @@ describe('InstanceFiltersBrowse', () => {
         },
       });
 
-      fireEvent.click(screen.getByLabelText('Clear selected Shared filters'));
-
       expect(getByRole('heading', { name: 'Shared' })).toBeInTheDocument();
-      expect(mockOnChange).toHaveBeenCalledWith({
-        name: FACETS.CALL_NUMBERS_SHARED,
-        values: [],
-      });
     });
   });
 

--- a/src/components/InstanceFiltersBrowse/instanceFiltersBrowse.test.js
+++ b/src/components/InstanceFiltersBrowse/instanceFiltersBrowse.test.js
@@ -143,7 +143,7 @@ describe('InstanceFiltersBrowse', () => {
 
       expect(getByRole('heading', { name: 'Shared' })).toBeInTheDocument();
       expect(mockOnChange).toHaveBeenCalledWith({
-        name: FACETS.SHARED,
+        name: FACETS.CALL_NUMBERS_SHARED,
         values: [],
       });
     });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Description
The Shared facet returns an error in call numbers, it should use `instances.shared` in the query parameter, we cannot simply specify the necessary value for it, since it is also used in the Search tab. So a new facet variable `FACET.CALL_NUMBERS_SHARED` is created which will use `instances.shared`.

Tests will pass after the https://github.com/folio-org/stripes-inventory-components/pull/112 is merged.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Related PRs
https://github.com/folio-org/stripes-inventory-components/pull/112

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
https://folio-org.atlassian.net/browse/UIIN-3254
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
