### PR TITLE
UIIN-3494 Changes to Instance search after removing all unnecessary fields from mod-search response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ UIIN-3437.
 * Add a default `source="local"` field to created Loan types. Fixes UIIN-3503.
 * Show order cells as text inputs when invoking “Move items within an instance” action. Refs UIIN-3486.
 * Deleted "Holdings" record displays in Instance "Holdings" accordion after deletion. Fixes UIIN-3498.
+* Changes to Instance search after removing all unnecessary fields from mod-search response. Refs UIIN-3494.
 
 ## [13.0.10](https://github.com/folio-org/ui-inventory/tree/v13.0.10) (2025-09-01)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.9...v13.0.10)

--- a/src/Instance/ViewInstance/components/InstanceDetails/InstanceAdministrativeView/InstanceAdministrativeView.test.js
+++ b/src/Instance/ViewInstance/components/InstanceDetails/InstanceAdministrativeView/InstanceAdministrativeView.test.js
@@ -6,7 +6,7 @@ import '../../../../../../test/jest/__mock__';
 
 import renderWithIntl from '../../../../../../test/jest/helpers/renderWithIntl';
 import translationsProperties from '../../../../../../test/jest/helpers/translationsProperties';
-import { instances as instancesFixture } from '../../../../../../test/fixtures/instances';
+import { instancesExpanded as instancesExpandedFixture } from '../../../../../../test/fixtures/instancesExpanded';
 import InstanceAdministrativeView from './InstanceAdministrativeView';
 import { QUERY_INDEXES } from '../../../../../constants';
 
