### PR TITLE
UIIN-3423 Use current tenant for MARC Holdings requests in View Source.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Adding HRID to the Inventory results list & show columns options. Refs UIIN-1262.
 * Display more detailed error message when updating ownership for holdings fails. Refs UIIN-3339.
 * ECS | Restore Held by Facet in Call number Browse. Refs UIIN-3414.
+* Use current tenant for MARC Holdings requests in View Source. Refs UIIN-3423.
 
 ## [13.0.4](https://github.com/folio-org/ui-inventory/tree/v13.0.4) (2025-04-18)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.3...v13.0.4)

--- a/src/components/ViewSource/ViewSource.js
+++ b/src/components/ViewSource/ViewSource.js
@@ -150,7 +150,13 @@ const ViewSource = ({
 
     const { okapi: { tenant, token, locale } } = stripes;
 
-    mutator.marcRecord.GET({ headers: getHeaders(tenantId ?? tenant, token, locale) })
+    // MARC Holdings doesn't support shared records yet
+    // so we should always request MARC Holdings records from a current tenant
+    const paramsForMarcSource = marcType === MARC_TYPES.HOLDINGS
+      ? null
+      : { headers: getHeaders(tenantId ?? tenant, token, locale) };
+
+    mutator.marcRecord.GET(paramsForMarcSource)
       .then((marcResponse) => {
         setMarc(marcResponse);
       })

--- a/src/components/ViewSource/ViewSource.test.js
+++ b/src/components/ViewSource/ViewSource.test.js
@@ -155,6 +155,19 @@ describe('ViewSource', () => {
     it('should set correct header to request', () => {
       expect(mutator.marcRecord.GET).toHaveBeenCalledWith({ headers: expect.objectContaining({ 'X-Okapi-Tenant': 'tenantId' }) });
     });
+
+    describe('when marc type is Holdings', () => {
+      beforeEach(async () => {
+        mutator.marcRecord.GET.mockClear();
+        await act(async () => {
+          await renderWithIntl(getViewSource({ tenantId: 'tenantId', marcType: MARC_TYPES.HOLDINGS }), translations);
+        });
+      });
+
+      it('should not set provided tenantId', () => {
+        expect(mutator.marcRecord.GET).not.toHaveBeenCalledWith({ headers: expect.objectContaining({ 'X-Okapi-Tenant': 'tenantId' }) });
+      });
+    });
   });
 
   describe('when Instance is shared', () => {


### PR DESCRIPTION
## Description
MARC Holdings doesn't support shared records yet so we should always request MARC Holdings records from a current tenant.

## Issues
[UIIN-3423](https://folio-org.atlassian.net/browse/UIIN-3423)