### PR TITLE
UIIN-3269: Make user name hyperlink in version history inactive if user does not have permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * *BREAKING* Holdings: Display all versions in View history second pane. Refs UIIN-3174.
 * *BREAKING* Item: Display all versions in View history second pane. Refs UIIN-3175.
 * Replace annotations for compatibility with esbuild-loader. Refs UIIN-3271.
+* Make user name hyperlink in version history inactive if user does not have permissions. Refs UIIN-3269.
 
 ## [12.0.12](https://github.com/folio-org/ui-inventory/tree/v12.0.12) (2025-01-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.11...v12.0.12)


### PR DESCRIPTION
## Purpose
* For FOLIO record Version history, If a user does not have the appropriate permissions to view User records, make the user name hyperlink inactive on the change history card.

## Approach
* Use `stripes.hasPerm('users.collection.get')` to check permission.

## Refs
[UIIN-3269](https://folio-org.atlassian.net/browse/UIIN-3269)

## Screenshots
### With permission
![image](https://github.com/user-attachments/assets/1932af1d-de91-42d2-88c0-d5cc98f2d538)

### Without permission
![image](https://github.com/user-attachments/assets/f30ef27f-d871-471e-9adb-b074ac5bc6f0)
