### PR TITLE
UIIN-3414: Restore Held by Facet in Call number Browse.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add source URI field to instance full-record display and (disabled) to edit form. Fixes UIIN-3287.
 * Adding HRID to the Inventory results list & show columns options. Refs UIIN-1262.
 * Display more detailed error message when updating ownership for holdings fails. Refs UIIN-3339.
+* ECS | Restore Held by Facet in Call number Browse. Refs UIIN-3414.
 
 ## [13.0.4](https://github.com/folio-org/ui-inventory/tree/v13.0.4) (2025-04-18)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.3...v13.0.4)

--- a/src/components/InstanceFiltersBrowse/InstanceFiltersBrowse.js
+++ b/src/components/InstanceFiltersBrowse/InstanceFiltersBrowse.js
@@ -7,6 +7,7 @@ import {
 } from '@folio/stripes/core';
 import {
   FACETS,
+  HeldByFacet,
   browseModeOptions,
   browseCallNumberOptions,
   browseClassificationOptions,
@@ -69,16 +70,16 @@ const InstanceFiltersBrowse = props => {
     />
   );
 
-  // const renderHeldByFacet = (name) => (
-  //   <HeldByFacet
-  //     name={name}
-  //     accordionsStatus={accordionsStatus}
-  //     activeFilters={activeFilters}
-  //     facetOptions={facetOptions}
-  //     onChange={onChange}
-  //     onToggle={onToggleAccordion}
-  //   />
-  // );
+  const renderHeldByFacet = (name) => (
+    <HeldByFacet
+      name={name}
+      accordionsStatus={accordionsStatus}
+      activeFilters={activeFilters}
+      facetOptions={facetOptions}
+      onChange={onChange}
+      onToggle={onToggleAccordion}
+    />
+  );
 
   return (
     <>
@@ -88,11 +89,12 @@ const InstanceFiltersBrowse = props => {
       {Object.values(browseCallNumberOptions).includes(qindex) && (
         <>
           {renderSharedFacet(FACETS.CALL_NUMBERS_SHARED)}
+          {renderHeldByFacet(FACETS.CALL_NUMBERS_HELD_BY)}
           <EffectiveLocationFacet
             name={FACETS.CALL_NUMBERS_EFFECTIVE_LOCATION}
             accordionsStatus={accordionsStatus}
             facetOptions={facetOptions}
-            separator={checkIfUserInMemberTenant(stripes)}
+            separator={isConsortiaEnv(stripes)}
             activeFilters={activeFilters}
             onChange={onChange}
             onToggle={onToggleAccordion}

--- a/src/components/InstanceFiltersBrowse/instanceFiltersBrowse.test.js
+++ b/src/components/InstanceFiltersBrowse/instanceFiltersBrowse.test.js
@@ -138,7 +138,7 @@ describe('InstanceFiltersBrowse', () => {
   });
 
   describe('When callNumber browseType was selected', () => {
-    it.skip('should display "Held By" facet accordion', () => {
+    it('should display "Held By" facet accordion', () => {
       const { getByRole } = renderInstanceFilters({
         data,
         query: {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Description
the “Held by” facet in Browse was removed due to issues regarding the relationship between this facet and the “Effective location (item)” facet, as well as additional bugs, in Sunflower and Ramsons (see notes below). However, after receiving feedback, some institutions need to only select their tenant, and others need to see call numbers from all tenants. Therefore, we need to restore the Held by facet.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->


## Screenshots
![image](https://github.com/user-attachments/assets/def238e6-e0c5-4396-9ab1-cf788f99937f)


## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-3414](https://folio-org.atlassian.net/browse/UIIN-3414)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

