### PR TITLE
UIIN-3635 `<ViewSource>` - don't load MARC record until Instance has finished loading.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [14.0.1] (IN PROGRESS)
 
 * Fix Tags accordion displaying in Holdings and Items until Tags setting is re-enabled. Fixes UIIN-3602.
+* `<ViewSource>` - don't load MARC record until Instance has finished loading. Fixes UIIN-3635.
 
 ## [14.0.0](https://github.com/folio-org/ui-inventory/tree/v14.0.0) (2026-04-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.13...v14.0.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/inventory",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "description": "Inventory manager",
   "repository": "folio-org/ui-inventory",
   "publishConfig": {

--- a/src/components/ViewSource/ViewSource.js
+++ b/src/components/ViewSource/ViewSource.js
@@ -145,6 +145,10 @@ const ViewSource = ({
   ], [stripes, redirectToMARCEdit]);
 
   useEffect(() => {
+    if (isInstanceLoading) {
+      return;
+    }
+
     setIsMarcLoading(true);
 
     const { okapi: { tenant, token, locale } } = stripes;
@@ -168,7 +172,7 @@ const ViewSource = ({
       .finally(() => {
         setIsMarcLoading(false);
       });
-  }, []);
+  }, [isInstanceLoading]);
 
   const canExport = !isHoldingsRecord && stripes.hasInterface('data-export') && stripes.hasPerm('ui-data-export.edit');
 

--- a/src/components/ViewSource/ViewSource.test.js
+++ b/src/components/ViewSource/ViewSource.test.js
@@ -108,6 +108,10 @@ describe('ViewSource', () => {
     it('should render LoadingView', () => {
       expect(screen.getByText('LoadingView')).toBeInTheDocument();
     });
+
+    it('should not fetch marc record yet', () => {
+      expect(mutator.marcRecord.GET).not.toHaveBeenCalled();
+    });
   });
 
   describe('when marc source request is failed', () => {
@@ -115,7 +119,7 @@ describe('ViewSource', () => {
       mutator.marcRecord.GET.mockRejectedValueOnce('marcRecord error');
 
       await act(async () => {
-        await renderWithIntl(getViewSource({ instance: null, isInstanceLoading: true }), translations);
+        await renderWithIntl(getViewSource({ instance: null, isInstanceLoading: false }), translations);
       });
     });
 


### PR DESCRIPTION
## Description
On a member tenant, when a View Source page is refreshed (or opened via copy-pasting a URL or duplicating a tab) we get an error that a MARC record was not found. This is caused by fetching MARC source record before Instance has finished loading.
We need that Instance record to know it's tenantId to know which tenant to request a MARC source record from

## Issues
[UIIN-3635](https://folio-org.atlassian.net/browse/UIIN-3635)