### PR TITLE
UIIN-3457 fix Held By facet default value not setting when switching browse options (follow-up)

### DIFF
--- a/src/views/BrowseInventory/BrowseInventory.js
+++ b/src/views/BrowseInventory/BrowseInventory.js
@@ -11,7 +11,7 @@ import {
   useLocation,
 } from 'react-router-dom';
 import querystring from 'query-string';
-import omit from 'lodash/omit';
+import pick from 'lodash/pick';
 
 import {
   TitleManager,
@@ -178,9 +178,14 @@ const BrowseInventory = () => {
   }, [deleteItemToView, clearFilters, changeSearchIndex]);
 
   useEffect(() => {
-    const hasFiltersApplied = Object.keys(omit(filters, ['qindex'])).length > 0;
+    const isHeldByFilterApplied = Object.keys(pick(filters, FACETS.CALL_NUMBERS_HELD_BY))?.length > 0;
+    const isQueryApplied = !!filters.query;
 
-    if (!hasFiltersApplied && isCallNumberBrowseOption(filters.qindex) && checkIfUserInMemberTenant(stripes)) {
+    if (isQueryApplied || isHeldByFilterApplied) {
+      return;
+    }
+
+    if (isCallNumberBrowseOption(filters.qindex) && checkIfUserInMemberTenant(stripes)) {
       // we want to applyFilters without writing the value to the url because it will trigger a search
       applyFilters(FACETS.CALL_NUMBERS_HELD_BY, [stripes.okapi.tenant], false);
     }

--- a/src/views/BrowseInventory/BrowseInventory.js
+++ b/src/views/BrowseInventory/BrowseInventory.js
@@ -87,6 +87,7 @@ const BrowseInventory = () => {
     changeSearchIndex,
     searchIndex,
     clearFilters,
+    applyLocationFiltersAsync,
   ] = useLocationFilters(location, history, () => {
     setPageConfig(INIT_PAGE_CONFIG);
   },
@@ -175,21 +176,12 @@ const BrowseInventory = () => {
     */
     changeSearchIndex(e);
     clearFilters();
-  }, [deleteItemToView, clearFilters, changeSearchIndex]);
 
-  useEffect(() => {
-    const isHeldByFilterApplied = Object.keys(pick(filters, FACETS.CALL_NUMBERS_HELD_BY))?.length > 0;
-    const isQueryApplied = !!filters.query;
-
-    if (isQueryApplied || isHeldByFilterApplied) {
-      return;
-    }
-
-    if (isCallNumberBrowseOption(filters.qindex) && checkIfUserInMemberTenant(stripes)) {
+    if (isCallNumberBrowseOption(e.target.value) && checkIfUserInMemberTenant(stripes)) {
       // we want to applyFilters without writing the value to the url because it will trigger a search
-      applyFilters(FACETS.CALL_NUMBERS_HELD_BY, [stripes.okapi.tenant], false);
+      applyLocationFiltersAsync(FACETS.CALL_NUMBERS_HELD_BY, [stripes.okapi.tenant], false);
     }
-  }, [filters.qindex]);
+  }, [deleteItemToView, clearFilters, changeSearchIndex, applyLocationFiltersAsync]);
 
   const onReset = useCallback(() => {
     resetAll();


### PR DESCRIPTION
## Description
fix Held By facet default value not setting when switching browse options.
Issue was caused by an incorrect condition for setting the filter value. That whole approach is now reworked so that we're setting the default value right in the change handler of browse options. This allows us to ignore cases when a useEffect is called initially on mount, as well as on changes of `filters.qindex`.
To support this, however, we need some additional utility from the `useLocationFilters` hook. Some of that logic is synchronous, some is asynchronous, which is problematic when we're clearing filters and want to set some default value right after.
For this, added new `applyLocationFiltersAsync` utility, which uses `useState`'s callback under the hood. `applyLocationFilters` doesn't have this - and I don't feel comfortable changing that utility because who knows where else it's used (yay returning arrays instead of objects from hooks - we can rename returned properties however we want when calling the hook). There should be an ESLint rule against that IMO.
Anyways, here's the related PR: https://github.com/folio-org/stripes-acq-components/pull/911

## Screenshots

https://github.com/user-attachments/assets/c3e99886-ed55-4d7f-85cb-a03731ccd011


## Issues
[UIIN-3457](https://folio-org.atlassian.net/browse/UIIN-3457)