### PR TITLE
UIIN-3299 Ramsons CSP - Call number browse | Remove held by facet for ECS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## [12.0.15] (IN PROGRESS)
+
+* Ramsons CSP - Call number browse | Remove held by facet for ECS. Refs UIIN-3299.
+
 ## [12.0.14](https://github.com/folio-org/ui-inventory/tree/v12.0.14) (2025-03-26)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.13...v12.0.14)
 

--- a/src/components/InstanceFiltersBrowse/InstanceFiltersBrowse.js
+++ b/src/components/InstanceFiltersBrowse/InstanceFiltersBrowse.js
@@ -10,7 +10,6 @@ import {
 import { AccordionSet } from '@folio/stripes/components';
 import {
   FACETS,
-  HeldByFacet,
   browseModeOptions,
   browseCallNumberOptions,
   browseClassificationOptions,
@@ -88,18 +87,18 @@ const InstanceFiltersBrowse = props => {
     />
   );
 
-  const renderHeldByFacet = (name) => (
-    <HeldByFacet
-      name={name}
-      activeFilters={activeFilters}
-      facetOptions={facetOptions}
-      getIsLoading={getIsLoading}
-      onChange={onChange}
-      onClear={onClear}
-      onFetch={onInputFocusAndMoreClick}
-      onSearch={onFacetOptionSearch}
-    />
-  );
+  // const renderHeldByFacet = (name) => (
+  //   <HeldByFacet
+  //     name={name}
+  //     activeFilters={activeFilters}
+  //     facetOptions={facetOptions}
+  //     getIsLoading={getIsLoading}
+  //     onChange={onChange}
+  //     onClear={onClear}
+  //     onFetch={onInputFocusAndMoreClick}
+  //     onSearch={onFacetOptionSearch}
+  //   />
+  // );
 
   return (
     <AccordionSet
@@ -115,11 +114,6 @@ const InstanceFiltersBrowse = props => {
             isNewCallNumberBrowseAvailable
               ? FACETS.CALL_NUMBERS_SHARED
               : FACETS.SHARED
-          )}
-          {renderHeldByFacet(
-            isNewCallNumberBrowseAvailable
-              ? FACETS.NEW_CALL_NUMBERS_HELD_BY
-              : FACETS.CALL_NUMBERS_HELD_BY
           )}
           <EffectiveLocationFacet
             name={isNewCallNumberBrowseAvailable

--- a/src/components/InstanceFiltersBrowse/instanceFiltersBrowse.test.js
+++ b/src/components/InstanceFiltersBrowse/instanceFiltersBrowse.test.js
@@ -144,7 +144,7 @@ describe('InstanceFiltersBrowse', () => {
       expect(getByText('Shared')).toBeInTheDocument();
     });
 
-    describe('"Held by" facet', () => {
+    describe.skip('"Held by" facet', () => {
       it('should be displayed', () => {
         mockHasInterface.mockReturnValue(false);
 
@@ -246,7 +246,7 @@ describe('InstanceFiltersBrowse', () => {
       expect(mockOnClear).toHaveBeenCalled();
     });
 
-    it('should display "Held By" facet accordion', () => {
+    it.skip('should display "Held By" facet accordion', () => {
       const { getByRole } = renderInstanceFilters({
         data,
         query: {


### PR DESCRIPTION
## Description
In ECS environments, the Held by facet was applied to call number browse but it is not needed as users can limit by the Effective location facet due to the fact that call number browse relies on the existence of an item record.

## Issues
[UIIN-3299](http://folio-org.atlassian.net/browse/UIIN-3299)