### PR TITLE
UIIN-3271 replace annotation with simple wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * *BREAKING* Instance: Display all versions in View history fourth pane. Refs UIIN-3173.
 * *BREAKING* MARC bib > View Source > Display Version History. Refs UIIN-3261.
 * "Copy barcode" icon is displayed next to item with no barcode. Fixes UIIN-3141.
+* Replace annotations for compatibility with esbuild-loader. Refs UIIN-3271.
 
 ## [12.0.12](https://github.com/folio-org/ui-inventory/tree/v12.0.12) (2025-01-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.11...v12.0.12)

--- a/src/settings/HRIDHandling/HRIDHandlingSettings.js
+++ b/src/settings/HRIDHandling/HRIDHandlingSettings.js
@@ -51,7 +51,6 @@ const validateAssignPrefixMaxLength = value => validateFieldLength(value, ASSIGN
 
 const composeValidators = (...validators) => value => validators.reduce((error, validator) => error || validator(value), undefined);
 
-@stripesConnect
 class HRIDHandlingSettings extends Component {
   static manifest = Object.freeze({
     hridSettings: {
@@ -289,4 +288,4 @@ class HRIDHandlingSettings extends Component {
   }
 }
 
-export default HRIDHandlingSettings;
+export default stripesConnect(HRIDHandlingSettings);


### PR DESCRIPTION
Annotations _should_ be fine, but our esbuild-loader config chokes on them. Luckily, they are easy to replace.

Refs [UIIN-3271](https://folio-org.atlassian.net/browse/UIIN-3271)