### PR TITLE
UIIN-2820 set default Held By facet value when resetting search (follow-up)

### DIFF
--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -313,6 +313,13 @@ class InstancesList extends React.Component {
       const lastSearchOffset = getLastSearchOffset(segment);
 
       parentMutator.resultOffset.replace(lastSearchOffset);
+
+      if (!params.query && !params.filters && stripes.user.user?.consortium && checkIfUserInMemberTenant(stripes)) {
+        searchParams.set('filters', `${FACETS.HELD_BY}.${stripes.okapi.tenant}`);
+        searchParams.set('_isInitial', true);
+
+        this.redirectToSearchParams(searchParams);
+      }
     }
 
     if (prevProps.data.displaySettings !== this.props.data.displaySettings) {
@@ -1066,6 +1073,7 @@ class InstancesList extends React.Component {
     const {
       publishOnReset,
       stripes,
+      segment,
     } = this.props;
 
     this.setState({
@@ -1080,6 +1088,8 @@ class InstancesList extends React.Component {
 
       searchParams.set('filters', `${FACETS.HELD_BY}.${stripes.okapi.tenant}`);
       searchParams.set('_isInitial', true);
+      searchParams.set('segment', segment);
+
       this.redirectToSearchParams(searchParams);
     }
   }

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -468,6 +468,36 @@ describe('InstancesList', () => {
             state: undefined,
           });
         });
+
+        describe('when a user is in a member tenant', () => {
+          it('should select current tenant as a default value in Held By facet', async () => {
+            jest.spyOn(history, 'replace');
+            spyOnCheckIfUserInMemberTenant.mockReturnValue(true);
+
+            act(() => history.push('/inventory?filters=staffSuppress.true&sort=contributors'));
+
+            await act(async () => renderInstancesList({
+              segment: 'instances',
+              data: {
+                ...data,
+                query: {
+                  query: '',
+                  sort: SORT_OPTIONS.CONTRIBUTORS,
+                },
+                displaySettings: {
+                  defaultSort: SORT_OPTIONS.RELEVANCE,
+                },
+              }
+            }));
+
+            fireEvent.change(screen.getByRole('textbox', { name: 'Search' }), { target: { value: 'test' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Reset all' }));
+
+            expect(history.replace).toHaveBeenLastCalledWith(expect.objectContaining({
+              search: expect.stringContaining('tenantId.diku&_isInitial=true'),
+            }));
+          });
+        });
       });
 
       describe('when search segment is changed', () => {
@@ -483,6 +513,27 @@ describe('InstancesList', () => {
           fireEvent.click(getByText('Holdings'));
 
           expect(getAllByLabelText('Select instance')[0].checked).toBeFalsy();
+        });
+
+        describe('when a user is in a member tenant', () => {
+          it('should select current tenant as a default value in Held By facet', async () => {
+            jest.spyOn(history, 'replace');
+            spyOnCheckIfUserInMemberTenant.mockReturnValue(true);
+
+            const {
+              getAllByLabelText,
+              getByText,
+            } = await act(async () => renderInstancesList({
+              segment: 'instances',
+            }));
+
+            fireEvent.click(getAllByLabelText('Select instance')[0]);
+            fireEvent.click(getByText('Holdings'));
+
+            expect(history.replace).toHaveBeenLastCalledWith(expect.objectContaining({
+              search: expect.stringContaining('tenantId.diku&_isInitial=true'),
+            }));
+          });
         });
       });
 


### PR DESCRIPTION
## Description
Fix two issues with default Held By facet value:
1. Set a default Held By facet value when switching between Instances, Holdings and Item search segments
2. Keep a default Held By facet value when clicking Reset all

## Screenshots

https://github.com/user-attachments/assets/060ddd18-2db1-4777-8bef-2f17a27d3f6c

## Issues
[UIIN-2820](https://folio-org.atlassian.net/browse/UIIN-2820)