### PR TITLE
UIIN-3447: User can not see holdings in data tenant on shared instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ UIIN-3437.
 * "New request" button is missing from the "Actions" dropdown in the Instance details pane. Fixes UIIN-3445.
 * Add additional call numbers to Holdings record. Refs UIIN-3327.
 * Add additional call numbers to Item records. Refs UIIN-3328.
-* 
+* ECS: Provide correct tenant to get member tenant holdings for instance. Fixes UIIN-3447.
+
 ## [13.0.8](https://github.com/folio-org/ui-inventory/tree/v13.0.8) (2025-07-16)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.7...v13.0.8)
 

--- a/src/Instance/ViewInstance/ViewInstance.js
+++ b/src/Instance/ViewInstance/ViewInstance.js
@@ -116,7 +116,8 @@ const ViewInstance = (props) => {
   }, [instance]);
 
   const isShared = Boolean(instance.shared);
-  const tenantId = instance.tenantId ?? stripes.okapi.tenant;
+  const currentTenant = stripes.okapi.tenant;
+  const instanceTenantOwner = instance.tenantId ?? currentTenant;
 
   const {
     userPermissions: centralTenantPermissions,
@@ -125,9 +126,9 @@ const ViewInstance = (props) => {
     enabled: Boolean(isShared && checkIfUserInMemberTenant(stripes)),
   });
   const { data: isInstanceImportSupported } = useInstanceImportSupportedQuery(instance.id, { enabled: isMarcOrLinkedDataSourceRecord });
-  const { data: marcRecord } = useMarcRecordQuery(instance.id, INSTANCE_RECORD_TYPE, isShared ? centralTenantId : tenantId, { enabled: isMarcOrLinkedDataSourceRecord });
-  const { data: { requests = [], totalRecords: totalRequestsRecords }, refetch: refetchRequests } = useCirculationInstanceRequestsQuery(instance.id, tenantId);
-  const { data: tlrSettings, isLoading: isTLRSettingsLoading } = useTLRSettingsQuery(tenantId);
+  const { data: marcRecord } = useMarcRecordQuery(instance.id, INSTANCE_RECORD_TYPE, isShared ? centralTenantId : instanceTenantOwner, { enabled: isMarcOrLinkedDataSourceRecord });
+  const { data: { requests = [], totalRecords: totalRequestsRecords }, refetch: refetchRequests } = useCirculationInstanceRequestsQuery(instance.id, instanceTenantOwner);
+  const { data: tlrSettings, isLoading: isTLRSettingsLoading } = useTLRSettingsQuery(instanceTenantOwner);
 
   useEffect(() => {
     const checkCanBeOpenedInLinkedData = () => {
@@ -182,12 +183,12 @@ const ViewInstance = (props) => {
 
   const { isInstanceSharing, handleShareLocalInstance } = useInstanceSharing({
     instance,
-    tenantId,
+    tenantId: instanceTenantOwner,
     centralTenantId,
     refetchInstance: refetch,
     sendCallout: callout.sendCallout,
   });
-  const { mutateInstance: mutateEntity } = useInstanceMutation({ tenantId });
+  const { mutateInstance: mutateEntity } = useInstanceMutation({ tenantId: instanceTenantOwner });
   const { importRecord } = useImportRecord();
 
   const tenantIdForDeletion = isShared && !isInstanceShadowCopy(instance.source) ? centralTenantId : stripes.okapi.tenant;
@@ -242,7 +243,7 @@ const ViewInstance = (props) => {
         canUseSingleRecordImport={canUseSingleRecordImport}
         canBeOpenedInLinkedData={canBeOpenedInLinkedData}
         callout={callout}
-        tenant={tenantId}
+        tenant={instanceTenantOwner}
         requests={requests}
         onCopy={onCopy}
         numberOfRequests={totalRequestsRecords || 0}
@@ -300,7 +301,7 @@ const ViewInstance = (props) => {
       <HoldingsListContainer
         instance={instance}
         draggable={isItemsMovement}
-        tenantId={tenantId}
+        tenantId={currentTenant}
         pathToAccordionsState={['holdings']}
         droppable
       />


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
User can not see holdings in data tenant on shared instance.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Provide correct tenant to get member tenant holdings for instance (not central tenant because it's shared instance, but member tenant)

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3447

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
