### PR TITLE
UIIN-3611: Hide `Move items within an instance` button for shared instances without local holdings on member tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## 13.0.14 (IN PROGRESS)
+
+* Hide `Move items within an instance` button for shared instances without local holdings on member tenant. Fixes UIIN-3611.
+
 ## [13.0.13](https://github.com/folio-org/ui-inventory/tree/v13.0.13) (2026-03-11)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.12...v13.0.13)
 

--- a/src/ViewInstance.js
+++ b/src/ViewInstance.js
@@ -729,7 +729,7 @@ class ViewInstance extends React.Component {
       titleLevelRequestsFeatureEnabled,
     } = this.state;
     const source = instance?.source;
-    const noInstanceHoldings = allInstanceHoldings?.other?.totalRecords === 0;
+    const noInstanceHoldings = allInstanceHoldings?.other?.totalRecords === 0 || allInstanceHoldings?.records?.length === 0;
 
     const editBibRecordPerm = 'ui-quick-marc.quick-marc-editor.all';
     const editInstancePerm = 'ui-inventory.instance.edit';


### PR DESCRIPTION
## Links
[UIIN-3611](https://folio-org.atlassian.net/browse/UIIN-3611)

* Verification of the absence of holdings by checking `allInstanceHoldings?.records?.length`