### PR TITLE
UIIN-3508 escape backslashes in Browse requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ UIIN-3437.
 * Change the order of items in the item list when dragging. Refs UIIN-3455.
 * Add missing permissions for instance view. Refs UIIN-3472.
 * Fix quick instance export. Refs UIIN-3504.
+* Escape backslashes in Browse requests. Fixes UIIN-3508.
 
 ## [13.0.10](https://github.com/folio-org/ui-inventory/tree/v13.0.10) (2025-09-01)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.9...v13.0.10)

--- a/src/hooks/useInventoryBrowse/useInventoryBrowse.js
+++ b/src/hooks/useInventoryBrowse/useInventoryBrowse.js
@@ -31,19 +31,22 @@ import {
 
 const isPrevious = (direction) => direction === PAGE_DIRECTIONS.prev;
 
+const escapeQueryString = (str) => str.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
 const getInitialPageQuery = (query, qindex) => {
+  const escapedQuery = escapeQueryString(query);
   return regExp.test(query)
     ? query
     : [
-      `${INITIAL_SEARCH_PARAMS_MAP[qindex]}>="${query.replace(/"/g, '\\"')}"`,
-      `${INITIAL_SEARCH_PARAMS_MAP[qindex]}<"${query.replace(/"/g, '\\"')}"`
+      `${INITIAL_SEARCH_PARAMS_MAP[qindex]}>="${escapedQuery}"`,
+      `${INITIAL_SEARCH_PARAMS_MAP[qindex]}<"${escapedQuery}"`
     ].join(' or ');
 };
 
 const getUpdatedPageQuery = (direction, anchor) => (_query, qindex) => {
   const param = PAGINATION_SEARCH_PARAMS_MAP[qindex];
-
-  return `${param} ${isPrevious(direction) ? '<' : '>'} "${anchor.replace(/"/g, '\\"')}"`;
+  const escapedString = escapeQueryString(anchor);
+  return `${param} ${isPrevious(direction) ? '<' : '>'} "${escapedString}"`;
 };
 
 const useInventoryBrowse = ({


### PR DESCRIPTION
## Description
escape backslashes in Browse requests to fix errors when switching to previous or next pages, if those queries contain backslashes

## Issues
[UIIN-3508](https://folio-org.atlassian.net/browse/UIIN-3508)