### PR TITLE
UIIN-3602: Fix Tags accordion displaying in Holdings and Items until `Tags` setting is re-enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## [14.0.1] (IN PROGRESS)
+
+* Fix Tags accordion displaying in Holdings and Items until Tags setting is re-enabled. Fixes UIIN-3602.
+
 ## [14.0.0](https://github.com/folio-org/ui-inventory/tree/v14.0.0) (2026-04-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.13...v14.0.0)
 

--- a/src/Item/ViewItem/ViewItem.js
+++ b/src/Item/ViewItem/ViewItem.js
@@ -255,7 +255,8 @@ const ViewItem = ({
   };
 
   const tagsEnabled = useMemo(
-    () => tagSettings.items?.[0]?.value,
+    // Empty settings means tags are enabled by default
+    () => !tagSettings.items?.length || tagSettings.items?.[0]?.value,
     [tagSettings],
   );
 

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -674,7 +674,8 @@ class ViewHoldingsRecord extends React.Component {
     const holdingsEffectiveLocation = referenceTables?.locationsById[holdingsRecord?.effectiveLocationId];
     const itemCount = get(items, 'records.length', 0);
     const holdingsSourceName = holdingsSource?.name;
-    const tagsEnabled = tagSettings?.records?.[0]?.items?.[0]?.value;
+    // Empty settings means tags are enabled by default
+    const tagsEnabled = !tagSettings?.records?.[0]?.items?.length || tagSettings?.records?.[0]?.items?.[0]?.value;
 
     const confirmHoldingsRecordDeleteModalMessage = (
       <FormattedMessage


### PR DESCRIPTION
## Purpose
* When the Tags setting is enabled, Tags should be displayed on each Folio record when applicable.

## Approach
* Empty settings means tags are enabled by default

## Refs
[UIIN-3602](https://folio-org.atlassian.net/browse/UIIN-3602)