### PR TITLE
UIIN-3279: Add `useSharedInstancesQuery` hook to determine if an instance is shared from a local one to display `Shared` in the version history original card.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * ECS FOLIO instances: Inventory version history feature toggle/icon. Refs UIIN-3284.
 * ECS | "Version history" pane is empty for Shared FOLIO Instance when opened from Member tenant. Fixes UIIN-3280.
 * Refactor `useAuditDataQuery` hooks to use `useInfiniteQuery` to implement loading indicator to version history panes. Refs UIIN-3286.
+* Add `useSharedInstancesQuery` hook to determine if an instance is shared from a local one to display "Shared" in the version history original card. Fixes UIIN-3279.
 
 ## [13.0.0](https://github.com/folio-org/ui-inventory/tree/v13.0.0) (2025-03-14)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.12...v13.0.0)

--- a/package.json
+++ b/package.json
@@ -690,7 +690,8 @@
           "audit.inventory.item.collection.get",
           "audit.marc.bib.collection.get",
           "audit.config.groups.settings.collection.get",
-          "audit.config.groups.settings.audit.inventory.collection.get"
+          "audit.config.groups.settings.audit.inventory.collection.get",
+          "consortia.sharing-instances.collection.get"
         ],
         "visible": true
       },

--- a/src/components/ViewSource/ViewSource.js
+++ b/src/components/ViewSource/ViewSource.js
@@ -43,6 +43,7 @@ import { useGoBack } from '../../common/hooks';
 import {
   useAuditSettings,
   useQuickExport,
+  useSharedInstancesQuery,
 } from '../../hooks';
 import { IdReportGenerator } from '../../reports';
 import {
@@ -76,11 +77,15 @@ const ViewSource = ({
   const callout = useCallout();
   const [isShownPrintPopup, setIsShownPrintPopup] = useState(false);
   const [isVersionHistoryOpen, setIsVersionHistoryOpen] = useState(false);
+
   const { exportRecords } = useQuickExport();
+  const { sharedInstances } = useSharedInstancesQuery({ searchParams: { instanceIdentifier: instanceId } });
+
   const openPrintPopup = () => setIsShownPrintPopup(true);
   const closePrintPopup = () => setIsShownPrintPopup(false);
   const isHoldingsRecord = marcType === MARC_TYPES.HOLDINGS;
   const isBibRecord = marcType === MARC_TYPES.BIB;
+  const isSharedFromLocalRecord = !!sharedInstances?.[0];
 
   const centralTenantId = stripes.user.user?.consortium?.centralTenantId;
   const isPrintBibAvailable = !isHoldingsRecord && stripes.hasPerm('ui-quick-marc.quick-marc-editor.view');
@@ -307,6 +312,7 @@ const ViewSource = ({
             onClose={() => setIsVersionHistoryOpen(false)}
             marcType="bib"
             tenantId={tenantId}
+            isSharedFromLocalRecord={isSharedFromLocalRecord}
           />
         )}
       </Paneset>

--- a/src/components/ViewSource/ViewSource.test.js
+++ b/src/components/ViewSource/ViewSource.test.js
@@ -13,6 +13,7 @@ import {
 
 import '../../../test/jest/__mock__';
 
+import { MarcVersionHistory } from '@folio/stripes-marc-components';
 import renderWithIntl from '../../../test/jest/helpers/renderWithIntl';
 import translations from '../../../test/jest/helpers/translationsProperties';
 import ViewSource from './ViewSource';
@@ -20,6 +21,7 @@ import useGoBack from '../../common/hooks/useGoBack';
 import {
   useAuditSettings,
   useQuickExport,
+  useSharedInstancesQuery,
 } from '../../hooks';
 import { CONSORTIUM_PREFIX } from '../../constants';
 import MARC_TYPES from './marcTypes';
@@ -43,6 +45,7 @@ jest.mock('../../hooks', () => ({
     }],
     isSettingsLoading: false,
   }),
+  useSharedInstancesQuery: jest.fn(),
 }));
 
 const mutator = {
@@ -81,6 +84,11 @@ describe('ViewSource', () => {
       push: mockPush,
     });
     useGoBack.mockReturnValue(mockGoBack);
+
+    useSharedInstancesQuery.mockReturnValue({
+      sharedInstances: [],
+      isLoadingSharedInstances: false,
+    });
   });
 
   afterEach(() => {
@@ -253,13 +261,28 @@ describe('ViewSource', () => {
     it('should open the version history pane', () => {
       fireEvent.click(screen.getByLabelText('stripes-acq-components.versionHistory.pane.header'));
 
-      expect(screen.getByText('stripes-components.auditLog.pane.sub')).toBeInTheDocument();
+      expect(screen.getByText('MarcVersionHistory')).toBeInTheDocument();
     });
 
     it('should disable Actions button', () => {
       fireEvent.click(document.getElementById('version-history-btn'));
 
       expect(screen.getByTestId('actions-dropdown')).toBeDisabled();
+    });
+
+    describe('when the record has been shared from the local one', () => {
+      it('should pass the `isSharedFromLocalRecord` as true to the `MarcVersionHistory`', () => {
+        useSharedInstancesQuery.mockReturnValue({
+          sharedInstances: [{}],
+          isLoadingSharedInstances: false,
+        });
+
+        fireEvent.click(document.getElementById('version-history-btn'));
+
+        expect(MarcVersionHistory).toHaveBeenCalledWith(expect.objectContaining({
+          isSharedFromLocalRecord: true,
+        }), {});
+      });
     });
   });
 

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -24,3 +24,4 @@ export * from '@folio/stripes-inventory-components/lib/queries/useInstanceDateTy
 export * from './useCallNumberTypesQuery';
 export * from './useAuditSettings';
 export * from './useCallNumberBrowseConfig';
+export * from './useSharedInstancesQuery';

--- a/src/hooks/useSharedInstancesQuery/index.js
+++ b/src/hooks/useSharedInstancesQuery/index.js
@@ -1,0 +1,1 @@
+export * from './useSharedInstancesQuery';

--- a/src/hooks/useSharedInstancesQuery/useSharedInstancesQuery.js
+++ b/src/hooks/useSharedInstancesQuery/useSharedInstancesQuery.js
@@ -1,0 +1,32 @@
+import { useQuery } from 'react-query';
+
+import {
+  useNamespace,
+  useOkapiKy,
+  useStripes,
+} from '@folio/stripes/core';
+
+const useSharedInstancesQuery = ({ searchParams } = {}) => {
+  const [namespace] = useNamespace({ key: 'sharing-instances' });
+  const ky = useOkapiKy();
+  const stripes = useStripes();
+
+  const { id: consortiumId } = stripes.user.user.consortium || {};
+
+  const { data, isLoading } = useQuery(
+    [namespace, consortiumId, searchParams],
+    () => ky.get(`consortia/${consortiumId}/sharing/instances`, {
+      searchParams,
+    }).json(),
+    {
+      enabled: Boolean(consortiumId),
+    },
+  );
+
+  return {
+    sharedInstances: data?.sharingInstances,
+    isLoadingSharedInstances: isLoading,
+  };
+};
+
+export { useSharedInstancesQuery };

--- a/src/hooks/useSharedInstancesQuery/useSharedInstancesQuery.test.js
+++ b/src/hooks/useSharedInstancesQuery/useSharedInstancesQuery.test.js
@@ -1,0 +1,53 @@
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+
+import {
+  renderHook,
+  act,
+} from '@folio/jest-config-stripes/testing-library/react';
+import {
+  useOkapiKy,
+  useStripes,
+} from '@folio/stripes/core';
+
+import { useSharedInstancesQuery } from './useSharedInstancesQuery';
+
+const queryClient = new QueryClient();
+
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+describe('useSharedInstancesQuery', () => {
+  beforeEach(() => {
+    useStripes.mockClear();
+
+    useOkapiKy.mockReturnValue({
+      get: () => ({
+        json: () => Promise.resolve({ sharingInstances: [{ id: 'id-1' }] }),
+      }),
+    });
+  });
+
+  it('should fetch shared instances', async () => {
+    useStripes.mockReturnValue({
+      user: {
+        user: {
+          consortium: {
+            id: 'consortium-id',
+          },
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useSharedInstancesQuery(), { wrapper });
+
+    await act(() => !result.current.isLoading);
+
+    expect(result.current.sharedInstances).toEqual([{ id: 'id-1' }]);
+  });
+});

--- a/test/jest/__mock__/stripesMarcComponents.mock.js
+++ b/test/jest/__mock__/stripesMarcComponents.mock.js
@@ -11,4 +11,5 @@ jest.mock('@folio/stripes-marc-components', () => ({
       {lastMenu}
     </>
   )),
+  MarcVersionHistory: jest.fn(() => <div>MarcVersionHistory</div>),
 }));


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
Display `Shared` instead of `Original version` in the version history original card when an instance was shared from the local one.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
Get shared instances from `consortia/${consortiumId}/sharing/instances` and pass the `isSharedFromLocalRecord` to the `MarcVersionHistory` component.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-3279](https://folio-org.atlassian.net/browse/UIIN-3279)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots

https://github.com/user-attachments/assets/395aaf2d-e06f-44de-8341-48b1b1e81c7d



<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
