### PR TITLE
UIIN-3286: Add loading indicator to AuditLogPane when data is initially loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [13.0.1] (IN PROGRESS)
 
 * Missing values in the version history modal for Suppressed from discovery and Staff suppressed fields. Fixed UIIN-3277.
+* Refactor `useAuditDataQuery` hooks to use `useInfiniteQuery` to implement loading indicator to version history panes. Refs UIIN-3286.
 
 ## [13.0.0](https://github.com/folio-org/ui-inventory/tree/v13.0.0) (2025-03-14)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.12...v13.0.0)

--- a/src/Holding/HoldingVersionHistory/HoldingVersionHistory.js
+++ b/src/Holding/HoldingVersionHistory/HoldingVersionHistory.js
@@ -1,7 +1,4 @@
-import {
-  useContext,
-  useState,
-} from 'react';
+import { useContext } from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
@@ -37,19 +34,19 @@ const HoldingVersionHistory = ({ onClose, holdingId }) => {
   const { formatMessage } = useIntl();
   const referenceData = useContext(DataContext);
 
-  const [lastVersionEventTs, setLastVersionEventTs] = useState(null);
-
   const {
     data,
     totalRecords,
     isLoading,
-  } = useHoldingAuditDataQuery(holdingId, lastVersionEventTs);
+    isLoadingMore,
+    fetchNextPage,
+    hasNextPage,
+  } = useHoldingAuditDataQuery(holdingId);
 
   const {
     actionsMap,
     versions,
-    isLoadMoreVisible,
-  } = useInventoryVersionHistory({ data, totalRecords });
+  } = useInventoryVersionHistory(data);
 
   const [totalVersions] = useTotalVersions(totalRecords);
 
