### PR TITLE
UIIN-3301 Browse Effective location - show separator only for member tenants (follow-up)

### DIFF
--- a/src/components/InstanceFiltersBrowse/InstanceFiltersBrowse.js
+++ b/src/components/InstanceFiltersBrowse/InstanceFiltersBrowse.js
@@ -92,7 +92,7 @@ const InstanceFiltersBrowse = props => {
             name={FACETS.CALL_NUMBERS_EFFECTIVE_LOCATION}
             accordionsStatus={accordionsStatus}
             facetOptions={facetOptions}
-            separator={isConsortiaEnv(stripes)}
+            separator={checkIfUserInMemberTenant(stripes)}
             activeFilters={activeFilters}
             onChange={onChange}
             onToggle={onToggleAccordion}


### PR DESCRIPTION
## Description
For Browse Effective Location filter show the top border only for member tenants. In central tenant this is the only filter so the border is not needed

## Screenshots
Member tenant
![image](https://github.com/user-attachments/assets/a5c4a1e9-e28b-41ac-927e-496084d792f0)

Central tenant
![image](https://github.com/user-attachments/assets/a59b0f59-8299-4445-98fc-00c6b3957b21)

## Issues
[UIIN-3301](https://folio-org.atlassian.net/browse/UIIN-3301)