### PR TITLE
UIIN-3518: Fix duplicating an item order value when duplicating an item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ UIIN-3437.
 * Add a default `source="local"` field to created Loan types. Fixes UIIN-3503.
 * Show order cells as text inputs when invoking “Move items within an instance” action. Refs UIIN-3486.
 * Deleted "Holdings" record displays in Instance "Holdings" accordion after deletion. Fixes UIIN-3498.
+* When duplicating an item order value is also duplicated. Fixes UIIN-3518.
 
 ## [13.0.10](https://github.com/folio-org/ui-inventory/tree/v13.0.10) (2025-09-01)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.9...v13.0.10)

--- a/src/Item/DuplicateItem/DuplicateItem.js
+++ b/src/Item/DuplicateItem/DuplicateItem.js
@@ -29,7 +29,7 @@ import {
 import { itemStatusesMap } from '../../constants';
 import { switchAffiliation } from '../../utils';
 
-const OMITTED_INITIAL_FIELDS = ['id', 'hrid', 'barcode', 'lastCheckIn'];
+const OMITTED_INITIAL_FIELDS = ['id', 'hrid', 'order', 'barcode', 'lastCheckIn'];
 
 const DuplicateItem = ({
   referenceData,


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
When a user duplicates an item, the new item receives the same order value as the original. This can lead to confusion in the list of items.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Omit `order` value during duplication of item.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3518

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
