### PR TITLE
UIIN-3282: Update instance header after overlaying source bibliographic record process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * ECS FOLIO instances: Inventory version history feature toggle/icon. Refs UIIN-3284.
 * ECS | "Version history" pane is empty for Shared FOLIO Instance when opened from Member tenant. Fixes UIIN-3280.
 * Refactor `useAuditDataQuery` hooks to use `useInfiniteQuery` to implement loading indicator to version history panes. Refs UIIN-3286.
+* Update instance header after overlaying source bibliographic record process. Fixes UIIN-3282.
 
 ## [13.0.0](https://github.com/folio-org/ui-inventory/tree/v13.0.0) (2025-03-14)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.12...v13.0.0)

--- a/src/Instance/InstanceDetails/InstanceDetails.js
+++ b/src/Instance/InstanceDetails/InstanceDetails.js
@@ -157,7 +157,7 @@ const InstanceDetails = forwardRef(({
         }
       );
     },
-    [isShared, instance?.source, isUserInConsortium],
+    [isShared, instance?.source, instance?.title, isUserInConsortium],
   );
   const paneSubTitle = useMemo(
     () => {


### PR DESCRIPTION
## Purpose
* The header of the Instance details pane is not changed after overlaying source bibliographic record process

## Approach
Update dependencies in `paneTitle`

## Refs
[UIIN-3282](https://folio-org.atlassian.net/browse/UIIN-3282)

https://github.com/user-attachments/assets/5b8fd831-8542-49cf-89db-3cf82a3a874a