@@ -31,7 +31,7 @@ const defaultHRID = '11110000';
 const searchInstance = qIndex => `?qindex=${qIndex}&query=${defaultHRID}`;
 
 const setupInstanceAdministrativeView = ({
-  instance = instancesFixture[0],
+  instance = instancesExpandedFixture[0],
   history
 }) => {
   const component = (
@@ -88,7 +88,7 @@ describe('InstanceAdministrativeView', () => {
         const history = getHistory(searchInstance(QUERY_INDEXES.BARCODE));
         const { getByText } = setupInstanceAdministrativeView({
           history,
-          instance: instancesFixture[2],
+          instance: instancesExpandedFixture[2],
         });
 
         expect(getByText('FOLIO-shared')).toBeInTheDocument();
@@ -100,7 +100,7 @@ describe('InstanceAdministrativeView', () => {
         const history = getHistory(searchInstance(QUERY_INDEXES.BARCODE));
         const { getByText } = setupInstanceAdministrativeView({
           history,
-          instance: instancesFixture[3],
+          instance: instancesExpandedFixture[3],
         });
 
         expect(getByText('MARC-shared')).toBeInTheDocument();

--- a/src/Instance/ViewInstance/components/InstanceDetails/InstanceAdministrativeView/StatisticalCodesList.test.js
+++ b/src/Instance/ViewInstance/components/InstanceDetails/InstanceAdministrativeView/StatisticalCodesList.test.js
@@ -4,7 +4,7 @@ import { noop } from 'lodash';
 import '../../../../../../test/jest/__mock__';
 import renderWithIntl from '../../../../../../test/jest/helpers/renderWithIntl';
 import translationsProperties from '../../../../../../test/jest/helpers/translationsProperties';
-import { instances as instancesFixture } from '../../../../../../test/fixtures/instances';
+import { instancesExpanded as instancesExpandedFixture } from '../../../../../../test/fixtures/instancesExpanded';
 import StatisticalCodesList from './StatisticalCodesList';
 import { QUERY_INDEXES } from '../../../../../constants';
 
@@ -29,7 +29,7 @@ const defaultHRID = '11110000';
 const searchInstance = qIndex => `?qindex=${qIndex}&query=${defaultHRID}`;
 
 const setupStatisticalCodesList = ({
-  instance = instancesFixture[0],
+  instance = instancesExpandedFixture[0],
   history
 }) => {
   const component = (

--- a/src/Instance/ViewInstance/components/InstanceDetails/InstanceRelationshipView/InstanceRelationshipView.test.js
+++ b/src/Instance/ViewInstance/components/InstanceDetails/InstanceRelationshipView/InstanceRelationshipView.test.js
@@ -17,7 +17,7 @@ import {
 } from '../../../../../../test/jest/helpers';
 import {
   identifierTypes,
-  instances,
+  instancesExpanded,
   instanceRelationshipTypes,
   childInstances,
 } from '../../../../../../test/fixtures';
@@ -55,7 +55,7 @@ const InstanceRelationshipViewSetup = () => (
 describe('InstanceRelationshipView', () => {
   beforeEach(() => {
     sandbox.stub(reactQuery, 'useQueries').returns(
-      instances.map(instance => ({ data: { instances: [instance] }, isSuccess: true }))
+      instancesExpanded.map(instance => ({ data: { instances: [instance] }, isSuccess: true }))
     );
 
     renderWithIntl(

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -1160,7 +1160,10 @@ class InstancesList extends React.Component {
   findAndOpenItem = async (instance) => {
     const {
       parentResources,
-      parentMutator: { itemsByQuery },
+      parentMutator: {
+        itemsByQuery,
+        fullInstanceQuery,
+      },
       getParams,
       stripes,
       history,
@@ -1178,7 +1181,21 @@ class InstancesList extends React.Component {
       this.setState({ searchInProgress: false });
     }
 
-    const tenantItemBelongsTo = instance?.items?.[0]?.tenantId || stripes.okapi.tenant;
+    // Inventory search doesn't use `expandAll=true`, and so `instance` here has a very limited
+    // set of properties, and `items` is not included. SO we need to make a request for a full Instance
+    const fullInstance = await fullInstanceQuery.GET({
+      params: {
+        query: `id=="${instance.id}"`,
+        expandAll: true,
+      },
+      headers: {
+        [OKAPI_TENANT_HEADER]: instance.tenantId,
+        [CONTENT_TYPE_HEADER]: 'application/json',
+        ...(stripes.okapi.token && { [OKAPI_TOKEN_HEADER]: stripes.okapi.token }),
+      },
+    });
+
+    const tenantItemBelongsTo = fullInstance[0]?.items?.[0]?.tenantId || stripes.okapi.tenant;
 
     // if a user is not affiliated with the item's member tenant then item details cannot be open
     if (isUserInConsortiumMode(stripes)) {

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -23,7 +23,7 @@ import {
 } from '@folio/stripes-inventory-components';
 
 import { renderWithIntl, translationsProperties } from '../../../test/jest/helpers';
-import { instances as instancesFixture } from '../../../test/fixtures/instances';
+import { instancesCollapsed as instancesCollapsedFixture } from '../../../test/fixtures/instancesCollapsed';
 import InstancesList from './InstancesList';
 import { setItem } from '../../storage';
 import * as utils from '../../utils';
@@ -41,6 +41,12 @@ const mockItemsByQuery = jest.fn().mockResolvedValue([{
   id: 'itemId',
   holdingsRecordId: 'holdingsRecordId',
   instanceId: '69640328-788e-43fc-9c3c-af39e243f3b7',
+}]);
+const mockFullInstanceQuery = jest.fn().mockResolvedValue([{
+  id: 'instanceId',
+  items: [{
+    tenantId: 'college',
+  }],
 }]);
 const mockUnsubscribeFromReset = jest.fn();
 const mockPublishOnReset = jest.fn();
@@ -145,11 +151,11 @@ const resources = {
   records: {
     hasLoaded: true,
     resource: 'records',
-    records: instancesFixture,
-    other: { totalRecords: instancesFixture.length },
+    records: instancesCollapsedFixture,
+    other: { totalRecords: instancesCollapsedFixture.length },
     isPending: false,
   },
-  resultCount: instancesFixture.length,
+  resultCount: instancesCollapsedFixture.length,
   resultOffset: 0,
 };
 
@@ -180,6 +186,7 @@ const getInstancesListTree = ({ segment = segments.instances, ...rest } = {}) =>
               query: { update: updateMock, replace: mockQueryReplace },
               records: { reset: mockRecordsReset, POST: mockRecordPost },
               itemsByQuery: { reset: noop, GET: mockItemsByQuery },
+              fullInstanceQuery: { GET: mockFullInstanceQuery },
             }}
             data={{
               ...data,

--- a/src/hooks/useInstancesQuery.test.js
+++ b/src/hooks/useInstancesQuery.test.js
@@ -9,7 +9,7 @@ import '../../test/jest/__mock__';
 
 import { useOkapiKy } from '@folio/stripes/core';
 
-import { instances } from '../../test/fixtures';
+import { instancesExpanded } from '../../test/fixtures';
 import useInstancesQuery from './useInstancesQuery';
 
 const queryClient = new QueryClient();
@@ -24,7 +24,7 @@ describe('useInstancesQuery', () => {
   beforeEach(() => {
     mock = useOkapiKy.mockClear().mockReturnValue({
       get: () => ({
-        json: () => ({ instances }),
+        json: () => ({ instances: instancesExpanded }),
       }),
     });
   });
@@ -34,9 +34,9 @@ describe('useInstancesQuery', () => {
   });
 
   it('fetches instances', async () => {
-    const { result } = renderHook(() => useInstancesQuery(instances.map(({ id }) => id)), { wrapper });
+    const { result } = renderHook(() => useInstancesQuery(instancesExpanded.map(({ id }) => id)), { wrapper });
 
     await act(() => result.isSuccess);
-    expect(result.current.data.instances[0].id).toEqual(instances[0].id);
+    expect(result.current.data.instances[0].id).toEqual(instancesExpanded[0].id);
   });
 });

--- a/src/routes/InstancesRoute.test.js
+++ b/src/routes/InstancesRoute.test.js
@@ -22,7 +22,7 @@ import { SORT_OPTIONS } from '@folio/stripes-inventory-components';
 import renderWithIntl from '../../test/jest/helpers/renderWithIntl';
 import OverlayContainer from '../../test/helpers/OverlayContainer';
 import translationsProperties from '../../test/jest/helpers/translationsProperties';
-import { instances as instancesFixture } from '../../test/fixtures/instances';
+import { instancesExpanded as instancesExpandedFixture } from '../../test/fixtures/instancesExpanded';
 import { items as callNumbers } from '../../test/fixtures/callNumbers';
 import { QUICK_EXPORT_LIMIT } from '../constants';
 import { DataContext, LastSearchTermsContext } from '../contexts';
@@ -44,7 +44,7 @@ const stripesStub = {
 };
 
 const InstancesRouteSetup = ({
-  instances = instancesFixture,
+  instances = instancesExpandedFixture,
   sendCallout = noop,
   quickExportPOST = noop,
 } = {}) => (

--- a/src/routes/buildManifestObject.js
+++ b/src/routes/buildManifestObject.js
@@ -61,5 +61,12 @@ export function buildManifestObject() {
       accumulate: true,
       fetch: false,
     },
+    fullInstanceQuery: {
+      type: 'okapi',
+      records: 'instances',
+      path: 'search/instances',
+      accumulate: true,
+      fetch: false,
+    },
   };
 }

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,6 +1,7 @@
 export { identifierTypes } from './identifierTypes';
 export { instanceRelationshipTypes } from './instanceRelationshipTypes';
-export { instances } from './instances';
+export { instancesExpanded } from './instancesExpanded';
+export { instancesCollapsed } from './instancesCollapsed';
 export { instance } from './instance';
 export { subInstances } from './subInstances';
 export { relationshipTypes } from './relationshipTypes';

--- a/test/fixtures/instancesCollapsed.js
+++ b/test/fixtures/instancesCollapsed.js
@@ -1,0 +1,89 @@
+export const instancesCollapsed = [
+  {
+    'id': '69640328-788e-43fc-9c3c-af39e243f3b7',
+    'tenantId': 'consortium',
+    'shared': true,
+    'hrid': 'inst000000000001',
+    'title': 'ABA Journal',
+    'publication': [
+      {
+        'publisher': 'American Bar Association',
+        'dateOfPublication': '1915-1983'
+      }
+    ],
+    'staffSuppress': false,
+    'discoverySuppress': false,
+    'isBoundWith': false
+  },
+  {
+    'id': '5bf370e0-8cca-4d9c-82e4-5170ab2a0a39',
+    'tenantId': 'consortium',
+    'shared': true,
+    'hrid': 'inst000000000022',
+    'title': 'A semantic web primer',
+    'contributors': [
+      {
+        'name': 'Antoniou, Grigoris',
+        'contributorTypeId': '6e09d47d-95e2-4d8a-831b-f777b8ef6d81',
+        'contributorNameTypeId': '2b94c631-fca9-4892-a730-03ee529ffe2a'
+      },
+      {
+        'name': 'Van Harmelen, Frank',
+        'contributorTypeId': '6e09d47d-95e2-4d8a-831b-f777b8ef6d81',
+        'contributorNameTypeId': '2b94c631-fca9-4892-a730-03ee529ffe2a'
+      }
+    ],
+    'publication': [
+      {
+        'publisher': 'MIT Press',
+        'dateOfPublication': 'c2004'
+      }
+    ],
+    'staffSuppress': false,
+    'discoverySuppress': false,
+    'isBoundWith': false
+  },
+  {
+    'id': '00f10ab9-d845-4334-92d2-ff55862bf4f9',
+    'tenantId': 'consortium',
+    'shared': true,
+    'hrid': 'inst000000000002',
+    'title': 'American Bar Association journal.',
+    'contributors': [
+      {
+        'name': 'American Bar Association',
+        'contributorTypeId': '6e09d47d-95e2-4d8a-831b-f777b8ef6d81',
+        'contributorNameTypeId': 'd376e36c-b759-4fed-8502-7130d1eeff39'
+      },
+      {
+        'name': 'American Bar Association. Journal',
+        'contributorTypeId': '06b2cbd8-66bf-4956-9d90-97c9776365a4',
+        'contributorNameTypeId': 'd376e36c-b759-4fed-8502-7130d1eeff39'
+      }
+    ],
+    'publication': [
+      {
+        'publisher': 'American Bar Association'
+      }
+    ],
+    'staffSuppress': false,
+    'discoverySuppress': false,
+    'isBoundWith': false
+  },
+  {
+    'id': '30fcc8e7-a019-43f4-b642-2edc389f4501',
+    'tenantId': 'consortium',
+    'shared': true,
+    'hrid': 'inst000000000003',
+    'title': 'The American Journal of Medicine',
+    'publication': [
+      {
+        'publisher': 'Dun-Donnelley Pub. Co. ',
+        'dateOfPublication': '1946-'
+      }
+    ],
+    'staffSuppress': false,
+    'discoverySuppress': false,
+    'isBoundWith': false
+  }
+]

--- a/test/fixtures/instancesExpanded.js
+++ b/test/fixtures/instancesExpanded.js
@@ -1,4 +1,4 @@
-export const instances = [
+export const instancesExpanded = [
   {
     'id': '3afe2364-c584-46b7-8699-9667d4244d35',
     'hrid': 'in00000000001',


### PR DESCRIPTION
## Description
1. Remove `expandAll=true` parameter from Instances search requests
2. Since `items` is not included in the response - when auto-opening Item records we need to make a request for the expanded Instance object
3. Renamed `instances` fixture to `instancesExpanded` and added a `instancesCollapsed` fixture.

## Issues
[UIIN-3494](https://folio-org.atlassian.net/browse/UIIN-3494)