### PR TITLE
UIIN-3513: Add number generators to duplicate holding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ UIIN-3437.
 * Deleted "Holdings" record displays in Instance "Holdings" accordion after deletion. Fixes UIIN-3498.
 * When duplicating an item order value is also duplicated. Fixes UIIN-3518.
 * Update Call number headers for Item and Holding records. Refs UIIN-3506, UIIN-3505.
+* Use of number generator while duplicating a Holdings record. Refs UIIN-3513.
 
 ## [13.0.10](https://github.com/folio-org/ui-inventory/tree/v13.0.10) (2025-09-01)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.9...v13.0.10)

--- a/src/Holding/DuplicateHolding/DuplicateHolding.js
+++ b/src/Holding/DuplicateHolding/DuplicateHolding.js
@@ -7,6 +7,7 @@ import { useStripes } from '@folio/stripes/core';
 import { LoadingView } from '@folio/stripes/components';
 
 import {
+  useNumberGeneratorOptions,
   useHoldingQuery,
   useInstanceQuery,
 } from '../../common/hooks';
@@ -37,6 +38,7 @@ const DuplicateHolding = ({
   const stripes = useStripes();
   const { instance, isLoading: isInstanceLoading } = useInstanceQuery(instanceId);
   const { holding, isLoading: isHoldingLoading } = useHoldingQuery(holdingId);
+  const { data: numberGeneratorData } = useNumberGeneratorOptions();
 
   const sourceId = referenceTables.holdingsSourcesByName?.FOLIO?.id;
 
@@ -90,6 +92,7 @@ const DuplicateHolding = ({
   return (
     <HoldingsForm
       initialValues={initialValues}
+      numberGeneratorData={numberGeneratorData}
       onSubmit={onSubmit}
       onCancel={onCancel}
       okapi={stripes.okapi}


### PR DESCRIPTION
[UIIN-3513](https://folio-org.atlassian.net/browse/UIIN-3513)

## Purpose
As a librarian I would like to generate call numbers via number generator while duplicating holdings records. 

Inventory > View holdings > Actions > Duplicate

**Current**
Right now no number generator functionality is available in the duplicate holdings view. Due to a misunderstanding of those different screens, the number generator functionality in this duplicate view has not yet been realized.

**Expected**
While duplicating a holdings record the button for the Call number number generator is visible and functional, when user has the appropriate permissions/capability sets and the number generator for Call number is enabled in Settings > Inventory > Holdings, Items > Number generator options

Number generator functionality in duplicate mode equals the number generator functionality in create (add) and edit mode of Inventory > Holdings. 


## Approach
Since the `numberGeneratorData` is already rendered in `src/edit/items/ItemForm.js` it is just necessary to add the data via `useNumberGeneratorOptions` in `DuplicateHolding.js`

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
