### PR TITLE
UIIN-3443: Add missing pane id to instance details pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@
 * Display `Service point` in the `Circulation history` section in the item view page after check in action. Fixes UIIN-3417.
 * *BREAKING* Update for Split Search & Browse APIs. Refs UIIN-3435.
 * *BREAKING* Bump up okapiInterface version of linked-data to 2.0. Refs UIIN-3428.
-* Effective location in FOLIO Inventory is not updated and shown as inactive. Fixes 
+* Effective location in FOLIO Inventory is not updated and shown as inactive. Fixes
 UIIN-3437.
 * Instance -> ViewInstance: refactor component. Refs UIIN-3382.
+* Add missing pane id to instance details pane. Fixes UIIN-3443.
 
 ## [13.0.8](https://github.com/folio-org/ui-inventory/tree/v13.0.8) (2025-07-16)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.7...v13.0.8)

--- a/src/Instance/ViewInstance/ViewInstance.js
+++ b/src/Instance/ViewInstance/ViewInstance.js
@@ -279,6 +279,7 @@ const ViewInstance = (props) => {
     >
       <ViewInstancePane
         {...props}
+        id="pane-instancedetails"
         instance={instance}
         isShared={isShared}
         tenantId={stripes.okapi.tenant}


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Instance pane id "pane-instancedetails" missing after refactoring Instance details which causes tests failures in inventory.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3443

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
