### PR TITLE
UIIN-3422 show all columns when Default Columns setting does not exist (follow-up)

### DIFF
--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -395,7 +395,7 @@ class InstancesList extends React.Component {
   getInitialToggleableColumns = () => {
     const { defaultColumns } = this.props.data.displaySettings;
 
-    return getItem(VISIBLE_COLUMNS_STORAGE_KEY) || defaultColumns || [];
+    return getItem(VISIBLE_COLUMNS_STORAGE_KEY) || defaultColumns || TOGGLEABLE_COLUMNS;
   }
 
   getInitialSegmentsSortBy = () => {

--- a/src/settings/DisplaySettings/DisplaySettings.js
+++ b/src/settings/DisplaySettings/DisplaySettings.js
@@ -48,12 +48,17 @@ const DisplaySettings = () => {
   const getInitialValues = ([data]) => {
     return {
       [fieldNames.DEFAULT_SORT]: data?.value[fieldNames.DEFAULT_SORT] || DEFAULT_SORT,
-      [fieldNames.DEFAULT_COLUMNS]: data?.value[fieldNames.DEFAULT_COLUMNS] || [],
+      [fieldNames.DEFAULT_COLUMNS]: data?.value[fieldNames.DEFAULT_COLUMNS] || TOGGLEABLE_COLUMNS,
     };
   };
 
   const formatPayload = (data) => {
-    return data;
+    return {
+      ...data,
+      // defaultColumns is null when all checkboxes are unchecked, so we need to add an empty array
+      // as a default value
+      [fieldNames.DEFAULT_COLUMNS]: data[fieldNames.DEFAULT_COLUMNS] || [],
+    };
   };
 
   return (


### PR DESCRIPTION
## Description
show all columns when Default Columns setting does not exist. 
show all checkboxes as checked if a setting hasn't been saved yet.
send empty array as the setting value when a user unchecks all checkboxes

## Issues
[UIIN-3422](https://folio-org.atlassian.net/browse/UIIN-3422)