### PR TITLE
bump major to v14.0.0 for new development work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-inventory
 
-## [13.0.1] (IN PROGRESS)
+## [14.0.0] (IN PROGRESS)
 
 * Missing values in the version history modal for Suppressed from discovery and Staff suppressed fields. Fixed UIIN-3277.
 * ECS FOLIO instances: Inventory version history feature toggle/icon. Refs UIIN-3284.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/inventory",
-  "version": "13.0.0",
+  "version": "14.0.0",
   "description": "Inventory manager",
   "repository": "folio-org/ui-inventory",
   "publishConfig": {


### PR DESCRIPTION
The major version was inadvertently bumped to 14 in PR #2769 and then reverted down to 13 in PR #2793. Although the present release was not intended to be a major release, now that some v14.x releases have already been published to CI we are better off just keeping that change rather than trying to undo it, which is likely to be even more disruptive.
