### PR TITLE
UIIN-3321: Use central tenant id in `useUsersBatch` to retrieve all users.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Enable MARC-related options for shared MARC instance on member tenant. Fixes UIIN-3292.
 * Call number browse | Remove held by facet for ECS. Refs UIIN-3301.
 * Display "Shared" label for promoted to be shared FOLIO records. Fixes UIIN-3300.
+* Use central tenant id in useUsersBatch to retrieve all users. Fixes UIIN-3321.
 
 ## [13.0.0](https://github.com/folio-org/ui-inventory/tree/v13.0.0) (2025-03-14)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.12...v13.0.0)

--- a/src/hooks/useInventoryVersionHistory/useInventoryVersionHistory.js
+++ b/src/hooks/useInventoryVersionHistory/useInventoryVersionHistory.js
@@ -58,7 +58,9 @@ const useInventoryVersionHistory = (data) => {
   const [usersId, setUsersId] = useState([]);
   const [usersMap, setUsersMap] = useState({});
 
-  const { users } = useUsersBatch(usersId);
+  const centralTenantId = stripes.user.user.consortium?.centralTenantId;
+
+  const { users } = useUsersBatch(usersId, { tenantId: centralTenantId });
 
   const canViewUser = stripes.hasPerm('users.item.get');
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
The "Source" field in the history pane shouldn't be empty for member tenants if changes are made by another member tenant (the College should see the user who made changes in the University).
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
https://folio-org.atlassian.net/browse/UIIN-3321
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
![image](https://github.com/user-attachments/assets/69684fd8-a9f8-47a2-8d65-5fb11029155b)


<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
