### PR TITLE
UIIN-3259: Move `set for deletion` checkbox field to 4th space in a row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Use the name CALL_NUMBERS_SHARED for the Shared facet instead of SHARED. Fixes UIIN-3254.
 * Adapt settings options for using number gernerator. Refs UIIN-2556.
 * Hide version history icon and settings if audit log feature is disabled. Refs UIIN-3231.
+* Move ‘Set for deletion’ checkbox field to 4th space in top row of Instance Edit view. Refs UIIN-3259.
 
 ## [12.0.12](https://github.com/folio-org/ui-inventory/tree/v12.0.12) (2025-01-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.11...v12.0.12)

--- a/src/edit/InstanceForm.js
+++ b/src/edit/InstanceForm.js
@@ -538,16 +538,6 @@ class InstanceForm extends React.Component {
                           <Row>
                             <Col sm={3}>
                               <Field
-                                label={<FormattedMessage id="ui-inventory.setForDeletion" />}
-                                name="deleted"
-                                component={Checkbox}
-                                type="checkbox"
-                                disabled={this.isFieldBlocked('deleted')}
-                                onChange={() => this.onSetForDeletionFieldChange()}
-                              />
-                            </Col>
-                            <Col sm={3}>
-                              <Field
                                 label={<FormattedMessage id="ui-inventory.discoverySuppress" />}
                                 name="discoverySuppress"
                                 id="input_discovery_suppress"
@@ -574,6 +564,16 @@ class InstanceForm extends React.Component {
                                 component={Checkbox}
                                 type="checkbox"
                                 disabled={this.isFieldBlocked('previouslyHeld')}
+                              />
+                            </Col>
+                            <Col sm={3}>
+                              <Field
+                                label={<FormattedMessage id="ui-inventory.setForDeletion" />}
+                                name="deleted"
+                                component={Checkbox}
+                                type="checkbox"
+                                disabled={this.isFieldBlocked('deleted')}
+                                onChange={() => this.onSetForDeletionFieldChange()}
                               />
                             </Col>
                           </Row>


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
To avoid user error, it has been recommended that we move the ‘Set for deletion’ checkbox in Instance Edit view to the 4th space in its current row, rather than the 1st space.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Move `Set for deletion` checkbox to the end of the row

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3259

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
