### PR TITLE
UIIN-3459: Fix disabled Tags dropdown after adding/removing tag for Item record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1065,6 +1065,7 @@ Inventory causes an error. Refs UIIN-2012.
 * Instance record: Update Instance record Actions menu. Refs UIIN-1625.
 * Add ability to move MARC holdings between instances. Refs UIIN-1633.
 * Make mapped fields read-only for MARC holdings records. Refs UIIN-1639.
+* Fix disabled `Tags` dropdown after adding/removing tag for Item record. Fixes UIIN-3459.
 
 ## [7.1.4](https://github.com/folio-org/ui-inventory/tree/v7.1.4) (2021-08-05)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v7.1.3...v7.1.4)

--- a/src/Item/ViewItem/ViewItem.js
+++ b/src/Item/ViewItem/ViewItem.js
@@ -122,7 +122,7 @@ const ViewItem = ({
   const isLoading = useMemo(() => isItemLoading || isInstanceLoading || isHoldingsLoading,
     [isItemLoading, isInstanceLoading, isHoldingsLoading]);
 
-  const { deleteItem } = useItemMutation();
+  const { deleteItem, mutateItem } = useItemMutation();
   const {
     markItemAsMissing,
     markItemAsWithdrawn,
@@ -144,6 +144,11 @@ const ViewItem = ({
     setUpdateOwnershipData,
     onSuccess: goBackToInstance,
   });
+
+  const onChangeTags = async (entity) => {
+    await mutateItem(entity);
+    await refetchItem();
+  }
 
   useEffect(() => {
     if (checkIfUserInMemberTenant(stripes)) {
@@ -282,6 +287,7 @@ const ViewItem = ({
             isTagsEnabled={tagsEnabled}
             requestCount={requestCount}
             requestsUrl={requestsUrl}
+            onChangeTags={onChangeTags}
           />
         </Pane>
         {isVersionHistoryOpen && (

--- a/src/Item/ViewItem/components/ItemDetailsContent/ItemDetailsContent.js
+++ b/src/Item/ViewItem/components/ItemDetailsContent/ItemDetailsContent.js
@@ -43,6 +43,7 @@ const ItemDetailsContent = ({
   isTagsEnabled,
   requestCount,
   requestsUrl,
+  onChangeTags
 }) => {
   const holdingLocation = useMemo(() => {
     const { locationsById } = referenceTables;
@@ -148,6 +149,7 @@ const ItemDetailsContent = ({
               link={`inventory/items/${item.id}`}
               getEntity={getEntity}
               getEntityTags={getEntityTags}
+              mutateEntity={onChangeTags}
               entityTagsPath="tags"
               hasOptimisticLocking
             />


### PR DESCRIPTION
## Purpose
* Fix disabled Tags dropdown after adding/removing tag for Item record

## Approach
* Since `ViewItem` component was refactored and now it's using `react-query` instead of `mutator`, we need to use `mutateItem` function and after that refresh the data.

## Refs
[UIIN-3459](https://folio-org.atlassian.net/browse/UIIN-3459)

## Screenshots
https://github.com/user-attachments/assets/b0339674-7a4e-4188-a843-2b77d91702fd