### PR TITLE
UIIN-3514: Add number generators to duplicate item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ UIIN-3437.
 * Deleted "Holdings" record displays in Instance "Holdings" accordion after deletion. Fixes UIIN-3498.
 * When duplicating an item order value is also duplicated. Fixes UIIN-3518.
 * Update Call number headers for Item and Holding records. Refs UIIN-3506, UIIN-3505.
+* Use of number generators while duplicating an Item record. Refs UIIN-3514.
 
 ## [13.0.10](https://github.com/folio-org/ui-inventory/tree/v13.0.10) (2025-09-01)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.9...v13.0.10)

--- a/src/Item/DuplicateItem/DuplicateItem.js
+++ b/src/Item/DuplicateItem/DuplicateItem.js
@@ -15,6 +15,7 @@ import {
   LoadingView,
 } from '@folio/stripes/components';
 
+import { useNumberGeneratorOptions } from '../../common/hooks';
 import {
   useInstanceQuery,
   useHoldingQuery,
@@ -43,6 +44,7 @@ const DuplicateItem = ({
   const { isLoading: isInstanceLoading, instance } = useInstanceQuery(instanceId);
   const { isLoading: isHoldingLoading, holding } = useHoldingQuery(holdingId);
   const { isLoading: isItemLoading, item } = useItemQuery(itemId);
+  const { data: numberGeneratorData } = useNumberGeneratorOptions();
   const callout = useCallout();
   const stripes = useStripes();
 
@@ -109,6 +111,7 @@ const DuplicateItem = ({
       id={holding.id}
       key={holding.id}
       initialValues={initialValues}
+      numberGeneratorData={numberGeneratorData}
       onSubmit={onSubmit}
       onCancel={onCancel}
       okapi={stripes.okapi}


### PR DESCRIPTION
[UIIN-3514](https://folio-org.atlassian.net/browse/UIIN-3514)

## Purpose
As a librarian I would like to generate Call numbers, Accession numbers and/or Item barcodes via number generators while duplicating item records.

Inventory > View item > Actions > Duplicate

**Current**
Right now no number generator functionality is available in the duplicate item view. Due to a misunderstanding of those different screens, the number generator functionality in this duplicate view has not yet been realized.

**Expected**
While duplicating an item record the buttons for the Call number, Accession number and Item barcode number generators are visible and functional, when user has the appropriate permissions/capability sets and the number generator for Call number, Accession number and/or Item barcode is enabled in Settings > Inventory > Holdings, Items > Number generator options

Number generator functionality in duplicate mode equals the number generator functionality in create (add) and edit mode of Inventory > Items. 

## Approach
Since the `numberGeneratorData` is already rendered in `src/edit/items/ItemForm.js` it is just necessary to add the data via `useNumberGeneratorOptions`  in `DuplicateItem.js`

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
