### PR TITLE
UIIN-3300: Display `Shared` label for promoted to be shared FOLIO records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Update instance header after overlaying source bibliographic record process. Fixes UIIN-3282.
 * Add `useSharedInstancesQuery` hook to determine if an instance is shared from a local one to display "Shared" in the version history original card. Fixes UIIN-3279.
 * Enable MARC-related options for shared MARC instance on member tenant. Fixes UIIN-3292.
+* Display "Shared" label for promoted to be shared FOLIO records. Fixes UIIN-3300.
 
 ## [13.0.0](https://github.com/folio-org/ui-inventory/tree/v13.0.0) (2025-03-14)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.12...v13.0.0)

--- a/src/Instance/InstanceDetails/InstanceDetails.js
+++ b/src/Instance/InstanceDetails/InstanceDetails.js
@@ -60,7 +60,7 @@ import {
   isInstanceShadowCopy,
   isUserInConsortiumMode,
 } from '../../utils';
-import { useAuditSettings } from '../../hooks';
+import { useAuditSettings, useSharedInstancesQuery } from '../../hooks';
 import { INVENTORY_AUDIT_GROUP } from '../../constants';
 
 import css from './InstanceDetails.css';
@@ -106,6 +106,8 @@ const InstanceDetails = forwardRef(({
 
   const { settings } = useAuditSettings({ group: INVENTORY_AUDIT_GROUP, tenantId: instance?.tenantId });
   const isVersionHistoryEnabled = getIsVersionHistoryEnabled(settings);
+
+  const { sharedInstances } = useSharedInstancesQuery({ searchParams: { instanceIdentifier: instance?.id } });
 
   const canCreateHoldings = stripes.hasPerm('ui-inventory.holdings.create');
   const tags = instance?.tags?.tagList;
@@ -353,6 +355,7 @@ const InstanceDetails = forwardRef(({
           instanceId={instance?.id}
           onClose={() => setIsVersionHistoryOpen(false)}
           tenantId={instance?.tenantId}
+          isSharedFromLocalRecord={!!sharedInstances?.[0]}
         />
       )}
       { helperApp &&

--- a/src/Instance/InstanceVersionHistory/InstanceVersionHistory.js
+++ b/src/Instance/InstanceVersionHistory/InstanceVersionHistory.js
@@ -48,6 +48,7 @@ const InstanceVersionHistory = ({
   instanceId,
   onClose,
   tenantId,
+  isSharedFromLocalRecord,
 }) => {
   const intl = useIntl();
   const { formatMessage } = intl;
@@ -125,6 +126,7 @@ const InstanceVersionHistory = ({
       fieldFormatter={fieldFormatter}
       actionsMap={actionsMap}
       totalVersions={totalVersions}
+      showSharedLabel={isSharedFromLocalRecord}
     />
   );
 };
@@ -133,6 +135,7 @@ InstanceVersionHistory.propTypes = {
   instanceId: PropTypes.string.isRequired,
   onClose: PropTypes.func,
   tenantId: PropTypes.string,
+  isSharedFromLocalRecord: PropTypes.bool,
 };
 
 export default InstanceVersionHistory;


### PR DESCRIPTION
## Purpose
* We should show “Shared” label instead of “Original version” in the first card for Instance records which were promoted to be Shared.

## Approach
* Add `useSharedInstancesQuery` hook to determine if an instance is shared from a local one to display "Shared" in the version history original card

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
[UIIN-3300](https://folio-org.atlassian.net/browse/UIIN-3300)
