### PR TITLE
UIIN-2820 close third pane after reset all

### DIFF
--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -1074,6 +1074,7 @@ class InstancesList extends React.Component {
       publishOnReset,
       stripes,
       segment,
+      history,
     } = this.props;
 
     this.setState({
@@ -1090,7 +1091,9 @@ class InstancesList extends React.Component {
       searchParams.set('_isInitial', true);
       searchParams.set('segment', segment);
 
-      this.redirectToSearchParams(searchParams);
+      history.push({
+        search: searchParams.toString(),
+      });
     }
   }
 


### PR DESCRIPTION
## Description
Fix issue where third pane wasn't closing after clicking on Reset all.
To set default Held By facet value we were redirecting to a new url with those values by calling `redirectToSearchParams`. That function redirects to a current pathname, which at the point of Reset all is still `inventory/view/:id`.
Instead to set records we can call `history.push` directly with just search parameters, which will let `<SearchAndSort>`'s own reset all handler to redirect us to the root path.

## Issues
[UIIN-2820](https://folio-org.atlassian.net/browse/UIIN-2820)