### PR TITLE
UIIN-3274: Fix bug in modal heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * Replace annotations for compatibility with esbuild-loader. Refs UIIN-3271.
 * Make user name hyperlink in version history inactive if user does not have permissions. Refs UIIN-3269.
 * Display Original version card of the audit log with no field changes. Refs UIIN-3270.
+* Change heading of modal generate accession and call number. Refs UIIN-3274.
 
 ## [12.0.12](https://github.com/folio-org/ui-inventory/tree/v12.0.12) (2025-01-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.11...v12.0.12)

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -399,7 +399,7 @@ class ItemForm extends React.Component {
           generator="inventory_accessionNumber"
           id="inventoryAccessionNumberAndCallNumber"
           modalProps={{
-            label: <FormattedMessage id="ui-inventory.numberGenerator.accessionAndCallNumberGenerator" />
+            label: <FormattedMessage id="ui-inventory.numberGenerator.generateAccessionAndCallNumber" />
           }}
           renderTop={() => (
             <p><FormattedMessage id="ui-inventory.numberGenerator.generateAccessionAndCallNumberWarning" /></p>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIIN-3274


## Purpose
Preconditions Settings > Inventory > Number generator options
- Number generator for accession number and call number are enabled either On, field editable or On, field not editable
- And checkbox “Use the same generated number for accession number and call number” is selected 

In inventory item record in edit or add view when opening the modal by clicking the button Generate accession and call numbers the heading of the modal is not displayed correctly  
Current:
_ui-inventory.numberGenerator.accessionAndCallNumberGenerator_
expected:
_Generate accession and call numbers_

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
