### PR TITLE
UIIN-3417: Display Service point in the Circulation history section in the item view page after check in action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Display more detailed error message when updating ownership for holdings fails. Refs UIIN-3339.
 * ECS | Restore Held by Facet in Call number Browse. Refs UIIN-3414.
 * Use current tenant for MARC Holdings requests in View Source. Refs UIIN-3423.
+* Display `Service point` in the `Circulation history` section in the item view page after check in action. Fixes UIIN-3417.
 
 ## [13.0.4](https://github.com/folio-org/ui-inventory/tree/v13.0.4) (2025-04-18)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.3...v13.0.4)

--- a/src/Item/hooks/useItemDetailsData/useItemDetailsData.js
+++ b/src/Item/hooks/useItemDetailsData/useItemDetailsData.js
@@ -179,7 +179,7 @@ const useItemDetailsData = ({
         {`${staffMember.personal.lastName}, ${staffMember.personal.firstName} ${staffMember.personal.middleName || ''}`}
       </Link>
     )
-  }), [item, staffMember]);
+  }), [item, staffMember, servicePoints.length]);
 
   const initialAccordionsState = {
     acc01: !areAllFieldsEmpty(values(administrativeData)),

--- a/test/jest/__mock__/stripesSmartComponents.mock.js
+++ b/test/jest/__mock__/stripesSmartComponents.mock.js
@@ -35,5 +35,8 @@ jest.mock('@folio/stripes/smart-components', () => ({
     const RealSearchAndSort = jest.requireActual('@folio/stripes/smart-components').SearchAndSort;
     return <RealSearchAndSort {...props} />;
   }),
+  withTags: Component => (props) => {
+    return <Component {...props} tagsEnabled={true} />;
+  },
 }), { virtual: true });
 


### PR DESCRIPTION
## Purpose
* The `Service point` should be displayed in the `Circulation history` section in the item view page after `check in` action.

## Approach
* Update dependency for `circulationHistory` in order to get updated data.

## Refs
[UIIN-3417](https://folio-org.atlassian.net/browse/UIIN-3417)