### PR TITLE
UIIN-3472: Fix missing perms for finance and acquisition methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ UIIN-3437.
 * Make "data-import-converter-storage" dependency as optional. Refs UIIN-3488.
 * Added a permission to delete records from SRS to a "Inventory: All permissions" and "Inventory: View, create, edit, delete holdings". Fixes UIIN-3434.
 * Change the order of items in the item list when dragging. Refs UIIN-3455.
+* Add missing permissions for instance view. Refs UIIN-3472.
 
 ## [13.0.10](https://github.com/folio-org/ui-inventory/tree/v13.0.10) (2025-09-01)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.9...v13.0.10)

--- a/package.json
+++ b/package.json
@@ -669,6 +669,8 @@
           "inventory-storage.subject-sources.collection.get",
           "inventory-storage.subject-types.collection.get",
           "data-export.quick.export.post",
+          "finance.transactions.collection.get",
+          "orders.acquisition-method.item.get",
           "orders.holding-summary.collection.get",
           "orders.pieces.collection.get",
           "orders.po-lines.collection.get",


### PR DESCRIPTION
[UIIN-3472](https://folio-org.atlassian.net/browse/UIIN-3472)

## Purpose
In this PR was additional data added to inventory item: https://github.com/folio-org/ui-inventory/pull/2824

For these requests the necessary permissions have been missed:
`orderSetting = await ky.get(orders/acquisition-methods/${orderLine.acquisitionMethod})`
`finance = await ky.get(finance/transactions?query=encumbrance.sourcePoLineId="${orderLine.id}")`


## Approach
To fix this bug, I added to `"permissionName": "ui-inventory.instance.view"`
the two permissions:
```
          "finance.transactions.collection.get",
          "orders.acquisition-method.item.get",
```


## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
