### PR TITLE
UIIN-3266: `ViewSource` - add `tenantId` to `useAuditSettings`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * Replace annotations for compatibility with esbuild-loader. Refs UIIN-3271.
 * Make user name hyperlink in version history inactive if user does not have permissions. Refs UIIN-3269.
 * Display Original version card of the audit log with no field changes. Refs UIIN-3270.
+* ViewSource - add tenantId to useAuditSettings. Refs UIIN-3266.
 
 ## [12.0.12](https://github.com/folio-org/ui-inventory/tree/v12.0.12) (2025-01-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.11...v12.0.12)

--- a/src/Holding/HoldingsMarc/HoldingsMarcContainer.js
+++ b/src/Holding/HoldingsMarc/HoldingsMarcContainer.js
@@ -12,6 +12,7 @@ const HoldingsMarcContainer = ({
   holdingsrecordid,
 }) => {
   const { instance, isLoading: isInstanceLoading } = useInstance(instanceId);
+  const tenantId = instance?.tenantId;
 
   return (
     <ViewSource
@@ -21,6 +22,7 @@ const HoldingsMarcContainer = ({
       isInstanceLoading={isInstanceLoading}
       holdingsRecordId={holdingsrecordid}
       marcType={MARC_TYPES.HOLDINGS}
+      tenantId={tenantId}
     />
   );
 };

--- a/src/components/ViewSource/ViewSource.js
+++ b/src/components/ViewSource/ViewSource.js
@@ -215,7 +215,7 @@ const ViewSource = ({
     );
   }, []);
 
-  const { settings } = useAuditSettings({ group: INVENTORY_AUDIT_GROUP });
+  const { settings } = useAuditSettings({ tenantId, group: INVENTORY_AUDIT_GROUP });
 
   const isVersionHistoryEnabled = getIsVersionHistoryEnabled(settings);
 

--- a/src/components/ViewSource/ViewSource.test.js
+++ b/src/components/ViewSource/ViewSource.test.js
@@ -266,12 +266,21 @@ describe('ViewSource', () => {
       });
 
       await act(async () => {
-        await renderWithIntl(getViewSource(), []);
+        await renderWithIntl(getViewSource({
+          tenantId: 'tenant-id',
+        }), []);
       });
     });
 
     it('should not show the version history button', () => {
       expect(screen.queryByLabelText('stripes-acq-components.versionHistory.pane.header')).not.toBeInTheDocument();
+    });
+
+    it('should be called with tenantId', () => {
+      expect(useAuditSettings).toHaveBeenCalledWith({
+        tenantId: 'tenant-id',
+        group: 'audit.inventory',
+      });
     });
   });
 });

--- a/src/hooks/useAuditSettings/useAuditSettings.js
+++ b/src/hooks/useAuditSettings/useAuditSettings.js
@@ -9,14 +9,14 @@ import {
   useOkapiKy,
 } from '@folio/stripes/core';
 
-export const useAuditSettings = ({ group } = {}) => {
-  const ky = useOkapiKy();
+export const useAuditSettings = ({ tenantId, group } = {}) => {
+  const ky = useOkapiKy({ tenant: tenantId });
   const [namespace] = useNamespace({ key: 'audit-settings' });
 
   const path = `audit/config/groups/${group}/settings`;
 
   const { data, isLoading, isError, refetch } = useQuery(
-    [namespace, group],
+    [namespace, group, tenantId],
     () => ky.get(path).json(),
   );
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Display the history feature toggle/icon only if it is enabled in settings. The shared record should call for settings with the central tenant id, local record with the local tenant id.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-3266](https://folio-org.atlassian.net/browse/UIIN-3266)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots

https://github.com/user-attachments/assets/8ef122d3-e0af-4e3b-9644-b823328d1cc8




<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
