### PR TITLE
UIIN-3377: Instance/holdings/items form - moved `form` under `Pane` component to suppress form submitting on Enter key click event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Move focus on the Instance detail view pane when record is opened. Refs UIIN-3122.
 * Update `orders` and `order-lines` interfaces to `13.0` and `4.0` accordingly. Refs UIIN-3345.
 * Remove extra record from Central tenant after adding `Receiving history` record in local member instance. Fixes UIIN-3211.
+* Instance/holdings/items form - moved `form` under `Pane` component to suppress form submitting on Enter key click event. Fixes UIIN-3377.
 
 ## [13.0.4](https://github.com/folio-org/ui-inventory/tree/v13.0.4) (2025-04-18)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.3...v13.0.4)

--- a/src/edit/InstanceForm.js
+++ b/src/edit/InstanceForm.js
@@ -489,26 +489,26 @@ class InstanceForm extends React.Component {
     return (
       <IntlConsumer>
         {intl => (
-          <form
-            data-test-instance-page-type={initialValues.id ? 'edit' : 'create'}
-            className={styles.instanceForm}
-            aria-label={intl.formatMessage({ id: 'ui-inventory.instanceForm' })}
+          <HasCommand
+            commands={shortcuts}
+            isWithinScope={checkScope}
+            scope={document.body}
           >
-            <HasCommand
-              commands={shortcuts}
-              isWithinScope={checkScope}
-              scope={document.body}
-            >
-              <Paneset isRoot>
-                <Pane
-                  defaultWidth="100%"
-                  dismissible
-                  onClose={onCancel}
-                  footer={this.getFooter()}
-                  paneTitle={this.getPaneTitle()}
-                  paneSub={initialValues?.id ? this.getPaneSubTitle() : null}
-                  actionMenu={this.getActionMenu}
-                  id={id}
+            <Paneset isRoot>
+              <Pane
+                defaultWidth="100%"
+                dismissible
+                onClose={onCancel}
+                footer={this.getFooter()}
+                paneTitle={this.getPaneTitle()}
+                paneSub={initialValues?.id ? this.getPaneSubTitle() : null}
+                actionMenu={this.getActionMenu}
+                id={id}
+              >
+                <form
+                  data-test-instance-page-type={initialValues.id ? 'edit' : 'create'}
+                  className={styles.instanceForm}
+                  aria-label={intl.formatMessage({ id: 'ui-inventory.instanceForm' })}
                 >
                   <OptimisticLockingBanner
                     httpError={httpError}
@@ -918,10 +918,10 @@ class InstanceForm extends React.Component {
                       </AccordionSet>
                     </AccordionStatus>
                   </div>
-                </Pane>
-              </Paneset>
-            </HasCommand>
-          </form>
+                </form>
+              </Pane>
+            </Paneset>
+          </HasCommand>
         )}
       </IntlConsumer>
     );

--- a/src/edit/holdings/HoldingsForm.js
+++ b/src/edit/holdings/HoldingsForm.js
@@ -331,38 +331,38 @@ class HoldingsForm extends React.Component {
     ];
 
     return (
-      <form
-        data-test-holdings-page-type={holdingsPageType}
-        className={styles.holdingsForm}
+      <HasCommand
+        commands={shortcuts}
+        isWithinScope={checkScope}
+        scope={document.body}
       >
-        <HasCommand
-          commands={shortcuts}
-          isWithinScope={checkScope}
-          scope={document.body}
-        >
-          <Paneset isRoot>
-            <Pane
-              appIcon={<AppIcon app="inventory" iconKey="holdings" />}
-              defaultWidth="100%"
-              dismissible
-              onClose={onCancel}
-              footer={this.getFooter()}
-              paneTitle={
-                <span data-test-header-title>
-                  {instance.title}
-                </span>
-              }
-              paneSub={
-                (instance.publication && instance.publication.length > 0) ?
-                  <>
-                    {instance.publication[0].publisher}
-                    {instance.publication[0].dateOfPublication
-                      ? `, ${instance.publication[0].dateOfPublication}`
-                      : null
-                    }
-                  </>
-                  : null
-              }
+        <Paneset isRoot>
+          <Pane
+            appIcon={<AppIcon app="inventory" iconKey="holdings" />}
+            defaultWidth="100%"
+            dismissible
+            onClose={onCancel}
+            footer={this.getFooter()}
+            paneTitle={
+              <span data-test-header-title>
+                {instance.title}
+              </span>
+            }
+            paneSub={
+              (instance.publication && instance.publication.length > 0) ?
+                <>
+                  {instance.publication[0].publisher}
+                  {instance.publication[0].dateOfPublication
+                    ? `, ${instance.publication[0].dateOfPublication}`
+                    : null
+                }
+                </>
+                : null
+            }
+          >
+            <form
+              data-test-holdings-page-type={holdingsPageType}
+              className={styles.holdingsForm}
             >
               <OptimisticLockingBanner
                 httpError={httpError}
@@ -780,10 +780,10 @@ class HoldingsForm extends React.Component {
                   </Accordion>
                 </AccordionSet>
               </AccordionStatus>
-            </Pane>
-          </Paneset>
-        </HasCommand>
-      </form>
+            </form>
+          </Pane>
+        </Paneset>
+      </HasCommand>
     );
   }
 }

--- a/src/edit/items/ItemForm.js
+++ b/src/edit/items/ItemForm.js
@@ -409,49 +409,49 @@ class ItemForm extends React.Component {
     };
 
     return (
-      <form
-        data-test-item-page-type={initialValues.id ? 'edit' : 'create'}
-        className={styles.itemForm}
-        onSubmit={handleSubmit}
+      <HasCommand
+        commands={shortcuts}
+        isWithinScope={checkScope}
+        scope={document.body}
       >
-        <HasCommand
-          commands={shortcuts}
-          isWithinScope={checkScope}
-          scope={document.body}
-        >
-          <Paneset isRoot>
-            <Pane
-              defaultWidth="100%"
-              dismissible
-              onClose={onCancel}
-              footer={this.getFooter()}
-              appIcon={<AppIcon app="inventory" iconKey="item" />}
-              paneTitle={
-                <span data-test-header-title>
-                  {instance.title}
-                  {(instance.publication && instance.publication.length > 0) &&
-                    <>
-                      &apos;, &apos;
-                      {instance.publication[0].publisher}
-                      {instance.publication[0].dateOfPublication
-                        ? `, ${instance.publication[0].dateOfPublication}`
-                        : null
-                      }
-                    </>
-                  }
-                </span>
-              }
-              paneSub={
-                <span data-test-header-sub>
-                  <FormattedMessage
-                    id="ui-inventory.holdingsTitle"
-                    values={{
-                      location: labelLocation,
-                      callNumber: labelCallNumber,
-                    }}
-                  />
-                </span>
-              }
+        <Paneset isRoot>
+          <Pane
+            defaultWidth="100%"
+            dismissible
+            onClose={onCancel}
+            footer={this.getFooter()}
+            appIcon={<AppIcon app="inventory" iconKey="item" />}
+            paneTitle={
+              <span data-test-header-title>
+                {instance.title}
+                {(instance.publication && instance.publication.length > 0) &&
+                  <>
+                    &apos;, &apos;
+                    {instance.publication[0].publisher}
+                    {instance.publication[0].dateOfPublication
+                      ? `, ${instance.publication[0].dateOfPublication}`
+                      : null
+                    }
+                  </>
+                }
+              </span>
+            }
+            paneSub={
+              <span data-test-header-sub>
+                <FormattedMessage
+                  id="ui-inventory.holdingsTitle"
+                  values={{
+                    location: labelLocation,
+                    callNumber: labelCallNumber,
+                  }}
+                />
+              </span>
+            }
+          >
+            <form
+              data-test-item-page-type={initialValues.id ? 'edit' : 'create'}
+              className={styles.itemForm}
+              onSubmit={handleSubmit}
             >
               <OptimisticLockingBanner
                 httpError={httpError}
@@ -503,7 +503,7 @@ class ItemForm extends React.Component {
                         sm={5}
                       >
                         {(item?.metadata && item?.metadata?.createdDate) &&
-                        <this.cViewMetaData metadata={item.metadata} />
+                          <this.cViewMetaData metadata={item.metadata} />
                         }
                         {/* <Field label="Material Type" name="materialType.name" id="additem_materialType" component={TextField} fullWidth /> */}
                       </Col>
@@ -881,13 +881,13 @@ class ItemForm extends React.Component {
                               aria-required="true"
                               fullWidth
                               dataOptions={
-                              [{
-                                label: placeholder,
-                                value: '',
-                                selected: !initialValues.loanType
-                              },
-                              ...loanTypeOptions
-                              ]}
+                                [{
+                                  label: placeholder,
+                                  value: '',
+                                  selected: !initialValues.loanType
+                                },
+                                ...loanTypeOptions
+                                ]}
                             />
                           )}
                         </FormattedMessage>
@@ -994,10 +994,10 @@ class ItemForm extends React.Component {
                   </Accordion>
                 </AccordionSet>
               </AccordionStatus>
-            </Pane>
-          </Paneset>
-        </HasCommand>
-      </form>
+            </form>
+          </Pane>
+        </Paneset>
+      </HasCommand>
     );
   }
 }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
When editing forms in Inventory, changing some text box and then clicking Enter key - the form is submitting which is not expected behavior.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Moved `form` tag under `Pane` component to suppress event propagation

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3377

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
