### PR TITLE
UIIN-3454: Handle saving new items order on dragEnd event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ UIIN-3437.
 * Change the order of items in the item list when dragging. Refs UIIN-3455.
 * Add missing permissions for instance view. Refs UIIN-3472.
 * Fix quick instance export. Refs UIIN-3504.
+* Handle saving items order on dragEnd event. Refs UIIN-3454.
 
 ## [13.0.10](https://github.com/folio-org/ui-inventory/tree/v13.0.10) (2025-09-01)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.9...v13.0.10)

--- a/src/Instance/ItemsList/DraggableItemsList.js
+++ b/src/Instance/ItemsList/DraggableItemsList.js
@@ -12,7 +12,7 @@ import { Checkbox } from '@folio/stripes/components';
 import DropZone from '../../dnd/DropZone';
 import DraggableHandle from './DraggableHandle';
 
-export const getDraggableFormater = ({ holdingId, ifItemsSelected, selectItemForDrag }) => ({
+export const getDraggableFormater = ({ holdingId, ifItemsSelected, selectItemForDrag, isFetching }) => ({
   'dnd': (item) => (
     <DraggableHandle itemId={item.id} holdingId={holdingId} />
   ),
@@ -26,6 +26,7 @@ export const getDraggableFormater = ({ holdingId, ifItemsSelected, selectItemFor
               aria-label={ariaLabel}
               checked={ifItemsSelected([item.id])}
               onChange={() => selectItemForDrag(item.id)}
+              disabled={isFetching}
             />
           </span>
         )
@@ -39,6 +40,7 @@ export const getDraggableColumnMapping = ({
   holdingsRecordId,
   ifItemsSelected,
   selectAllItemsForDrag,
+  isFetching,
 }) => ({
   'dnd': '',
   'select': (
@@ -48,6 +50,7 @@ export const getDraggableColumnMapping = ({
         aria-label={intl.formatMessage({ id: 'ui-inventory.moveItems.selectAll' })}
         checked={ifItemsSelected(items.map(({ id }) => id))}
         onChange={(e) => selectAllItemsForDrag(holdingsRecordId, e.target?.checked)}
+        disabled={isFetching}
       />
     </span>
   ),

--- a/src/Instance/ItemsList/ItemsList.js
+++ b/src/Instance/ItemsList/ItemsList.js
@@ -46,6 +46,7 @@ const getFormatter = (
   locationsById,
   holdingsMapById,
   isBarcodeAsHotlink,
+  isFetching,
   tenantId,
 ) => ({
   'order': (item) => item.order || <NoValue />,
@@ -57,7 +58,7 @@ const getFormatter = (
             item={item}
             holdingId={item.holdingsRecordId}
             instanceId={holdingsMapById[item.holdingsRecordId]?.instanceId}
-            isBarcodeAsHotlink={isBarcodeAsHotlink}
+            isBarcodeAsHotlink={isBarcodeAsHotlink && !isFetching}
             tenantId={tenantId}
           />
           {item.discoverySuppress &&
@@ -177,6 +178,7 @@ const ItemsList = ({
         holdingsRecordId: holding.id,
         ifItemsSelected,
         selectAllItemsForDrag,
+        isFetching,
       });
       const colMapping = getColumnMapping(intl);
 
@@ -193,6 +195,7 @@ const ItemsList = ({
         holdingId: id,
         selectItemForDrag,
         ifItemsSelected,
+        isFetching,
       });
       const f = getFormatter(
         intl,
@@ -200,6 +203,7 @@ const ItemsList = ({
         locationsById,
         holdingsMapById,
         isBarcodeAsHotlink,
+        isFetching,
         tenantId,
       );
 

--- a/src/dnd/hooks/useDndHandlers.js
+++ b/src/dnd/hooks/useDndHandlers.js
@@ -259,7 +259,7 @@ const useDndHandlers = () => {
           const onSuccess = () => actions.previewCommit();
           const onReject = () => actions.previewCancel();
           await moveSelectedHoldingsToInstance({ holdingIds, fromInstanceId, toInstanceId: finalTo, toInstanceHrid, onSuccess, onReject });
-        } catch (error) {
+        } catch {
           actions.previewCancel();
         }
       }
@@ -355,7 +355,7 @@ const useDndHandlers = () => {
           await moveItems({ fromHoldingId, toHoldingId: finalTo, itemIds });
           actions.previewCommit();
           clear();
-        } catch (error) {
+        } catch {
           actions.previewCancel();
         }
       } else {
@@ -364,7 +364,7 @@ const useDndHandlers = () => {
           const onSuccess = () => actions.previewCommit();
           const onReject = () => actions.previewCancel();
           await moveSelectedItemsToHolding({ fromHoldingId, toHoldingId: finalTo, itemIds, onSuccess, onReject });
-        } catch (error) {
+        } catch {
           actions.previewCancel();
         }
       }

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -18,6 +18,7 @@ export { default as useClassificationBrowseConfig } from './useClassificationBro
 export { default as useUpdateOwnershipMutation } from './useUpdateOwnershipMutation';
 export { default as useLocalStorageItems } from './useLocalStorageItems';
 export { default as useInventoryVersionHistory } from './useInventoryVersionHistory';
+export { default as useItemsUpdateMutation } from './useItemsUpdateMutation';
 export { default as useStaffMembersQuery } from './useStaffMembersQuery';
 export { default as useTagSettingsQuery } from './useTagSettingsQuery';
 export { default as useTLRSettingsQuery } from './useTLRSettingsQuery';

--- a/src/hooks/useItemsUpdateMutation/index.js
+++ b/src/hooks/useItemsUpdateMutation/index.js
@@ -1,0 +1,1 @@
+export { default } from './useItemsUpdateMutation';

--- a/src/hooks/useItemsUpdateMutation/useItemsUpdateMutation.js
+++ b/src/hooks/useItemsUpdateMutation/useItemsUpdateMutation.js
@@ -1,0 +1,45 @@
+import { useContext } from 'react';
+import { FormattedMessage } from 'react-intl';
+import {
+  useMutation,
+  useQueryClient,
+} from 'react-query';
+
+import {
+  CalloutContext,
+  useNamespace,
+  useOkapiKy,
+} from '@folio/stripes/core';
+
+const useItemsUpdateMutation = ({ tenantId } = {}) => {
+  const ky = useOkapiKy({ tenant: tenantId });
+  const queryClient = useQueryClient();
+  const [fetchItemsPerHoldingNamespace] = useNamespace({ key: 'itemsByHoldingId' });
+  const callout = useContext(CalloutContext);
+
+  const { mutateAsync } = useMutation({
+    mutationFn: (body) => {
+      const requestBody = { items: body.items.map(({ holdingId: _holdingId, ...item }) => item) };
+      return ky.patch('item-storage/items', { json: requestBody }).json();
+    },
+    onError: () => {
+      callout.sendCallout({
+        type: 'error',
+        message: <FormattedMessage id="ui-inventory.communicationProblem" />,
+      });
+    },
+    onSettled: (data, error, variables) => {
+      const updatedHoldingIds = variables.items.map(item => item.holdingId).filter(Boolean);
+
+      if (!error) {
+        updatedHoldingIds.forEach(holdingId => {
+          queryClient.invalidateQueries({ queryKey: [fetchItemsPerHoldingNamespace, 'items', holdingId] });
+        });
+      }
+    },
+  });
+
+  return { mutateAsync };
+};
+
+export default useItemsUpdateMutation;

--- a/src/hooks/useItemsUpdateMutation/useItemsUpdateMutation.js
+++ b/src/hooks/useItemsUpdateMutation/useItemsUpdateMutation.js
@@ -32,9 +32,9 @@ const useItemsUpdateMutation = ({ tenantId } = {}) => {
       const updatedHoldingIds = variables.items.map(item => item.holdingId).filter(Boolean);
 
       if (!error) {
-        updatedHoldingIds.forEach(holdingId => {
+        for (const holdingId of updatedHoldingIds) {
           queryClient.invalidateQueries({ queryKey: [fetchItemsPerHoldingNamespace, 'items', holdingId] });
-        });
+        }
       }
     },
   });

--- a/src/hooks/useItemsUpdateMutation/useItemsUpdateMutation.test.js
+++ b/src/hooks/useItemsUpdateMutation/useItemsUpdateMutation.test.js
@@ -1,0 +1,179 @@
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { renderHook, act } from '@folio/jest-config-stripes/testing-library/react';
+
+import { useOkapiKy, useNamespace, CalloutContext } from '@folio/stripes/core';
+
+import '../../../test/jest/__mock__';
+
+import useItemsUpdateMutation from './useItemsUpdateMutation';
+
+const queryClient = new QueryClient();
+
+const mockCallout = {
+  sendCallout: jest.fn(),
+};
+
+const wrapper = ({ children }) => (
+  <CalloutContext.Provider value={mockCallout}>
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  </CalloutContext.Provider>
+);
+
+describe('useItemsUpdateMutation', () => {
+  const mockKy = {
+    patch: jest.fn(),
+  };
+
+  const mockItems = [
+    {
+      id: 'item-1',
+      _version: '1',
+      holdingId: 'holding-1',
+      order: '1',
+    },
+    {
+      id: 'item-2',
+      _version: '1',
+      holdingId: 'holding-2',
+      order: '2',
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useOkapiKy.mockReturnValue(mockKy);
+    useNamespace.mockReturnValue(['itemsByHoldingId']);
+    queryClient.clear();
+  });
+
+  it('should return mutateAsync function', () => {
+    const { result } = renderHook(
+      () => useItemsUpdateMutation(),
+      { wrapper },
+    );
+
+    expect(result.current).toHaveProperty('mutateAsync');
+    expect(typeof result.current.mutateAsync).toBe('function');
+  });
+
+  it('should make patch request with correct data when mutateAsync is called', async () => {
+    const mockResponse = { success: true };
+    const patchMock = jest.fn().mockReturnValue({ json: () => Promise.resolve(mockResponse) });
+    mockKy.patch = patchMock;
+
+    const { result } = renderHook(
+      () => useItemsUpdateMutation(),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync({ items: mockItems });
+    });
+
+    expect(patchMock).toHaveBeenCalledWith('item-storage/items', {
+      json: {
+        items: [
+          {
+            id: 'item-1',
+            _version: '1',
+            order: '1',
+          },
+          {
+            id: 'item-2',
+            _version: '1',
+            order: '2',
+          },
+        ],
+      },
+    });
+  });
+
+  it('should remove holdingId from items before sending request', async () => {
+    const mockResponse = { success: true };
+    const patchMock = jest.fn().mockReturnValue({ json: () => Promise.resolve(mockResponse) });
+    mockKy.patch = patchMock;
+
+    const { result } = renderHook(
+      () => useItemsUpdateMutation(),
+      { wrapper },
+    );
+
+    const itemsWithHoldingId = [
+      {
+        id: 'item-1',
+        _version: '1',
+        holdingId: 'holding-1',
+        order: '1',
+      },
+    ];
+
+    await act(async () => {
+      await result.current.mutateAsync({ items: itemsWithHoldingId });
+    });
+
+    expect(patchMock).toHaveBeenCalledWith('item-storage/items', {
+      json: {
+        items: [
+          {
+            id: 'item-1',
+            _version: '1',
+            order: '1',
+          },
+        ],
+      },
+    });
+  });
+
+  it('should invalidate queries for updated holdings on successful mutation', async () => {
+    const mockResponse = { success: true };
+    const patchMock = jest.fn().mockReturnValue({ json: () => Promise.resolve(mockResponse) });
+    mockKy.patch = patchMock;
+
+    const invalidateQueriesSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(
+      () => useItemsUpdateMutation(),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync({ items: mockItems });
+    });
+
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: ['itemsByHoldingId', 'items', 'holding-1'],
+    });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: ['itemsByHoldingId', 'items', 'holding-2'],
+    });
+  });
+
+  it('should not invalidate queries for items without holdingId', async () => {
+    const mockResponse = { success: true };
+    const patchMock = jest.fn().mockReturnValue({ json: () => Promise.resolve(mockResponse) });
+    mockKy.patch = patchMock;
+
+    const invalidateQueriesSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(
+      () => useItemsUpdateMutation(),
+      { wrapper },
+    );
+
+    const itemsWithoutHoldingId = [
+      {
+        id: 'item-1',
+        _version: '1',
+        order: '1',
+      },
+    ];
+
+    await act(async () => {
+      await result.current.mutateAsync({ items: itemsWithoutHoldingId });
+    });
+
+    expect(invalidateQueriesSpy).not.toHaveBeenCalled();
+  });
+});

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -103,7 +103,7 @@ const mockStripesCore = {
   // eslint-disable-next-line react/prop-types
   IfInterface: jest.fn(props => <>{props.children}</>),
 
-  useNamespace: () => ['@folio/inventory'],
+  useNamespace: jest.fn(() => ['@folio/inventory']),
 
   useCallout: jest.fn().mockReturnValue({
     sendCallout: jest.fn(),


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
When dragging and dropping item/items within the same holding it is required to send patch request to save new order on the server.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Implement new mutation hook to update items
- Call patch request on dragEnd event
- Disable checkboxes when items are fetching

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3454

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/user-attachments/assets/14c18b91-c642-4453-b095-640f3ecadde2

