### PR TITLE
UIIN-3440: ECS | No request send when user confirms ownership update of item record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ UIIN-3437.
 * Instance -> ViewInstance: refactor component. Refs UIIN-3382.
 * Add missing pane id to instance details pane. Fixes UIIN-3443.
 * Provide hasCentralTenantPerm arg to useInstancePermissions hook. Fixes UIIN-3444.
+* ECS | No request send when user confirms ownership update of item record. Fixes UIIN-3440.
 
 ## [13.0.8](https://github.com/folio-org/ui-inventory/tree/v13.0.8) (2025-07-16)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.7...v13.0.8)

--- a/src/Item/hooks/useItemUpdateOwnership/useItemUpdateOwnership.js
+++ b/src/Item/hooks/useItemUpdateOwnership/useItemUpdateOwnership.js
@@ -135,14 +135,14 @@ const useItemUpdateOwnership = ({
         });
         showSuccessMessageAndGoBack(item.hrid);
       } catch (error) {
-        if (error.response.status === 400) {
+        if (error.response?.status === 400) {
           showReferenceDataErrorCallout();
         } else {
           showCommonErrorCallout();
         }
       }
     }
-  }, [stripes, item]);
+  }, [stripes.user.user?.tenants, item, updateOwnershipData]);
 
   return {
     handleUpdateOwnership,


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
No request sends when user clicks on “Confirm” button in “Update ownership of items” modal.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Add missing `useCallback` dependencies to `onConfirmHandleUpdateOwnership` handler

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3440

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
