### PR TITLE
UIIN-3471: Add default values

### DIFF
--- a/src/settings/NumberGeneratorSettings/NumberGeneratorSettings.js
+++ b/src/settings/NumberGeneratorSettings/NumberGeneratorSettings.js
@@ -5,17 +5,28 @@ import { useStripes } from '@folio/stripes/core';
 import { ConfigManager } from '@folio/stripes/smart-components';
 
 import {
+  ACCESSION_NUMBER_SETTING,
+  BARCODE_SETTING,
+  CALL_NUMBER_SETTING,
+  NUMBER_GENERATOR_OPTIONS_OFF,
   NUMBER_GENERATOR_SETTINGS_KEY,
   NUMBER_GENERATOR_SETTINGS_SCOPE,
 } from './constants';
 import NumberGeneratorSettingsForm from './NumberGeneratorSettingsForm';
+
+const DEFAULT_VALUES = {
+  [ACCESSION_NUMBER_SETTING]: NUMBER_GENERATOR_OPTIONS_OFF,
+  [BARCODE_SETTING]: NUMBER_GENERATOR_OPTIONS_OFF,
+  [CALL_NUMBER_SETTING]: NUMBER_GENERATOR_OPTIONS_OFF,
+  [`${CALL_NUMBER_SETTING}Holdings`]: NUMBER_GENERATOR_OPTIONS_OFF,
+};
 
 const NumberGeneratorSettings = () => {
   const stripes = useStripes();
   const ConnectedConfigManager = useMemo(() => stripes.connect(ConfigManager), [stripes]);
 
   const beforeSave = (data) => data || '';
-  const getInitialValues = (settings) => (settings?.[0]?.value || '');
+  const getInitialValues = (settings) => (settings?.[0]?.value || DEFAULT_VALUES);
 
   return (
     <ConnectedConfigManager


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIIN-3471

## Purpose
Correcting the behavior of save button, drop-down menu and checkbox in Settings > Inventory > Number generator options by adding default values for the form.
The save button will not be enabled if the initial default values are selected.

See also first changes of this issue:
https://github.com/folio-org/ui-inventory/pull/2877

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
