### PR TITLE
UIIN-3434 Added a permission to delete records from SRS to a "Inventory: All permissions" and "Inventory: View, create, edit, delete holdings"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ UIIN-3437.
 * Show green message after creating the instance. Fixes UIIN-3446.
 * Fix "Move holdings/items" action item displaying on shared instance. Fixes UIIN-3487.
 * ECS: Set Held by facet default to current tenant context in Inventory Call number Browse. Refs UIIN-3457.
+* Added a permission to delete records from SRS to a "Inventory: All permissions" and "Inventory: View, create, edit, delete holdings". Fixes UIIN-3434.
 
 ## [13.0.10](https://github.com/folio-org/ui-inventory/tree/v13.0.10) (2025-09-01)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.9...v13.0.10)

--- a/package.json
+++ b/package.json
@@ -155,7 +155,8 @@
           "browse.contributors.instances.collection.get",
           "inventory-storage.bound-with-parts.collection.get",
           "source-storage.records.matching.collection.post",
-          "users.item.get"
+          "users.item.get",
+          "source-storage.records.delete"
         ],
         "visible": true
       },
@@ -841,7 +842,8 @@
         "displayName": "Inventory: View, create, edit, delete holdings",
         "subPermissions": [
           "ui-inventory.holdings.edit",
-          "inventory-storage.holdings.item.delete"
+          "inventory-storage.holdings.item.delete",
+          "source-storage.records.delete"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Description
Added a permission to delete records from SRS to a "Inventory: All permissions" and "Inventory: View, create, edit, delete holdings"
Users were unable to delete MARC Holdings records with these permissions assigned

## Issues
[UIIN-3434](https://folio-org.atlassian.net/browse/UIIN-3434)