### PR TITLE
UIIN-3317: Hide Set for deletion action when Set for deletion field value is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Display "Shared" label for promoted to be shared FOLIO records. Fixes UIIN-3300.
 * Remove default Staff suppress facet settings. Refs UIIN-3302.
 * Use central tenant id in useUsersBatch to retrieve all users. Fixes UIIN-3321.
+* Hide `Set for deletion` action when `Set for deletion` field value is true. Refs UIIN-3317.
 
 ## [13.0.0](https://github.com/folio-org/ui-inventory/tree/v13.0.0) (2025-03-14)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v12.0.12...v13.0.0)

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -55,7 +55,6 @@ import {
   INSTANCE_RECORD_TYPE,
   INSTANCE_SHARING_STATUSES,
   layers,
-  LEADER_RECORD_STATUSES,
   LINKED_DATA_CHECK_EXTERNAL_RESOURCE_FETCHABLE,
   LINKED_DATA_EDITOR_PERM,
   LINKED_DATA_ID_PREFIX,
@@ -806,13 +805,6 @@ class ViewInstance extends React.Component {
     const canMemberTenantSetForDeletion = (isShared && this.hasCentralTenantPerm(setForDeletionAndSuppressPerm)) || (!isShared && hasSetForDeletionPermission);
     const canSetForDeletion = canNonConsortialTenantSetForDeletion || canCentralTenantSetForDeletion || canMemberTenantSetForDeletion;
 
-    const isRecordSuppressed = instance?.discoverySuppress && instance?.staffSuppress;
-    const isRecordSetForDeletion = isSourceMARC
-      && instance?.discoverySuppress
-      && instance?.deleted
-      && instance?.leaderRecordStatus === LEADER_RECORD_STATUSES.DELETED;
-    const isInstanceSuppressed = isRecordSuppressed || isRecordSetForDeletion;
-
     const numberOfRequests = instanceRequests.other?.totalRecords;
     const canReorderRequests = titleLevelRequestsFeatureEnabled && hasReorderPermissions && numberOfRequests && canReorder;
     const canViewRequests = !checkIfUserInCentralTenant(stripes) && !titleLevelRequestsFeatureEnabled;
@@ -972,7 +964,7 @@ class ViewInstance extends React.Component {
                 onClickHandler={buildOnClickHandler(this.triggerQuickExport)}
               />
             )}
-            {canSetForDeletion && !isInstanceSuppressed && !isSourceLinkedData && (
+            {canSetForDeletion && !instance?.deleted && !isSourceLinkedData && (
               <ActionItem
                 id="quick-export-trigger"
                 icon="flag"

--- a/src/ViewInstance.test.js
+++ b/src/ViewInstance.test.js
@@ -1084,26 +1084,10 @@ describe('ViewInstance', () => {
         });
       });
 
-      describe('when instance is suppressed from staff and discovery', () => {
+      describe('when instance is set for deletion', () => {
         it('should not see "Set record for deletion" action item', () => {
           StripesConnectedInstance.prototype.instance.mockImplementation(() => ({
             ...instance,
-            discoverySuppress: true,
-            staffSuppress: true,
-          }));
-
-          renderViewInstance();
-
-          expect(screen.queryByText('button', { name: 'Set record for deletion' })).not.toBeInTheDocument();
-        });
-      });
-
-      describe('when instance has source = "MARC" and it is marked as deleted', () => {
-        it('should not see "Set record for deletion" action item', () => {
-          StripesConnectedInstance.prototype.instance.mockImplementation(() => ({
-            ...instance,
-            discoverySuppress: true,
-            leaderRecordStatus: 'd',
             deleted: true,
           }));
 


### PR DESCRIPTION
## Purpose
* Currently, the `Set record for deletion` action is set to be hidden if an Instance has both `Staff suppressed` and `Suppress from discovery` set to **true**. We should instead hide this action only if the `Set for deletion` field has been set to **true** for an instance.

## Refs
[UIIN-3317](https://folio-org.atlassian.net/browse/UIIN-3317)

## Screenshots
https://github.com/user-attachments/assets/21d63420-ff73-4964-87a0-c32bace11e10