### PR TITLE
UIIN-3382 fix issue with checking for central tenant permissions (follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 UIIN-3437.
 * Instance -> ViewInstance: refactor component. Refs UIIN-3382.
 * Add missing pane id to instance details pane. Fixes UIIN-3443.
+* Provide hasCentralTenantPerm arg to useInstancePermissions hook. Fixes UIIN-3444.
 
 ## [13.0.8](https://github.com/folio-org/ui-inventory/tree/v13.0.8) (2025-07-16)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.7...v13.0.8)

--- a/src/Instance/ViewInstance/ViewInstance.js
+++ b/src/Instance/ViewInstance/ViewInstance.js
@@ -19,6 +19,7 @@ import PropTypes from 'prop-types';
 
 import {
   checkIfUserInMemberTenant,
+  getUserTenantsPermissions,
   stripesConnect,
   useCallout,
   useStripes,
@@ -59,6 +60,7 @@ import {
   isInstanceShadowCopy,
   isLinkedDataSource,
   isMARCSource,
+  isUserInConsortiumMode,
 } from '../../utils';
 import {
   CONSORTIUM_PREFIX,
@@ -93,6 +95,7 @@ const ViewInstance = (props) => {
   const [canBeOpenedInLinkedData, setCanBeOpenedInLinkedData] = useState(false);
   const [isMARCSourceRecord, setIsMARCSourceRecord] = useState(false);
   const [isLinkedDataSourceRecord, setIsLinkedDataSourceRecord] = useState(false);
+  const [userTenantPermissions, setUserTenantPermissions] = useState([]);
 
   const isMarcOrLinkedDataSourceRecord = Boolean(isMARCSourceRecord || isLinkedDataSourceRecord);
 
@@ -129,6 +132,13 @@ const ViewInstance = (props) => {
       checkCanBeOpenedInLinkedData();
     }
   }, [isMarcOrLinkedDataSourceRecord, isInstanceImportSupported, instance]);
+
+  useEffect(() => {
+    if (isUserInConsortiumMode(stripes)) {
+      const { user: { user: { tenants } } } = stripes;
+      getUserTenantsPermissions(stripes, tenants).then(perms => setUserTenantPermissions(perms));
+    }
+  }, [stripes.user?.user?.tenants]);
 
   useEffect(() => {
     if (!isLoading && instance?.id && focusTitleOnInstanceLoad && !isCentralTenantPermissionsLoading) {
@@ -295,6 +305,7 @@ const ViewInstance = (props) => {
         isInstanceSharing={isInstanceSharing}
         holdingsSection={holdingsSection}
         paneTitleRef={paneTitleRef}
+        userTenantPermissions={userTenantPermissions}
       />
       <InstanceModals
         instance={instance}

--- a/src/Instance/ViewInstance/components/InstanceActionMenu/InstanceActionMenu.js
+++ b/src/Instance/ViewInstance/components/InstanceActionMenu/InstanceActionMenu.js
@@ -22,7 +22,10 @@ import {
 } from '../../../hooks';
 import useReferenceData from '../../../../hooks/useReferenceData';
 
-import { isLinkedDataSource } from '../../../../utils';
+import {
+  flattenCentralTenantPermissions,
+  isLinkedDataSource,
+} from '../../../../utils';
 import { indentifierTypeNames } from '../../../../constants';
 
 const InstanceActionMenu = ({
@@ -30,7 +33,7 @@ const InstanceActionMenu = ({
   instance = {},
   marcRecord,
   isShared,
-  centralTenantPermissions,
+  centralTenantPermissions = [],
   canUseSingleRecordImport,
   canBeOpenedInLinkedData,
   titleLevelRequestsFeatureEnabled,
@@ -44,7 +47,8 @@ const InstanceActionMenu = ({
   const stripes = useStripes();
   const referenceData = useReferenceData();
 
-  const hasCentralTenantPerm = useCallback((perm) => centralTenantPermissions.has(perm), [centralTenantPermissions]);
+  const hasCentralTenantPerm = useCallback((perm) => flattenCentralTenantPermissions(centralTenantPermissions).has(perm), [centralTenantPermissions]);
+
   const isSourceLinkedData = isLinkedDataSource(instance.source);
 
   const {
@@ -75,6 +79,7 @@ const InstanceActionMenu = ({
     titleLevelRequestsFeatureEnabled,
     tenant,
     numberOfRequests,
+    hasCentralTenantPerm,
   });
 
   const {

--- a/src/Instance/hooks/useInstancePermissions/useInstancePermissions.js
+++ b/src/Instance/hooks/useInstancePermissions/useInstancePermissions.js
@@ -1,17 +1,13 @@
-import { useCallback } from 'react';
-
 import {
   checkIfUserInCentralTenant,
   checkIfUserInMemberTenant,
   useStripes,
-  useUserTenantPermissions,
 } from '@folio/stripes/core';
 
 import useInstanceHoldingsQuery from '../useInstanceHoldingsQuery';
 
 import {
   checkIfCentralOrderingIsActive,
-  flattenCentralTenantPermissions,
   isInstanceShadowCopy,
   isMARCSource,
 } from '../../../utils';
@@ -27,20 +23,13 @@ const useInstancePermissions = ({
   canUseSingleRecordImport,
   tenant,
   numberOfRequests,
+  hasCentralTenantPerm,
 }) => {
   const stripes = useStripes();
   const source = instance.source;
-  const centralTenantId = stripes.user.user?.consortium?.centralTenantId;
 
   const { totalRecords: holdigsTotalRecords } = useInstanceHoldingsQuery(instance.id, tenant);
   const { data: centralOrdering } = useCentralOrderingSettingsQuery();
-  const {
-    userPermissions: centralTenantPermissions,
-  } = useUserTenantPermissions({ tenantId: centralTenantId }, {
-    enabled: Boolean(isShared && checkIfUserInMemberTenant(stripes)),
-  });
-
-  const hasCentralTenantPerm = useCallback((perm) => flattenCentralTenantPermissions(centralTenantPermissions).has(perm), [centralTenantPermissions]);
 
   const noInstanceHoldings = holdigsTotalRecords === 0;
 


### PR DESCRIPTION
## Description
`useInstancePermissions` hook referenced `this.hasCentralTenantPerm` in code, which caused an exception.