@@ -88,17 +85,14 @@ const HoldingVersionHistory = ({ onClose, holdingId }) => {
 
   const fieldFormatter = getFieldFormatter(referenceData);
 
-  const handleLoadMore = lastEventTs => {
-    setLastVersionEventTs(lastEventTs);
-  };
-
   return (
     <AuditLogPane
       versions={versions}
       onClose={onClose}
-      isLoadMoreVisible={isLoadMoreVisible}
-      handleLoadMore={handleLoadMore}
-      isLoading={isLoading}
+      isLoadMoreVisible={hasNextPage}
+      handleLoadMore={() => fetchNextPage()}
+      isLoading={isLoadingMore}
+      isInitialLoading={isLoading}
       fieldLabelsMap={fieldLabelsMap}
       fieldFormatter={fieldFormatter}
       actionsMap={actionsMap}

--- a/src/Instance/InstanceVersionHistory/InstanceVersionHistory.js
+++ b/src/Instance/InstanceVersionHistory/InstanceVersionHistory.js
@@ -1,7 +1,4 @@
-import {
-  useContext,
-  useState,
-} from 'react';
+import { useContext } from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
@@ -56,18 +53,19 @@ const InstanceVersionHistory = ({
 
   const referenceData = useContext(DataContext);
 
-  const [lastVersionEventTs, setLastVersionEventTs] = useState(null);
-
   const {
     data,
     totalRecords,
     isLoading,
-  } = useInstanceAuditDataQuery(instanceId, lastVersionEventTs);
+    isLoadingMore,
+    fetchNextPage,
+    hasNextPage,
+  } = useInstanceAuditDataQuery(instanceId);
+
   const {
     actionsMap,
     versions,
-    isLoadMoreVisible,
-  } = useInventoryVersionHistory({ data, totalRecords });
+  } = useInventoryVersionHistory({ data });
 
   const [totalVersions] = useTotalVersions(totalRecords);
 
@@ -114,17 +112,14 @@ const InstanceVersionHistory = ({
   };
   const fieldFormatter = getFieldFormatter(referenceData);
 
-  const handleLoadMore = lastEventTs => {
-    setLastVersionEventTs(lastEventTs);
-  };
-
   return (
     <AuditLogPane
       versions={versions}
       onClose={onClose}
-      isLoadMoreVisible={isLoadMoreVisible}
-      handleLoadMore={handleLoadMore}
-      isLoading={isLoading}
+      isLoadMoreVisible={hasNextPage}
+      handleLoadMore={() => fetchNextPage()}
+      isLoading={isLoadingMore}
+      isInitialLoading={isLoading}
       fieldLabelsMap={fieldLabelsMap}
       fieldFormatter={fieldFormatter}
       actionsMap={actionsMap}

--- a/src/Item/ItemVersionHistory/ItemVersionHistory.js
+++ b/src/Item/ItemVersionHistory/ItemVersionHistory.js
@@ -1,7 +1,4 @@
-import {
-  useContext,
-  useState,
-} from 'react';
+import { useContext } from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
@@ -50,18 +47,18 @@ const ItemVersionHistory = ({
   const { formatMessage } = useIntl();
   const referenceData = useContext(DataContext);
 
-  const [lastVersionEventTs, setLastVersionEventTs] = useState(null);
-
   const {
     data,
     totalRecords,
     isLoading,
-  } = useItemAuditDataQuery(itemId, lastVersionEventTs);
+    isLoadingMore,
+    fetchNextPage,
+    hasNextPage,
+  } = useItemAuditDataQuery(itemId);
   const {
     actionsMap,
     versions,
-    isLoadMoreVisible,
-  } = useInventoryVersionHistory({ data, totalRecords });
+  } = useInventoryVersionHistory(data);
 
   const [totalVersions] = useTotalVersions(totalRecords);
 
@@ -112,17 +109,14 @@ const ItemVersionHistory = ({
 
   const fieldFormatter = createFieldFormatter(referenceData, circulationHistory);
 
-  const handleLoadMore = lastEventTs => {
-    setLastVersionEventTs(lastEventTs);
-  };
-
   return (
     <AuditLogPane
       versions={versions}
       onClose={onClose}
-      isLoadMoreVisible={isLoadMoreVisible}
-      handleLoadMore={handleLoadMore}
-      isLoading={isLoading}
+      isLoadMoreVisible={hasNextPage}
+      handleLoadMore={() => fetchNextPage()}
+      isLoading={isLoadingMore}
+      isInitialLoading={isLoading}
       fieldLabelsMap={fieldLabelsMap}
       fieldFormatter={fieldFormatter}
       actionsMap={actionsMap}

--- a/src/hooks/useHoldingAuditDataQuery/useHoldingAuditDataQuery.js
+++ b/src/hooks/useHoldingAuditDataQuery/useHoldingAuditDataQuery.js
@@ -1,30 +1,62 @@
-import { useQuery } from 'react-query';
+import { useInfiniteQuery } from 'react-query';
+import { useMemo } from 'react';
 
 import {
   useNamespace,
   useOkapiKy,
 } from '@folio/stripes/core';
 
-const useHoldingAuditDataQuery = (holdingId, eventTs) => {
+const useHoldingAuditDataQuery = (holdingId) => {
   const ky = useOkapiKy();
   const [namespace] = useNamespace({ key: 'holding-audit-data' });
 
-  // eventTs param is used to load more data
-  const { isLoading, data = {} } = useQuery({
-    queryKey: [namespace, holdingId, eventTs],
-    queryFn: () => ky.get(`audit-data/inventory/holdings/${holdingId}`, {
+  const {
+    data,
+    isLoading,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    ...rest
+  } = useInfiniteQuery({
+    queryKey: [namespace, holdingId],
+    queryFn: ({ pageParam }) => ky.get(`audit-data/inventory/holdings/${holdingId}`, {
       searchParams: {
-        ...(eventTs && { eventTs })
+        ...(pageParam && { eventTs: pageParam }),
       }
     }).json(),
+    getNextPageParam: (lastPage, allPages) => {
+      const totalRecords = lastPage?.totalRecords || 0;
+      const totalFetchedItems = allPages.reduce((sum, page) => {
+        return sum + (page?.inventoryAuditItems?.length || 0);
+      }, 0);
+
+      // if we've fetched all records, return undefined to disable further loading
+      if (totalFetchedItems >= totalRecords) {
+        return undefined;
+      }
+
+      // otherwise, return the timestamp of the last item for the next page
+      const items = lastPage?.inventoryAuditItems || [];
+      return items.length > 0 ? items[items.length - 1].eventTs : undefined;
+    },
     enabled: Boolean(holdingId),
     cacheTime: 0,
   });
 
+  // flatten all pages into a single array
+  const flattenedData = useMemo(() => {
+    return data?.pages?.flatMap(page => page?.inventoryAuditItems || []) || [];
+  }, [data]);
+  const totalRecords = data?.pages?.[0]?.totalRecords || 0;
+
   return {
-    data: data?.inventoryAuditItems || [],
-    totalRecords: data?.totalRecords,
+    data: flattenedData,
+    totalRecords,
     isLoading,
+    isLoadingMore: isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    ...rest,
   };
 };
 

--- a/src/hooks/useHoldingAuditDataQuery/useHoldingAuditDataQuery.test.js
+++ b/src/hooks/useHoldingAuditDataQuery/useHoldingAuditDataQuery.test.js
@@ -1,20 +1,36 @@
 import React, { act } from 'react';
-import {
-  QueryClient,
-  QueryClientProvider,
-} from 'react-query';
+import { QueryClient, QueryClientProvider } from 'react-query';
 
-import { renderHook } from '@folio/jest-config-stripes/testing-library/react';
+import {
+  renderHook,
+  waitFor,
+} from '@folio/jest-config-stripes/testing-library/react';
 import { useOkapiKy } from '@folio/stripes/core';
 
 import '../../../test/jest/__mock__';
 
 import useHoldingAuditDataQuery from './useHoldingAuditDataQuery';
 
+// Mock the dependencies
 jest.mock('@folio/stripes/core', () => ({
   ...jest.requireActual('@folio/stripes/core'),
   useOkapiKy: jest.fn(),
 }));
+
+const mockHoldingsId = '123';
+const mockAuditData = {
+  totalRecords: 3,
+  inventoryAuditItems: [
+    { eventTs: '2024-03-20T10:00:00Z', id: '1' },
+    { eventTs: '2024-03-20T09:00:00Z', id: '2' },
+  ],
+};
+
+const mockKy = {
+  get: jest.fn().mockReturnValue({
+    json: () => Promise.resolve(mockAuditData),
+  }),
+};
 
 const queryClient = new QueryClient();
 const wrapper = ({ children }) => (
@@ -25,10 +41,8 @@ const wrapper = ({ children }) => (
 
 describe('useHoldingAuditDataQuery', () => {
   beforeEach(() => {
-    useOkapiKy.mockClear().mockReturnValue({
-      get: () => ({
-        json: () => Promise.resolve({ inventoryAuditItems: [{ action: 'UPDATE' }] }),
-      }),
+    useOkapiKy.mockReturnValue({
+      ...mockKy,
     });
   });
 
@@ -36,11 +50,99 @@ describe('useHoldingAuditDataQuery', () => {
     jest.clearAllMocks();
   });
 
-  it('should fetch holdings', async () => {
-    const { result } = renderHook(() => useHoldingAuditDataQuery('holdingId'), { wrapper });
+  it('should fetch audit data when instanceId is provided', async () => {
+    const { result } = renderHook(
+      () => useHoldingAuditDataQuery(mockHoldingsId),
+      { wrapper }
+    );
+
+    expect(result.current.isLoading).toBe(true);
 
     await act(() => !result.current.isLoading);
 
-    expect(result.current.data).toEqual([{ action: 'UPDATE' }]);
+    await waitFor(() => {
+      expect(mockKy.get).toHaveBeenCalledWith(
+        `audit-data/inventory/holdings/${mockHoldingsId}`,
+        expect.any(Object)
+      );
+      expect(result.current.data).toEqual(mockAuditData.inventoryAuditItems);
+      expect(result.current.totalRecords).toBe(mockAuditData.totalRecords);
+    });
+  });
+
+  it('should not fetch data when instanceId is not provided', () => {
+    const { result } = renderHook(
+      () => useHoldingAuditDataQuery(null),
+      { wrapper }
+    );
+
+    expect(result.current.isLoading).toBe(false);
+    expect(mockKy.get).not.toHaveBeenCalled();
+  });
+
+  it('should handle fetchNextPage correctly', async () => {
+    const secondPageData = {
+      totalRecords: 3,
+      inventoryAuditItems: [
+        { eventTs: '2024-03-20T08:00:00Z', id: '3' },
+      ],
+    };
+
+    useOkapiKy
+      .mockClear()
+      .mockReturnValueOnce({
+        get: () => ({
+          json: () => Promise.resolve(mockAuditData),
+        }),
+      })
+      .mockReturnValueOnce({
+        get: () => ({
+          json: () => Promise.resolve(secondPageData),
+        }),
+      });
+
+    const { result } = renderHook(
+      () => useHoldingAuditDataQuery(mockHoldingsId),
+      { wrapper }
+    );
+
+    await act(() => !result.current.isLoading);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toHaveLength(3);
+      expect(result.current.isLoadingMore).toBe(false);
+    });
+  });
+
+  it('should set hasNextPage to false when all records are fetched', async () => {
+    const singlePageData = {
+      totalRecords: 2,
+      inventoryAuditItems: [
+        { eventTs: '2024-03-20T10:00:00Z', id: '1' },
+        { eventTs: '2024-03-20T09:00:00Z', id: '2' },
+      ],
+    };
+
+    useOkapiKy
+      .mockClear()
+      .mockReturnValueOnce({
+        get: () => ({
+          json: () => Promise.resolve(singlePageData),
+        }),
+      });
+
+    const { result } = renderHook(
+      () => useHoldingAuditDataQuery(mockHoldingsId),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.hasNextPage).toBe(false);
+    });
   });
 });

--- a/src/hooks/useInstanceAuditDataQuery/useInstanceAuditDataQuery.js
+++ b/src/hooks/useInstanceAuditDataQuery/useInstanceAuditDataQuery.js
@@ -1,9 +1,10 @@
 import { useInfiniteQuery } from 'react-query';
+import { useMemo } from 'react';
+
 import {
   useNamespace,
   useOkapiKy,
 } from '@folio/stripes/core';
-import { useMemo } from 'react';
 
 const useInstanceAuditDataQuery = (instanceId) => {
   const ky = useOkapiKy();

--- a/src/hooks/useInstanceAuditDataQuery/useInstanceAuditDataQuery.js
+++ b/src/hooks/useInstanceAuditDataQuery/useInstanceAuditDataQuery.js
@@ -1,30 +1,61 @@
-import { useQuery } from 'react-query';
-
+import { useInfiniteQuery } from 'react-query';
 import {
   useNamespace,
   useOkapiKy,
 } from '@folio/stripes/core';
+import { useMemo } from 'react';
 
-const useInstanceAuditDataQuery = (instanceId, eventTs) => {
+const useInstanceAuditDataQuery = (instanceId) => {
   const ky = useOkapiKy();
   const [namespace] = useNamespace({ key: 'instance-audit-data' });
 
-  // eventTs param is used to load more data
-  const { isLoading, data = {} } = useQuery({
-    queryKey: [namespace, instanceId, eventTs],
-    queryFn: () => ky.get(`audit-data/inventory/instance/${instanceId}`, {
+  const {
+    data,
+    isLoading,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    ...rest
+  } = useInfiniteQuery({
+    queryKey: [namespace, instanceId],
+    queryFn: ({ pageParam }) => ky.get(`audit-data/inventory/instance/${instanceId}`, {
       searchParams: {
-        ...(eventTs && { eventTs }),
+        ...(pageParam && { eventTs: pageParam }),
       }
     }).json(),
+    getNextPageParam: (lastPage, allPages) => {
+      const totalRecords = lastPage?.totalRecords || 0;
+      const totalFetchedItems = allPages.reduce((sum, page) => {
+        return sum + (page?.inventoryAuditItems?.length || 0);
+      }, 0);
+
+      // if we've fetched all records, return undefined to disable further loading
+      if (totalFetchedItems >= totalRecords) {
+        return undefined;
+      }
+
+      // otherwise, return the timestamp of the last item for the next page
+      const items = lastPage?.inventoryAuditItems || [];
+      return items.length > 0 ? items[items.length - 1].eventTs : undefined;
+    },
     enabled: Boolean(instanceId),
     cacheTime: 0,
   });
 
+  // flatten all pages into a single array
+  const flattenedData = useMemo(() => {
+    return data?.pages?.flatMap(page => page?.inventoryAuditItems || []) || [];
+  }, [data]);
+  const totalRecords = data?.pages?.[0]?.totalRecords || 0;
+
   return {
-    data: data?.inventoryAuditItems || [],
-    totalRecords: data?.totalRecords,
+    data: flattenedData,
+    totalRecords,
     isLoading,
+    isLoadingMore: isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    ...rest,
   };
 };
 

--- a/src/hooks/useInstanceAuditDataQuery/useInstanceAuditDataQuery.test.js
+++ b/src/hooks/useInstanceAuditDataQuery/useInstanceAuditDataQuery.test.js
@@ -1,0 +1,148 @@
+import React, { act } from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+import {
+  renderHook,
+  waitFor,
+} from '@folio/jest-config-stripes/testing-library/react';
+import { useOkapiKy } from '@folio/stripes/core';
+
+import '../../../test/jest/__mock__';
+
+import useInstanceAuditDataQuery from './useInstanceAuditDataQuery';
+
+// Mock the dependencies
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  useOkapiKy: jest.fn(),
+}));
+
+const mockInstanceId = '123';
+const mockAuditData = {
+  totalRecords: 3,
+  inventoryAuditItems: [
+    { eventTs: '2024-03-20T10:00:00Z', id: '1' },
+    { eventTs: '2024-03-20T09:00:00Z', id: '2' },
+  ],
+};
+
+const mockKy = {
+  get: jest.fn().mockReturnValue({
+    json: () => Promise.resolve(mockAuditData),
+  }),
+};
+
+const queryClient = new QueryClient();
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+describe('useInstanceAuditDataQuery', () => {
+  beforeEach(() => {
+    useOkapiKy.mockReturnValue({
+      ...mockKy,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch audit data when instanceId is provided', async () => {
+    const { result } = renderHook(
+      () => useInstanceAuditDataQuery(mockInstanceId),
+      { wrapper }
+    );
+
+    expect(result.current.isLoading).toBe(true);
+
+    await act(() => !result.current.isLoading);
+
+    await waitFor(() => {
+      expect(mockKy.get).toHaveBeenCalledWith(
+        `audit-data/inventory/instance/${mockInstanceId}`,
+        expect.any(Object)
+      );
+      expect(result.current.data).toEqual(mockAuditData.inventoryAuditItems);
+      expect(result.current.totalRecords).toBe(mockAuditData.totalRecords);
+    });
+  });
+
+  it('should not fetch data when instanceId is not provided', () => {
+    const { result } = renderHook(
+      () => useInstanceAuditDataQuery(null),
+      { wrapper }
+    );
+
+    expect(result.current.isLoading).toBe(false);
+    expect(mockKy.get).not.toHaveBeenCalled();
+  });
+
+  it('should handle fetchNextPage correctly', async () => {
+    const secondPageData = {
+      totalRecords: 3,
+      inventoryAuditItems: [
+        { eventTs: '2024-03-20T08:00:00Z', id: '3' },
+      ],
+    };
+
+    useOkapiKy
+      .mockClear()
+      .mockReturnValueOnce({
+        get: () => ({
+          json: () => Promise.resolve(mockAuditData),
+        }),
+      })
+      .mockReturnValueOnce({
+        get: () => ({
+          json: () => Promise.resolve(secondPageData),
+        }),
+      });
+
+    const { result } = renderHook(
+      () => useInstanceAuditDataQuery(mockInstanceId),
+      { wrapper }
+    );
+
+    await act(() => !result.current.isLoading);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toHaveLength(3);
+      expect(result.current.isLoadingMore).toBe(false);
+    });
+  });
+
+  it('should set hasNextPage to false when all records are fetched', async () => {
+    const singlePageData = {
+      totalRecords: 2,
+      inventoryAuditItems: [
+        { eventTs: '2024-03-20T10:00:00Z', id: '1' },
+        { eventTs: '2024-03-20T09:00:00Z', id: '2' },
+      ],
+    };
+
+    useOkapiKy
+      .mockClear()
+      .mockReturnValueOnce({
+        get: () => ({
+          json: () => Promise.resolve(singlePageData),
+        }),
+      });
+
+    const { result } = renderHook(
+      () => useInstanceAuditDataQuery(mockInstanceId),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.hasNextPage).toBe(false);
+    });
+  });
+});

--- a/src/hooks/useInventoryVersionHistory/useInventoryVersionHistory.js
+++ b/src/hooks/useInventoryVersionHistory/useInventoryVersionHistory.js
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useMemo,
   useState,
 } from 'react';
 import { Link } from 'react-router-dom';
@@ -9,7 +10,6 @@ import {
   uniq,
 } from 'lodash';
 
-import { useVersionHistory } from '@folio/stripes/components';
 import {
   formatDateTime,
   useUsersBatch,
@@ -51,10 +51,7 @@ export const versionsFormatter = (usersMap, intl, canViewUser) => (diffArray) =>
     }));
 };
 
-const useInventoryVersionHistory = ({
-  data,
-  totalRecords,
-}) => {
+const useInventoryVersionHistory = (data) => {
   const stripes = useStripes();
   const intl = useIntl();
 
@@ -89,21 +86,15 @@ const useInventoryVersionHistory = ({
     }));
   }, [users]);
 
-  const {
-    versions,
-    isLoadMoreVisible,
-  } = useVersionHistory({
-    data,
-    totalRecords,
-    versionsFormatter: versionsFormatter(usersMap, intl, canViewUser),
-  });
-
   const actionsMap = { ...getActionLabel(intl.formatMessage) };
+  const versions = useMemo(
+    () => versionsFormatter(usersMap, intl, canViewUser)(data),
+    [usersMap, canViewUser, data],
+  );
 
   return {
     actionsMap,
     versions,
-    isLoadMoreVisible,
   };
 };
 

--- a/src/hooks/useInventoryVersionHistory/useInventoryVersionHistory.test.js
+++ b/src/hooks/useInventoryVersionHistory/useInventoryVersionHistory.test.js
@@ -31,10 +31,9 @@ describe('useInventoryVersionHistory', () => {
   });
 
   it('should initialize with default values', () => {
-    const { result } = renderHook(() => useInventoryVersionHistory({ data: [], totalRecords: 10 }), { wrapper: MemoryRouter });
+    const { result } = renderHook(() => useInventoryVersionHistory({ data: [] }), { wrapper: MemoryRouter });
 
     expect(result.current.actionsMap).toBeDefined();
-    expect(result.current.isLoadMoreVisible).toBe(true);
     expect(result.current.versions).toEqual([]);
   });
 

--- a/src/hooks/useItemAuditDataQuery/useItemAuditDataQuery.js
+++ b/src/hooks/useItemAuditDataQuery/useItemAuditDataQuery.js
@@ -1,30 +1,62 @@
-import { useQuery } from 'react-query';
+import { useInfiniteQuery } from 'react-query';
+import { useMemo } from 'react';
 
 import {
   useNamespace,
   useOkapiKy,
 } from '@folio/stripes/core';
 
-const useItemAuditDataQuery = (itemId, eventTs) => {
+const useItemAuditDataQuery = (itemId) => {
   const ky = useOkapiKy();
   const [namespace] = useNamespace({ key: 'item-audit-data' });
 
-  // eventTs param is used to load more data
-  const { isLoading, data = {} } = useQuery({
-    queryKey: [namespace, itemId, eventTs],
-    queryFn: () => ky.get(`audit-data/inventory/item/${itemId}`, {
+  const {
+    data,
+    isLoading,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    ...rest
+  } = useInfiniteQuery({
+    queryKey: [namespace, itemId],
+    queryFn: ({ pageParam }) => ky.get(`audit-data/inventory/item/${itemId}`, {
       searchParams: {
-        ...(eventTs && { eventTs })
+        ...(pageParam && { eventTs: pageParam }),
       }
     }).json(),
+    getNextPageParam: (lastPage, allPages) => {
+      const totalRecords = lastPage?.totalRecords || 0;
+      const totalFetchedItems = allPages.reduce((sum, page) => {
+        return sum + (page?.inventoryAuditItems?.length || 0);
+      }, 0);
+
+      // if we've fetched all records, return undefined to disable further loading
+      if (totalFetchedItems >= totalRecords) {
+        return undefined;
+      }
+
+      // otherwise, return the timestamp of the last item for the next page
+      const items = lastPage?.inventoryAuditItems || [];
+      return items.length > 0 ? items[items.length - 1].eventTs : undefined;
+    },
     enabled: Boolean(itemId),
     cacheTime: 0,
   });
 
+  // flatten all pages into a single array
+  const flattenedData = useMemo(() => {
+    return data?.pages?.flatMap(page => page?.inventoryAuditItems || []) || [];
+  }, [data]);
+  const totalRecords = data?.pages?.[0]?.totalRecords || 0;
+
   return {
-    data: data?.inventoryAuditItems || [],
-    totalRecords: data?.totalRecords,
+    data: flattenedData,
+    totalRecords,
     isLoading,
+    isLoadingMore: isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    ...rest,
   };
 };
 

--- a/src/hooks/useItemAuditDataQuery/useItemAuditDataQuery.test.js
+++ b/src/hooks/useItemAuditDataQuery/useItemAuditDataQuery.test.js
@@ -1,20 +1,36 @@
 import React, { act } from 'react';
-import {
-  QueryClient,
-  QueryClientProvider,
-} from 'react-query';
+import { QueryClient, QueryClientProvider } from 'react-query';
 
-import { renderHook } from '@folio/jest-config-stripes/testing-library/react';
+import {
+  renderHook,
+  waitFor,
+} from '@folio/jest-config-stripes/testing-library/react';
 import { useOkapiKy } from '@folio/stripes/core';
 
 import '../../../test/jest/__mock__';
 
 import useItemAuditDataQuery from './useItemAuditDataQuery';
 
+// Mock the dependencies
 jest.mock('@folio/stripes/core', () => ({
   ...jest.requireActual('@folio/stripes/core'),
   useOkapiKy: jest.fn(),
 }));
+
+const mockItemId = '123';
+const mockAuditData = {
+  totalRecords: 3,
+  inventoryAuditItems: [
+    { eventTs: '2024-03-20T10:00:00Z', id: '1' },
+    { eventTs: '2024-03-20T09:00:00Z', id: '2' },
+  ],
+};
+
+const mockKy = {
+  get: jest.fn().mockReturnValue({
+    json: () => Promise.resolve(mockAuditData),
+  }),
+};
 
 const queryClient = new QueryClient();
 const wrapper = ({ children }) => (
@@ -25,10 +41,8 @@ const wrapper = ({ children }) => (
 
 describe('useItemAuditDataQuery', () => {
   beforeEach(() => {
-    useOkapiKy.mockClear().mockReturnValue({
-      get: () => ({
-        json: () => Promise.resolve({ inventoryAuditItems: [{ action: 'UPDATE' }] }),
-      }),
+    useOkapiKy.mockReturnValue({
+      ...mockKy,
     });
   });
 
@@ -36,11 +50,99 @@ describe('useItemAuditDataQuery', () => {
     jest.clearAllMocks();
   });
 
-  it('should fetch item version history', async () => {
-    const { result } = renderHook(() => useItemAuditDataQuery('itemId'), { wrapper });
+  it('should fetch audit data when instanceId is provided', async () => {
+    const { result } = renderHook(
+      () => useItemAuditDataQuery(mockItemId),
+      { wrapper }
+    );
+
+    expect(result.current.isLoading).toBe(true);
 
     await act(() => !result.current.isLoading);
 
-    expect(result.current.data).toEqual([{ action: 'UPDATE' }]);
+    await waitFor(() => {
+      expect(mockKy.get).toHaveBeenCalledWith(
+        `audit-data/inventory/item/${mockItemId}`,
+        expect.any(Object)
+      );
+      expect(result.current.data).toEqual(mockAuditData.inventoryAuditItems);
+      expect(result.current.totalRecords).toBe(mockAuditData.totalRecords);
+    });
+  });
+
+  it('should not fetch data when instanceId is not provided', () => {
+    const { result } = renderHook(
+      () => useItemAuditDataQuery(null),
+      { wrapper }
+    );
+
+    expect(result.current.isLoading).toBe(false);
+    expect(mockKy.get).not.toHaveBeenCalled();
+  });
+
+  it('should handle fetchNextPage correctly', async () => {
+    const secondPageData = {
+      totalRecords: 3,
+      inventoryAuditItems: [
+        { eventTs: '2024-03-20T08:00:00Z', id: '3' },
+      ],
+    };
+
+    useOkapiKy
+      .mockClear()
+      .mockReturnValueOnce({
+        get: () => ({
+          json: () => Promise.resolve(mockAuditData),
+        }),
+      })
+      .mockReturnValueOnce({
+        get: () => ({
+          json: () => Promise.resolve(secondPageData),
+        }),
+      });
+
+    const { result } = renderHook(
+      () => useItemAuditDataQuery(mockItemId),
+      { wrapper }
+    );
+
+    await act(() => !result.current.isLoading);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toHaveLength(3);
+      expect(result.current.isLoadingMore).toBe(false);
+    });
+  });
+
+  it('should set hasNextPage to false when all records are fetched', async () => {
+    const singlePageData = {
+      totalRecords: 2,
+      inventoryAuditItems: [
+        { eventTs: '2024-03-20T10:00:00Z', id: '1' },
+        { eventTs: '2024-03-20T09:00:00Z', id: '2' },
+      ],
+    };
+
+    useOkapiKy
+      .mockClear()
+      .mockReturnValueOnce({
+        get: () => ({
+          json: () => Promise.resolve(singlePageData),
+        }),
+      });
+
+    const { result } = renderHook(
+      () => useItemAuditDataQuery(mockItemId),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.hasNextPage).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->
Requires https://github.com/folio-org/stripes-components/pull/2444

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Currently, there is no indicator that the version history pane is loading; instead a blank pane is displayed.

**Requirements**:

As the version history details are loading, display a loading indicator on:

FOLIO version history pane

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Refactor `useAuditDataQuery` hooks to use `useInfiniteQuery` to implement loading indicator to version history panes.

Using useInfiniteQuery instead of useQuery:

- Better suited for pagination/infinite loading
- Automatically manages multiple pages of data
- Provides built-in loading states for both initial and subsequent loads
- isLoading used for initial load
- isFetchingNextPage for subsequent loads
- hasNextPage to control when to show the load more button
- Uses getNextPageParam to automatically determine the next page's parameters

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3286

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
