### PR TITLE
UIIN-3257 include limit param in jobProfiles query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Item: Suppress action menu and disable buttons when click Change log icon. Refs UIIN-3178.
 * Use the name CALL_NUMBERS_SHARED for the Shared facet instead of SHARED. Fixes UIIN-3254.
 * Adapt settings options for using number gernerator. Refs UIIN-2556.
+* Provide ids _and `length` param_ when retrieving job profiles. Refs UIIN-3257.
 
 ## [12.0.12](https://github.com/folio-org/ui-inventory/tree/v12.0.12) (2025-01-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.11...v12.0.12)

--- a/src/components/ImportRecordModal/ImportRecordModal.js
+++ b/src/components/ImportRecordModal/ImportRecordModal.js
@@ -14,9 +14,8 @@ import { Loading, Modal, Select, TextField, ModalFooter, Button } from '@folio/s
 import { buildQueryByIds } from '../../utils';
 
 // upper limit of how many job profiles may be retrieved for a given target.
-// a limit clause is necessary because a query like 
-// `query=id==A or id==B or ... Z` will only retrieve 10 (the default limit) 
-// even when more than 10 ids are specified.
+// a limit clause is required to return anything other than the default number
+// of records.
 //
 // 60 is not an arbitrary number; it's a back-of-the-envelope calculation
 // intended to make sure we stay under the query-string's length-limit.

--- a/src/components/ImportRecordModal/ImportRecordModal.js
+++ b/src/components/ImportRecordModal/ImportRecordModal.js
@@ -13,6 +13,16 @@ import { Loading, Modal, Select, TextField, ModalFooter, Button } from '@folio/s
 
 import { buildQueryByIds } from '../../utils';
 
+// upper limit of how many job profiles may be retrieved for a given target.
+// a limit clause is necessary because a query like 
+// `query=id==A or id==B or ... Z` will only retrieve 10 (the default limit) 
+// even when more than 10 ids are specified.
+//
+// 60 is not an arbitrary number; it's a back-of-the-envelope calculation
+// intended to make sure we stay under the query-string's length-limit.
+// see also stripes-core/src/queries/useChunkedCQLFetch.js
+const COPYCAT_PROFILE_LIMIT = 60;
+
 const ImportRecordModal = ({
   isOpen,
   currentExternalIdentifier, // eslint-disable-line no-unused-vars
@@ -57,6 +67,7 @@ const ImportRecordModal = ({
       mutator.jobProfiles.GET({
         params: {
           query: `${buildQueryByIds(allowedJobProfileIds)} sortBy name`,
+          limit: COPYCAT_PROFILE_LIMIT,
         }
       }).then(response => {
         const optionsForSelect = response.jobProfiles?.map(profile => ({


### PR DESCRIPTION
Without a `limit` clause, CQL will only return 10 records (the default) even when more than 10 identifiers are specifically passed in the query. This suprises me, but apparently it is by design.

Follows up on PR #1820 where we added a `limit` clause to retrieve all providers; this PR makes sure we retrieve all a provider's job profiles. 

Refs [UIIN-3257](https://folio-org.atlassian.net/browse/UIIN-3257)