### PR TITLE
UIIN-3455: Change the order of items in the item list when dragging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ UIIN-3437.
 * Fix "Move holdings/items" action item displaying on shared instance. Fixes UIIN-3487.
 * ECS: Set Held by facet default to current tenant context in Inventory Call number Browse. Refs UIIN-3457.
 * Make "data-import-converter-storage" dependency as optional. Refs UIIN-3488.
+* Change the order of items in the item list when dragging. Refs UIIN-3455.
 
 ## [13.0.10](https://github.com/folio-org/ui-inventory/tree/v13.0.10) (2025-09-01)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.9...v13.0.10)

--- a/src/dnd/InventoryProvider/InventoryProvider.js
+++ b/src/dnd/InventoryProvider/InventoryProvider.js
@@ -96,6 +96,11 @@ const reducer = (state, action) => {
       return reducer(state, { type: 'MOVE_HOLDINGS', payload: action.payload });
     }
 
+    case 'PREVIEW_REORDER_ITEMS': {
+      if (!state.__snapshot) return state;
+      return reducer(state, { type: 'REORDER_ITEMS', payload: action.payload });
+    }
+
     case 'PREVIEW_CANCEL': {
       if (!state.__snapshot) return state;
       return { ...state, ...state.__snapshot, __snapshot: null };
@@ -103,6 +108,21 @@ const reducer = (state, action) => {
 
     case 'PREVIEW_COMMIT': {
       return state.__snapshot ? { ...state, __snapshot: null } : state;
+    }
+
+    case 'REORDER_ITEMS': {
+      const { holdingId, itemIds } = action.payload || {};
+      if (!holdingId || !Array.isArray(itemIds)) return state;
+      return {
+        ...state,
+        holdings: {
+          ...state.holdings,
+          [holdingId]: {
+            ...state.holdings[holdingId],
+            itemIds,
+          },
+        },
+      };
     }
 
     case 'MOVE_ITEM': {
@@ -238,10 +258,12 @@ const InventoryProvider = ({
     moveItem: (opts) => dispatch({ type: 'MOVE_ITEM', payload: opts }),
     moveItems: (opts) => dispatch({ type: 'MOVE_ITEMS', payload: opts }),
     moveHolding: (opts) => dispatch({ type: 'MOVE_HOLDING', payload: opts }),
+    reorderItems: (opts) => dispatch({ type: 'REORDER_ITEMS', payload: opts }),
 
     previewStart: () => dispatch({ type: 'PREVIEW_START' }),
     previewMoveItems: (opts) => dispatch({ type: 'PREVIEW_MOVE_ITEMS', payload: opts }),
     previewMoveHoldings: (opts) => dispatch({ type: 'PREVIEW_MOVE_HOLDINGS', payload: opts }),
+    previewReorderItems: (opts) => dispatch({ type: 'PREVIEW_REORDER_ITEMS', payload: opts }),
     previewCancel:  () => dispatch({ type: 'PREVIEW_CANCEL' }),
     previewCommit:  () => dispatch({ type: 'PREVIEW_COMMIT' }),
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
**_NOTE:_** This ticket requires only UI changes, it means that after page refresh list order resets to its initial state. Saving new items order will be handled in another UI story after connecting UI to BE.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Handled moving items position within the same holding

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3455

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/user-attachments/assets/8b28164e-ba3a-45ab-9cb5-bbc4fc4ebaab

