### PR TITLE
UIIN-3448: Fix hotkey handlers for Instance details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ UIIN-3437.
 * "New request" button is missing from the "Actions" dropdown in the Instance details pane. Fixes UIIN-3445.
 * Add additional call numbers to Holdings record. Refs UIIN-3327.
 * Add additional call numbers to Item records. Refs UIIN-3328.
-* 
+* Fix hotkey handlers for Instance details. Fixes UIIN-3448.
+
 ## [13.0.8](https://github.com/folio-org/ui-inventory/tree/v13.0.8) (2025-07-16)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.7...v13.0.8)
 

--- a/src/Instance/ViewInstance/InstanceDetailsContent/InstanceDetailsContent.js
+++ b/src/Instance/ViewInstance/InstanceDetailsContent/InstanceDetailsContent.js
@@ -64,12 +64,12 @@ const InstanceDetailsContent = ({
   tenantId,
   userTenantPermissions,
   holdingsSection,
+  accordionStatusRef,
 }) => {
   const stripes = useStripes();
   const location = useLocation();
 
   const searchParams = new URLSearchParams(location.search);
-  const accordionStatusRef = useRef();
   const prevInstanceId = useRef(instance?.id);
   const referenceData = useReferenceData();
 
@@ -222,6 +222,7 @@ InstanceDetailsContent.propTypes = {
   tenantId: PropTypes.string,
   userTenantPermissions: PropTypes.arrayOf(PropTypes.object),
   holdingsSection: PropTypes.node,
+  accordionStatusRef: PropTypes.object,
 };
 
 export default InstanceDetailsContent;

--- a/src/Instance/ViewInstance/ViewInstance.js
+++ b/src/Instance/ViewInstance/ViewInstance.js
@@ -88,6 +88,7 @@ const ViewInstance = (props) => {
   const history = useHistory();
   const location = useLocation();
   const paneTitleRef = useRef(null);
+  const accordionStatusRef = useRef();
 
   const centralTenantId = stripes.user.user?.consortium?.centralTenantId;
 
@@ -223,6 +224,8 @@ const ViewInstance = (props) => {
     marcRecord,
     callout,
     canBeOpenedInLinkedData,
+    accordionStatusRef,
+    onCopy,
   });
 
   const mutateInstance = async (entity, { onError }) => {
@@ -332,6 +335,7 @@ const ViewInstance = (props) => {
         holdingsSection={holdingsSection}
         paneTitleRef={paneTitleRef}
         userTenantPermissions={userTenantPermissions}
+        accordionStatusRef={accordionStatusRef}
       />
       <InstanceModals
         instance={instance}

--- a/src/Instance/ViewInstance/ViewInstancePane/ViewInstancePane.js
+++ b/src/Instance/ViewInstance/ViewInstancePane/ViewInstancePane.js
@@ -63,6 +63,7 @@ const ViewInstancePane = ({
   isInstanceSharing = false,
   holdingsSection,
   paneTitleRef,
+  accordionStatusRef,
 }) => {
   const intl = useIntl();
   const stripes = useStripes();
@@ -184,6 +185,7 @@ const ViewInstancePane = ({
           tenantId={tenantId}
           userTenantPermissions={userTenantPermissions}
           holdingsSection={holdingsSection}
+          accordionStatusRef={accordionStatusRef}
         />
       </Pane>
 
@@ -224,6 +226,7 @@ ViewInstancePane.propTypes = {
   isInstanceSharing: PropTypes.bool,
   holdingsSection: PropTypes.node,
   paneTitleRef: PropTypes.object,
+  accordionStatusRef: PropTypes.object,
 };
 
 export default ViewInstancePane;

--- a/src/Instance/hooks/useInstanceDetailsShortcuts/useInstanceDetailsShortcuts.js
+++ b/src/Instance/hooks/useInstanceDetailsShortcuts/useInstanceDetailsShortcuts.js
@@ -17,6 +17,8 @@ const useInstanceDetailsShortcuts = ({
   marcRecord,
   callout,
   canBeOpenedInLinkedData,
+  accordionStatusRef,
+  onCopy,
 }) => {
   const stripes = useStripes();
 
@@ -30,6 +32,7 @@ const useInstanceDetailsShortcuts = ({
     callout,
     instance,
     canBeOpenedInLinkedData,
+    onCopy,
   });
 
   return [
@@ -73,11 +76,11 @@ const useInstanceDetailsShortcuts = ({
     },
     {
       name: 'expandAllSections',
-      handler: (e) => expandAllSections(e, this.accordionStatusRef),
+      handler: (e) => expandAllSections(e, accordionStatusRef),
     },
     {
       name: 'collapseAllSections',
-      handler: (e) => collapseAllSections(e, this.accordionStatusRef),
+      handler: (e) => collapseAllSections(e, accordionStatusRef),
     },
   ];
 };


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
When user use hotkeys for duplicate instance (alt + C), expanding all accordions (ctrl + alt + B) and collapsing all accordions (ctrl + alt + G) nothing happens. All other hotkeys are working as expected.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Provide missing handlers to copy instance and access accordions state.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3448

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
