### PR TITLE
UIIN-3283: Add default value for number of versions counter on "Version history" pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Change history for ui-inventory
 
-## [13.0.1] (IN PROGRESS)
-
-* Add default value for number of versions counter on "Version history" pane. Fixes UIIN-3283.
-
 ## [13.0.0] (IN PROGRESS)
 
 * ECS | Instance details pane does not contain all tenants when user does not have affiliations / permissions in all tenants. Fixes UIIN-3113.
@@ -57,7 +53,8 @@
 * Display Original version card of the audit log with no field changes. Refs UIIN-3270.
 * Change heading of modal generate accession and call number. Refs UIIN-3274.
 * ViewSource - add tenantId to useAuditSettings. Refs UIIN-3266.
-* Enhancement help text on Settings > Inventory > Number generator options. Refs UIIN-3217..
+* Enhancement help text on Settings > Inventory > Number generator options. Refs UIIN-3217.
+* Add default value for number of versions counter on "Version history" pane. Fixes UIIN-3283.
 
 ## [12.0.12](https://github.com/folio-org/ui-inventory/tree/v12.0.12) (2025-01-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.11...v12.0.12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## [13.0.1] (IN PROGRESS)
+
+* Add default value for number of versions counter on "Version history" pane. Fixes UIIN-3283.
+
 ## [13.0.0] (IN PROGRESS)
 
 * ECS | Instance details pane does not contain all tenants when user does not have affiliations / permissions in all tenants. Fixes UIIN-3113.
@@ -53,7 +57,7 @@
 * Display Original version card of the audit log with no field changes. Refs UIIN-3270.
 * Change heading of modal generate accession and call number. Refs UIIN-3274.
 * ViewSource - add tenantId to useAuditSettings. Refs UIIN-3266.
-* Enhancement help text on Settings > Inventory > Number generator options. Refs UIIN-3217.
+* Enhancement help text on Settings > Inventory > Number generator options. Refs UIIN-3217..
 
 ## [12.0.12](https://github.com/folio-org/ui-inventory/tree/v12.0.12) (2025-01-27)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.11...v12.0.12)

--- a/src/Holding/HoldingVersionHistory/HoldingVersionHistory.js
+++ b/src/Holding/HoldingVersionHistory/HoldingVersionHistory.js
@@ -99,6 +99,7 @@ const HoldingVersionHistory = ({ onClose, holdingId }) => {
       fieldLabelsMap={fieldLabelsMap}
       fieldFormatter={fieldFormatter}
       actionsMap={actionsMap}
+      totalVersions={totalRecords ?? 0}
     />
   );
 };

--- a/src/Instance/InstanceVersionHistory/InstanceVersionHistory.js
+++ b/src/Instance/InstanceVersionHistory/InstanceVersionHistory.js
@@ -121,6 +121,7 @@ const InstanceVersionHistory = ({
       fieldLabelsMap={fieldLabelsMap}
       fieldFormatter={fieldFormatter}
       actionsMap={actionsMap}
+      totalVersions={totalRecords ?? 0}
     />
   );
 };

--- a/src/Item/ItemVersionHistory/ItemVersionHistory.js
+++ b/src/Item/ItemVersionHistory/ItemVersionHistory.js
@@ -120,6 +120,7 @@ const ItemVersionHistory = ({
       fieldLabelsMap={fieldLabelsMap}
       fieldFormatter={fieldFormatter}
       actionsMap={actionsMap}
+      totalVersions={totalRecords ?? 0}
     />
   );
 };


### PR DESCRIPTION
## Purpose
* NaN displays instead of counter value for FOLIO Instances/Holdings/Items on "Version history" pane.

## Approach
* Set 0 as a default value when loading

## Refs
[UIIN-3283](https://folio-org.atlassian.net/browse/UIIN-3283)