### PR TITLE
Release v13.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [14.0.0] (IN PROGRESS)
 
 * Move focus on the Instance detail view pane when record is opened. Refs UIIN-3122.
+
+## [13.0.3](https://github.com/folio-org/ui-inventory/tree/v13.0.3) (2025-04-14)
+[Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.1...v13.0.3)
+
 * Add `useSharedInstancesQuery` hook to determine if an instance is shared from a local one to display "Shared" in the version history original card. Fixes UIIN-3279.
 * Call number browse | Remove held by facet for ECS. Refs UIIN-3301.
 * Display "Shared" label for promoted to be shared FOLIO records. Fixes UIIN-3300.


### PR DESCRIPTION
`v13.0.2` was skipped due to a release workflow issue: [FOLIO-4281](https://folio-org.atlassian.net/browse/FOLIO-4281)