### PR TITLE
UIIN-3213: Update titles in `CardsPerVersionHistoryPage` to reflect version history (follow-up).

### DIFF
--- a/src/settings/CardsPerVersionHistoryPage/CardsPerVersionHistoryPage.js
+++ b/src/settings/CardsPerVersionHistoryPage/CardsPerVersionHistoryPage.js
@@ -53,7 +53,7 @@ export const CardsPerVersionHistoryPage = () => {
 
   return (
     <TitleManager
-      record={intl.formatMessage({ id: 'ui-inventory.settings.section.cardsPerPage' })}
+      record={intl.formatMessage({ id: 'ui-inventory.settings.section.versionHistory' })}
     >
       <Paneset id="cardsPerPage">
         {isSettingsLoading ? (

--- a/src/settings/CardsPerVersionHistoryPage/components/CardsPerVersionHistoryPageForm/CardsPerVersionHistoryPageForm.js
+++ b/src/settings/CardsPerVersionHistoryPage/components/CardsPerVersionHistoryPageForm/CardsPerVersionHistoryPageForm.js
@@ -42,7 +42,7 @@ const CardsPerVersionHistoryPageForm = ({
     return (
       <PaneHeader
         {...paneHeaderProps}
-        paneTitle={intl.formatMessage({ id: 'ui-inventory.settings.section.cardsPerPage' })}
+        paneTitle={intl.formatMessage({ id: 'ui-inventory.settings.section.versionHistory' })}
       />
     );
   };


### PR DESCRIPTION

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Display the `Version history` header instead of `Cards per page` in the `Version history` settings.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-3213](https://folio-org.atlassian.net/browse/UIIN-3213)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
![image](https://github.com/user-attachments/assets/f90b62b3-8dfd-4cf3-af5c-f26af5366470)

<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
