### PR TITLE
UIIN-3122 Move focus on the Instance detail view pane when record is opened.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * ECS FOLIO instances: Inventory version history feature toggle/icon. Refs UIIN-3284.
 * ECS | "Version history" pane is empty for Shared FOLIO Instance when opened from Member tenant. Fixes UIIN-3280.
 * Refactor `useAuditDataQuery` hooks to use `useInfiniteQuery` to implement loading indicator to version history panes. Refs UIIN-3286.
+* Move focus on the Instance detail view pane when record is opened. Refs UIIN-3122.
 
 ## [13.0.0](https://github.com/folio-org/ui-inventory/tree/v13.0.0) (2025-03-14)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.12...v13.0.0)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -234,6 +234,7 @@ class ViewInstance extends React.Component {
 
     this.calloutRef = createRef();
     this.accordionStatusRef = createRef();
+    this.paneTitleRef = createRef();
   }
 
   componentDidMount() {
@@ -253,6 +254,10 @@ class ViewInstance extends React.Component {
 
     if (isUserInConsortiumMode(stripes)) {
       this.getCurrentTenantPermissions();
+    }
+
+    if (selectedInstance?.id && this.props.focusTitleOnInstanceLoad) {
+      this.paneTitleRef.current?.focus();
     }
   }
 
@@ -278,6 +283,10 @@ class ViewInstance extends React.Component {
     if ((isMARCSourceRecord || isLinkedDataSourceRecord) && (isViewingAnotherRecord || recordSourceWasChanged)) {
       this.getMARCRecord();
       this.checkCanBeOpenedInLinkedData();
+    }
+
+    if (isViewingAnotherRecord && this.props.focusTitleOnInstanceLoad) {
+      this.paneTitleRef.current?.focus();
     }
 
     // component got updated after a new record was created
@@ -1122,6 +1131,7 @@ class ViewInstance extends React.Component {
         userTenantPermissions={this.state.userTenantPermissions}
         isShared={isShared}
         mutateInstance={mutateInstance}
+        paneTitleRef={this.paneTitleRef}
       >
         {
           (!holdingsrecordid && !itemid) ?
@@ -1374,6 +1384,7 @@ ViewInstance.propTypes = {
   isError: PropTypes.bool,
   error: PropTypes.object,
   mutateInstance: PropTypes.func,
+  focusTitleOnInstanceLoad: PropTypes.bool,
 };
 
 export default flowRight(

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -1507,6 +1507,7 @@ class InstancesList extends React.Component {
             detailProps={{
               referenceTables: data,
               onCopy: this.copyInstance,
+              focusTitleOnInstanceLoad: true,
             }}
             basePath={path}
             path={`${path}/(view|viewsource)/:id/:holdingsrecordid?/:itemid?`}


### PR DESCRIPTION
## Description
Move focus on the Instance detail view pane when Instance record is opened.

## Screenshots

https://github.com/user-attachments/assets/8b1d690e-5fd1-4745-9245-2037ee76391a


## Issues
[UIIN-3122](https://folio-org.atlassian.net/browse/UIIN-3122)