### PR TITLE
UIIN-3270: Display Original version card of the audit log with no field changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * *BREAKING* Holdings: Display all versions in View history second pane. Refs UIIN-3174.
 * *BREAKING* Item: Display all versions in View history second pane. Refs UIIN-3175.
 * Replace annotations for compatibility with esbuild-loader. Refs UIIN-3271.
+* Display Original version card of the audit log with no field changes. Refs UIIN-3270.
 
 ## [12.0.12](https://github.com/folio-org/ui-inventory/tree/v12.0.12) (2025-01-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.11...v12.0.12)

--- a/src/components/ViewSource/ViewSource.test.js
+++ b/src/components/ViewSource/ViewSource.test.js
@@ -251,7 +251,7 @@ describe('ViewSource', () => {
     it('should open the version history pane', () => {
       fireEvent.click(screen.getByLabelText('stripes-acq-components.versionHistory.pane.header'));
 
-      expect(screen.getByText('stripes-components.versionHistory.pane.sub')).toBeInTheDocument();
+      expect(screen.getByText('stripes-components.auditLog.pane.sub')).toBeInTheDocument();
     });
   });
 

--- a/src/hooks/useHoldingAuditDataQuery/useHoldingAuditDataQuery.js
+++ b/src/hooks/useHoldingAuditDataQuery/useHoldingAuditDataQuery.js
@@ -18,6 +18,7 @@ const useHoldingAuditDataQuery = (holdingId, eventTs) => {
       }
     }).json(),
     enabled: Boolean(holdingId),
+    cacheTime: 0,
   });
 
   return {

--- a/src/hooks/useInstanceAuditDataQuery/useInstanceAuditDataQuery.js
+++ b/src/hooks/useInstanceAuditDataQuery/useInstanceAuditDataQuery.js
@@ -14,10 +14,11 @@ const useInstanceAuditDataQuery = (instanceId, eventTs) => {
     queryKey: [namespace, instanceId, eventTs],
     queryFn: () => ky.get(`audit-data/inventory/instance/${instanceId}`, {
       searchParams: {
-        ...(eventTs && { eventTs })
+        ...(eventTs && { eventTs }),
       }
     }).json(),
     enabled: Boolean(instanceId),
+    cacheTime: 0,
   });
 
   return {

--- a/src/hooks/useInventoryVersionHistory/constants.js
+++ b/src/hooks/useInventoryVersionHistory/constants.js
@@ -1,0 +1,5 @@
+export const ACTIONS = {
+  CREATE: 'CREATE',
+  UPDATE: 'UPDATE',
+  DELETE: 'DELETE',
+};

--- a/src/hooks/useInventoryVersionHistory/useInventoryVersionHistory.js
+++ b/src/hooks/useInventoryVersionHistory/useInventoryVersionHistory.js
@@ -17,6 +17,7 @@ import {
 
 import { getChangedFieldsList } from './getChangedFieldsList';
 import { getActionLabel } from './getActionLabel';
+import { ACTIONS } from './constants';
 
 export const versionsFormatter = (usersMap, intl) => (diffArray) => {
   const anonymousUserLabel = intl.formatMessage({ id: 'ui-inventory.versionHistory.anonymousUser' });
@@ -31,8 +32,8 @@ export const versionsFormatter = (usersMap, intl) => (diffArray) => {
   };
 
   return diffArray
-    .filter(({ action }) => action !== 'CREATE')
-    .map(({ eventDate, eventTs, userId, eventId, diff }) => ({
+    .map(({ action, eventDate, eventTs, userId, eventId, diff }) => ({
+      isOriginal: action === ACTIONS.CREATE,
       eventDate: formatDateTime(eventDate, intl),
       source: getSourceLink(userId),
       userName: getUserName(userId) || anonymousUserLabel,

--- a/src/hooks/useInventoryVersionHistory/useInventoryVersionHistory.test.js
+++ b/src/hooks/useInventoryVersionHistory/useInventoryVersionHistory.test.js
@@ -69,18 +69,5 @@ describe('useInventoryVersionHistory', () => {
       expect(formattedData).toHaveLength(1);
       expect(formattedData[0].userName).toBe('ui-inventory.versionHistory.anonymousUser');
     });
-
-    it('should filter out CREATE actions', () => {
-      const mockData = [
-        { eventDate: '2024-03-01', eventTs: 12345, userId: '1', eventId: 'evt1', diff: [], action: 'CREATE' },
-        { eventDate: '2024-03-02', eventTs: 12346, userId: '2', eventId: 'evt2', diff: [], action: 'DELETE' },
-      ];
-
-      const formatVersions = versionsFormatter(mockUsersMap, mockIntl);
-      const formattedData = formatVersions(mockData);
-
-      expect(formattedData).toHaveLength(1);
-      expect(formattedData[0].userName).toBe('Smith, Jane');
-    });
   });
 });

--- a/src/hooks/useItemAuditDataQuery/useItemAuditDataQuery.js
+++ b/src/hooks/useItemAuditDataQuery/useItemAuditDataQuery.js
@@ -18,6 +18,7 @@ const useItemAuditDataQuery = (itemId, eventTs) => {
       }
     }).json(),
     enabled: Boolean(itemId),
+    cacheTime: 0,
   });
 
   return {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
When a record is first created, we do not need to show the field-level creation data. We only need to show that the card represents the original version of the record. 

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Instead of filtering out versions with `action = CREATE`, show it as original version.

Related PR in `stripes-components` https://github.com/folio-org/stripes-components/pull/2436

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3270

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
<img width="748" alt="Screenshot 2025-03-06 at 13 31 43" src="https://github.com/user-attachments/assets/35c2f9a3-1468-4da9-a473-cc54e41ad13a" />
