### PR TITLE
UIIN-3478: Fix sorting for Items on Instance details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ UIIN-3437.
 * Correcting the behavior of drop-down menu and checkbox in Settings > Inventory > Number generator options. Refs UIIN-3471.
 * Hide staff suppressed Instances based on existing permission for Staff suppress facet. Refs UIIN-3465.
 * Move permissions for creating export jobs to "Inventory: View instances, holdings, and items" permission. Fixes UIIN-3474.
+* Fix sorting for Items on Instance details page. Fixes UIIN-3478.
 
 ## [13.0.8](https://github.com/folio-org/ui-inventory/tree/v13.0.8) (2025-07-16)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.7...v13.0.8)

--- a/src/hooks/useHoldingItemsQuery.js
+++ b/src/hooks/useHoldingItemsQuery.js
@@ -41,7 +41,9 @@ const useHoldingItemsQuery = (
       const sortQuery = options.searchParams.sortBy;
       const sortDirection = sortQuery.startsWith('-') ? 'descending' : 'ascending';
       const sortOrder = sortQuery.replace(/^-/, '');
-      const newSortBy = sortMap[sortOrder] ? `${sortMap[sortOrder]}/sort.${sortDirection}` : sortBy;
+      const newSortBy = sortMap[sortOrder]
+        ? `${sortMap[sortOrder]}${sortOrder === 'order' ? '/number' : ''}/sort.${sortDirection}`
+        : sortBy;
 
       setSortBy(newSortBy);
     }

--- a/src/hooks/useHoldingItemsQuery.js
+++ b/src/hooks/useHoldingItemsQuery.js
@@ -36,13 +36,13 @@ const useHoldingItemsQuery = (
   };
 
   useEffect(() => {
-    console.log(options)
     if (options.searchParams?.sortBy) {
       const sortQuery = options.searchParams.sortBy;
       const sortDirection = sortQuery.startsWith('-') ? 'descending' : 'ascending';
       const sortOrder = sortQuery.replace(/^-/, '');
+      const sortOrderColumnPreffix = sortOrder === 'order' ? '/number' : '';
       const newSortBy = sortMap[sortOrder]
-        ? `${sortMap[sortOrder]}${sortOrder === 'order' ? '/number' : ''}/sort.${sortDirection}`
+        ? `${sortMap[sortOrder]}${sortOrderColumnPreffix}/sort.${sortDirection}`
         : sortBy;
 
       setSortBy(newSortBy);

--- a/src/hooks/useHoldingItemsQuery.js
+++ b/src/hooks/useHoldingItemsQuery.js
@@ -25,7 +25,7 @@ const useHoldingItemsQuery = (
   // sortMap contains not all item table's columns because sorting by some columns
   // is not implemented on BE yet
   const sortMap = {
-    'order': 'order',
+    'order': 'order/number',
     'barcode': 'barcode',
     'status': 'status.name',
     'copyNumber': 'copyNumber',
@@ -40,9 +40,8 @@ const useHoldingItemsQuery = (
       const sortQuery = options.searchParams.sortBy;
       const sortDirection = sortQuery.startsWith('-') ? 'descending' : 'ascending';
       const sortOrder = sortQuery.replace(/^-/, '');
-      const sortOrderColumnPreffix = sortOrder === 'order' ? '/number' : '';
       const newSortBy = sortMap[sortOrder]
-        ? `${sortMap[sortOrder]}${sortOrderColumnPreffix}/sort.${sortDirection}`
+        ? `${sortMap[sortOrder]}/sort.${sortDirection}`
         : sortBy;
 
       setSortBy(newSortBy);

--- a/src/hooks/useHoldingItemsQuery.test.js
+++ b/src/hooks/useHoldingItemsQuery.test.js
@@ -82,4 +82,32 @@ describe('useHoldingItemsQuery', () => {
       );
     });
   });
+
+  describe('when sortBy param is order', () => {
+    it('should fetch items with order sortby param', async () => {
+      const limit = 5;
+      const id = items[0].holdingsRecordId;
+
+      const { result } = renderHook(() => useHoldingItemsQuery(id, {
+        searchParams: {
+          limit,
+          sortBy: 'order',
+        }
+      }), { wrapper });
+
+      await act(() => !result.current.isFetching);
+
+      expect(result.current.items).toEqual(items.slice(0, limit));
+      expect(mockGet).toHaveBeenCalledWith(
+        'inventory/items-by-holdings-id',
+        {
+          searchParams: {
+            offset: 0,
+            limit,
+            query: `holdingsRecordId==${id} sortby order/number/sort.ascending`
+          }
+        }
+      );
+    });
+  });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
* Fix sorting of Order column. Make sure sorting by the rest of enabled columns also works as expected.

## Approach
* When sorting by Order column we need to change query like this `.../order/number/...`

## Refs
[UIIN-3478](https://folio-org.atlassian.net/browse/UIIN-3478)

## Screenshots
https://github.com/user-attachments/assets/f0dd4cbd-b363-4f0a-8d04-3ee3385d48eb
