### PR TITLE
UIIN-3416 Open Item record detail view when exact match is found via Keyword search option in Item tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ UIIN-3437.
 * ECS: Provide correct tenant to get member tenant holdings for instance. Fixes UIIN-3447.
 * Fix hotkey handlers for Instance details. Fixes UIIN-3448.
 * Classification browse | Add Contributors to results list. Refs UIIN-3368.
+* Open Item record detail view when exact match is found via Keyword search option in Item tab. Refs UIIN-3416.
 
 ## [13.0.8](https://github.com/folio-org/ui-inventory/tree/v13.0.8) (2025-07-16)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.7...v13.0.8)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -58,6 +58,7 @@ import {
   getSearchResultsFormatter,
   SEARCH_COLUMN_MAPPINGS,
   withReset,
+  getDefaultQindex,
 } from '@folio/stripes-inventory-components';
 
 import FilterNavigation from '../FilterNavigation';
@@ -1368,7 +1369,8 @@ class InstancesList extends React.Component {
             advancedSearchIndex={queryIndexes.ADVANCED_SEARCH}
             advancedSearchOptions={advancedSearchOptions}
             advancedSearchQueryBuilder={advancedSearchQueryBuilder}
-            selectedIndex={get(data.query, 'qindex')}
+            // query.qindex is empty by default when switching between segments so we need to pass some default value here
+            selectedIndex={get(data.query, 'qindex') || getDefaultQindex(segment)}
             searchableIndexesPlaceholder={null}
             initialResultCount={INITIAL_RESULT_COUNT}
             initiallySelectedRecord={getItem(`${namespace}.${segment}.lastOpenRecord`)}

--- a/src/constants.js
+++ b/src/constants.js
@@ -192,6 +192,7 @@ export const SYSTEM_USER_ID = '00000000-0000-0000-0000-000000000000';
 export const SYSTEM_USER_NAME = 'System';
 
 export const SINGLE_ITEM_QUERY_TEMPLATES = {
+  [queryIndexes.ITEMS_KEYWORD]: 'hrid=="%{query}" or uuid=="%{query}" or barcode=="%{query}"',
   [queryIndexes.ITEMS_BARCODE]: 'barcode=="%{query}"',
   [queryIndexes.ISBN]: 'isbn=="%{query}"',
   [queryIndexes.ISSN]: 'issn=="%{query}"',


### PR DESCRIPTION
## Description
Open Item record detail view when exact match is found via Keyword search option in Item tab.
Items keywork option will search items only by hrid, uuid and barcode because those are the available item search parameters.

## Screenshots

https://github.com/user-attachments/assets/e9ee15a1-fc8f-495e-8ce6-98bc98561e0b


## Issues
[UIIN-3416](https://folio-org.atlassian.net/browse/UIIN-3416)