### PR TITLE
UIIN-3604: Show error message when edit URLs are with invalid UUIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * `<ViewSource>` - don't load MARC record until Instance has finished loading. Fixes UIIN-3635.
 * Item status is displayed in lowercase (“available”) instead of capitalized (“Available”) in the item title. Fixes UIIN-3640.
 * `<ViewSource>` - add missing useEffect/useMemo deps to update when instance data is loaded. Fixes UIIN-3641.
+* Show error message when edit URLs are with invalid UUIDs. Fixes UIIN-3604.
 
 ## [14.0.0](https://github.com/folio-org/ui-inventory/tree/v14.0.0) (2026-04-17)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.13...v14.0.0)

--- a/src/Instance/Move/useHoldingsMove.js
+++ b/src/Instance/Move/useHoldingsMove.js
@@ -48,7 +48,7 @@ export const useHoldingsMove = (options = {}) => {
 
         return { success: true, holdingId: marcHoldingsId };
       } catch (error) {
-        console.error(`Failed to update MARC holding ${marcHoldingsId}:`, error);
+        console.error(`Failed to update MARC holding ${marcHoldingsId}:`, error); // eslint-disable-line no-console
         return { success: false, holdingId: marcHoldingsId, error };
       }
     });

--- a/src/Instance/hooks/useLinkedDataIdQuery/useLinkedDataIdQuery.test.js
+++ b/src/Instance/hooks/useLinkedDataIdQuery/useLinkedDataIdQuery.test.js
@@ -1,4 +1,4 @@
-﻿import {
+import {
   QueryClient,
   QueryClientProvider,
 } from 'react-query';

--- a/src/Instance/hooks/useSetRecordForDeletion/useSetRecordForDeletion.test.js
+++ b/src/Instance/hooks/useSetRecordForDeletion/useSetRecordForDeletion.test.js
@@ -50,7 +50,9 @@ describe('useSetRecordForDeletion', () => {
     await act(async () => {
       try {
         await result.current.setRecordForDeletion('instance-123');
-      } catch (e) {}
+      } catch (e) {
+        console.error('Error in setRecordForDeletion:', e); // eslint-disable-line no-console
+      }
     });
 
     expect(mockDelete).toHaveBeenCalledWith('inventory/instances/instance-123/mark-deleted');

--- a/src/dnd/hooks/useMoveCommands.js
+++ b/src/dnd/hooks/useMoveCommands.js
@@ -113,7 +113,7 @@ const useMoveCommands = () => {
         actions.moveItems({ itemIds: [...itemsToMove], toHoldingId });
         toggleAllItems(fromHoldingId, false); // clear selection after success
       } catch (error) {
-        console.error('Failed to move items:', error);
+        console.error('Failed to move items:', error); // eslint-disable-line no-console
       }
     }
   };

--- a/src/routes/EditHoldingRoute.js
+++ b/src/routes/EditHoldingRoute.js
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { useParams, useLocation } from 'react-router-dom';
 
 import { AuthenticatedError } from '@folio/stripes/core';
-import { isValidUUID } from '@folio/stripes-util';
+import { isValidUUID } from '@folio/stripes/util';
 
 import { DataContext } from '../contexts';
 import { EditHolding } from '../Holding';

--- a/src/routes/EditHoldingRoute.js
+++ b/src/routes/EditHoldingRoute.js
@@ -1,12 +1,23 @@
 import React, { useContext } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
+
+import { AuthenticatedError } from '@folio/stripes/core';
+import { isValidUUID } from '@folio/stripes-util';
 
 import { DataContext } from '../contexts';
 import { EditHolding } from '../Holding';
 
 const EditHoldingRoute = () => {
+  const location = useLocation();
   const { id: instanceId, holdingsrecordid: holdingId } = useParams();
+
   const referenceTables = useContext(DataContext);
+
+  const hasValidParams = [instanceId, holdingId].every(isValidUUID);
+
+  if (!hasValidParams) {
+    return <AuthenticatedError location={location} />;
+  }
 
   return (
     <EditHolding

--- a/src/routes/EditHoldingRoute.js
+++ b/src/routes/EditHoldingRoute.js
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { useParams, useLocation } from 'react-router-dom';
 
 import { AuthenticatedError } from '@folio/stripes/core';
-import { isValidUUID } from '@folio/stripes-util';
+import { isValidUUID } from '@folio/stripes/util;
 
 import { DataContext } from '../contexts';
 import { EditHolding } from '../Holding';

--- a/src/routes/EditHoldingRoute.test.js
+++ b/src/routes/EditHoldingRoute.test.js
@@ -1,17 +1,16 @@
 import { MemoryRouter } from 'react-router-dom';
 
 import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import * as stripesUtil from '@folio/stripes/util';
 
 import EditHoldingRoute from './EditHoldingRoute';
 
-const mockedUseParams = jest.fn();
 const mockAuthenticatedError = jest.fn(({ location }) => (
   <div>AuthenticatedError: {location.pathname}</div>
 ));
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useParams: () => mockedUseParams(),
+jest.mock('@folio/stripes/util', () => ({
+  isValidUUID: jest.fn(() => false),
 }));
 
 jest.mock('@folio/stripes/core', () => ({
@@ -40,15 +39,10 @@ const renderEditHoldingRoute = (initialEntry = '/holdings/foo/bar') => render(
 
 describe('EditHoldingRoute', () => {
   beforeEach(() => {
-    mockAuthenticatedError.mockClear();
+    jest.clearAllMocks();
   });
 
   it('renders authenticated error for invalid UUID params', () => {
-    mockedUseParams.mockReturnValue({
-      id: 'foo',
-      holdingsrecordid: 'bar',
-    });
-
     renderEditHoldingRoute();
 
     expect(screen.getByText('AuthenticatedError: /holdings/foo/bar')).toBeInTheDocument();
@@ -62,10 +56,7 @@ describe('EditHoldingRoute', () => {
   });
 
   it('renders holding edit for valid UUID params', () => {
-    mockedUseParams.mockReturnValue({
-      id: '11111111-1111-4111-8111-111111111111',
-      holdingsrecordid: '22222222-2222-4222-8222-222222222222',
-    });
+    stripesUtil.isValidUUID.mockReturnValue(true);
 
     renderEditHoldingRoute('/holdings/11111111-1111-4111-8111-111111111111/22222222-2222-4222-8222-222222222222');
 

--- a/src/routes/EditItemRoute.js
+++ b/src/routes/EditItemRoute.js
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { useParams, useLocation } from 'react-router-dom';
 
 import { AuthenticatedError } from '@folio/stripes/core';
-import { isValidUUID } from '@folio/stripes-util';
+import { isValidUUID } from '@folio/stripes/util';
 
 import { EditItem } from '../Item';
 import { DataContext } from '../contexts';

--- a/src/routes/EditItemRoute.js
+++ b/src/routes/EditItemRoute.js
@@ -1,12 +1,23 @@
 import React, { useContext } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
+
+import { AuthenticatedError } from '@folio/stripes/core';
+import { isValidUUID } from '@folio/stripes-util';
 
 import { EditItem } from '../Item';
 import { DataContext } from '../contexts';
 
 const EditItemRoute = () => {
+  const location = useLocation();
   const { id, holdingId, itemId } = useParams();
+
   const referenceData = useContext(DataContext);
+
+  const hasValidParams = [id, holdingId, itemId].every(isValidUUID);
+
+  if (!hasValidParams) {
+    return <AuthenticatedError location={location} />;
+  }
 
   return (
     <EditItem

--- a/src/routes/EditItemRoute.test.js
+++ b/src/routes/EditItemRoute.test.js
@@ -1,32 +1,77 @@
-import '../../test/jest/__mock__';
-
 import { MemoryRouter } from 'react-router-dom';
+
 import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import EditItemRoute from './EditItemRoute';
 
-jest.mock('../Item', () => ({
-  ...jest.requireActual('../Item'),
-  EditItem: jest.fn().mockReturnValue('EditItem')
+const mockedUseParams = jest.fn();
+const mockAuthenticatedError = jest.fn(({ location }) => (
+  <div>AuthenticatedError: {location.pathname}</div>
+));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => mockedUseParams(),
 }));
 
-const wrapper = ({ children }) => (
-  <MemoryRouter>
-    {children}
-  </MemoryRouter>
-);
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  AuthenticatedError: (props) => mockAuthenticatedError(props),
+}));
 
-const renderEditItemRoute = (props = {}) => render(
-  <EditItemRoute
-    {...props}
-  />,
-  { wrapper },
+jest.mock('../contexts', () => ({
+  DataContext: {
+    Consumer: ({ children }) => children({}),
+  },
+}));
+
+jest.mock('../Item', () => ({
+  EditItem: jest.fn().mockReturnValue('EditItem'),
+}));
+
+const renderEditItemRoute = (initialEntry = '/inventory/edit/foo/bar/baz') => render(
+  <MemoryRouter initialEntries={[initialEntry]}>
+    <EditItemRoute
+      location={{ search: '', state: {}, pathname: '/inventory/edit/foo/bar/baz' }}
+      stripes={{ okapi: { tenant: 'diku' } }}
+    />
+  </MemoryRouter>,
 );
 
 describe('EditItemRoute', () => {
-  it('should render EditItem component', () => {
+  beforeEach(() => {
+    mockAuthenticatedError.mockClear();
+  });
+
+  it('renders authenticated error for invalid UUID params', () => {
+    mockedUseParams.mockReturnValue({
+      id: 'foo',
+      holdingId: 'bar',
+      itemId: 'baz',
+    });
+
     renderEditItemRoute();
 
+    expect(screen.getByText('AuthenticatedError: /inventory/edit/foo/bar/baz')).toBeInTheDocument();
+    expect(mockAuthenticatedError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location: expect.objectContaining({
+          pathname: '/inventory/edit/foo/bar/baz',
+        }),
+      }),
+    );
+  });
+
+  it('renders item edit for valid UUID params', () => {
+    mockedUseParams.mockReturnValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      holdingId: '22222222-2222-4222-8222-222222222222',
+      itemId: '33333333-3333-4333-8333-333333333333',
+    });
+
+    renderEditItemRoute('/inventory/edit/11111111-1111-4111-8111-111111111111/22222222-2222-4222-8222-222222222222/33333333-3333-4333-8333-333333333333');
+
     expect(screen.getByText('EditItem')).toBeInTheDocument();
+    expect(mockAuthenticatedError).not.toHaveBeenCalled();
   });
 });

--- a/src/routes/EditItemRoute.test.js
+++ b/src/routes/EditItemRoute.test.js
@@ -1,17 +1,16 @@
 import { MemoryRouter } from 'react-router-dom';
 
 import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import * as stripesUtil from '@folio/stripes/util';
 
 import EditItemRoute from './EditItemRoute';
 
-const mockedUseParams = jest.fn();
 const mockAuthenticatedError = jest.fn(({ location }) => (
   <div>AuthenticatedError: {location.pathname}</div>
 ));
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useParams: () => mockedUseParams(),
+jest.mock('@folio/stripes/util', () => ({
+  isValidUUID: jest.fn(() => false),
 }));
 
 jest.mock('@folio/stripes/core', () => ({
@@ -40,16 +39,10 @@ const renderEditItemRoute = (initialEntry = '/inventory/edit/foo/bar/baz') => re
 
 describe('EditItemRoute', () => {
   beforeEach(() => {
-    mockAuthenticatedError.mockClear();
+    jest.clearAllMocks();
   });
 
   it('renders authenticated error for invalid UUID params', () => {
-    mockedUseParams.mockReturnValue({
-      id: 'foo',
-      holdingId: 'bar',
-      itemId: 'baz',
-    });
-
     renderEditItemRoute();
 
     expect(screen.getByText('AuthenticatedError: /inventory/edit/foo/bar/baz')).toBeInTheDocument();
@@ -63,11 +56,7 @@ describe('EditItemRoute', () => {
   });
 
   it('renders item edit for valid UUID params', () => {
-    mockedUseParams.mockReturnValue({
-      id: '11111111-1111-4111-8111-111111111111',
-      holdingId: '22222222-2222-4222-8222-222222222222',
-      itemId: '33333333-3333-4333-8333-333333333333',
-    });
+    stripesUtil.isValidUUID.mockReturnValue(true);
 
     renderEditItemRoute('/inventory/edit/11111111-1111-4111-8111-111111111111/22222222-2222-4222-8222-222222222222/33333333-3333-4333-8333-333333333333');
 

--- a/src/routes/InstanceEditRoute.js
+++ b/src/routes/InstanceEditRoute.js
@@ -1,13 +1,23 @@
 import React, { useContext } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
 
+import { AuthenticatedError } from '@folio/stripes/core';
+import { isValidUUID } from '@folio/stripes-util';
 
 import { InstanceEdit } from '../Instance';
 import { DataContext } from '../contexts';
 
 const InstanceEditRoute = () => {
+  const location = useLocation();
   const { id: instanceId } = useParams();
+
   const referenceData = useContext(DataContext);
+
+  const hasValidParams = isValidUUID(instanceId);
+
+  if (!hasValidParams) {
+    return <AuthenticatedError location={location} />;
+  }
 
   return (
     <InstanceEdit

--- a/src/routes/InstanceEditRoute.js
+++ b/src/routes/InstanceEditRoute.js
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { useParams, useLocation } from 'react-router-dom';
 
 import { AuthenticatedError } from '@folio/stripes/core';
-import { isValidUUID } from '@folio/stripes-util';
+import { isValidUUID } from '@folio/stripes/util';
 
 import { InstanceEdit } from '../Instance';
 import { DataContext } from '../contexts';

--- a/src/routes/InstanceEditRoute.test.js
+++ b/src/routes/InstanceEditRoute.test.js
@@ -1,8 +1,7 @@
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
-import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
-
-import EditHoldingRoute from './EditHoldingRoute';
+import InstanceEditRoute from './InstanceEditRoute';
 
 const mockedUseParams = jest.fn();
 const mockAuthenticatedError = jest.fn(({ location }) => (
@@ -25,20 +24,20 @@ jest.mock('../contexts', () => ({
   },
 }));
 
-jest.mock('../Holding', () => ({
-  EditHolding: jest.fn().mockReturnValue('EditHolding'),
+jest.mock('../Instance', () => ({
+  InstanceEdit: jest.fn().mockReturnValue('InstanceEdit'),
 }));
 
-const renderEditHoldingRoute = (initialEntry = '/holdings/foo/bar') => render(
+const renderInstanceEditRoute = (initialEntry = '/inventory/edit/foo') => render(
   <MemoryRouter initialEntries={[initialEntry]}>
-    <EditHoldingRoute
-      location={{ search: '', state: {}, pathname: '/holdings/foo/bar' }}
+    <InstanceEditRoute
+      location={{ search: '', state: {}, pathname: '/inventory/edit/foo' }}
       stripes={{ okapi: { tenant: 'diku' } }}
     />
   </MemoryRouter>,
 );
 
-describe('EditHoldingRoute', () => {
+describe('InstanceEditRoute', () => {
   beforeEach(() => {
     mockAuthenticatedError.mockClear();
   });
@@ -46,30 +45,28 @@ describe('EditHoldingRoute', () => {
   it('renders authenticated error for invalid UUID params', () => {
     mockedUseParams.mockReturnValue({
       id: 'foo',
-      holdingsrecordid: 'bar',
     });
 
-    renderEditHoldingRoute();
+    renderInstanceEditRoute();
 
-    expect(screen.getByText('AuthenticatedError: /holdings/foo/bar')).toBeInTheDocument();
+    expect(screen.getByText('AuthenticatedError: /inventory/edit/foo')).toBeInTheDocument();
     expect(mockAuthenticatedError).toHaveBeenCalledWith(
       expect.objectContaining({
         location: expect.objectContaining({
-          pathname: '/holdings/foo/bar',
+          pathname: '/inventory/edit/foo',
         }),
       }),
     );
   });
 
-  it('renders holding edit for valid UUID params', () => {
+  it('renders instance edit for valid UUID params', () => {
     mockedUseParams.mockReturnValue({
       id: '11111111-1111-4111-8111-111111111111',
-      holdingsrecordid: '22222222-2222-4222-8222-222222222222',
     });
 
-    renderEditHoldingRoute('/holdings/11111111-1111-4111-8111-111111111111/22222222-2222-4222-8222-222222222222');
+    renderInstanceEditRoute('/inventory/edit/11111111-1111-4111-8111-111111111111');
 
-    expect(screen.getByText('EditHolding')).toBeInTheDocument();
+    expect(screen.getByText('InstanceEdit')).toBeInTheDocument();
     expect(mockAuthenticatedError).not.toHaveBeenCalled();
   });
 });

--- a/src/routes/InstanceEditRoute.test.js
+++ b/src/routes/InstanceEditRoute.test.js
@@ -1,16 +1,16 @@
-import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import * as stripesUtil from '@folio/stripes/util';
 
 import InstanceEditRoute from './InstanceEditRoute';
 
-const mockedUseParams = jest.fn();
 const mockAuthenticatedError = jest.fn(({ location }) => (
   <div>AuthenticatedError: {location.pathname}</div>
 ));
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useParams: () => mockedUseParams(),
+jest.mock('@folio/stripes/util', () => ({
+  isValidUUID: jest.fn(() => false),
 }));
 
 jest.mock('@folio/stripes/core', () => ({
@@ -39,14 +39,10 @@ const renderInstanceEditRoute = (initialEntry = '/inventory/edit/foo') => render
 
 describe('InstanceEditRoute', () => {
   beforeEach(() => {
-    mockAuthenticatedError.mockClear();
+    jest.clearAllMocks();
   });
 
   it('renders authenticated error for invalid UUID params', () => {
-    mockedUseParams.mockReturnValue({
-      id: 'foo',
-    });
-
     renderInstanceEditRoute();
 
     expect(screen.getByText('AuthenticatedError: /inventory/edit/foo')).toBeInTheDocument();
@@ -60,9 +56,7 @@ describe('InstanceEditRoute', () => {
   });
 
   it('renders instance edit for valid UUID params', () => {
-    mockedUseParams.mockReturnValue({
-      id: '11111111-1111-4111-8111-111111111111',
-    });
+    stripesUtil.isValidUUID.mockReturnValue(true);
 
     renderInstanceEditRoute('/inventory/edit/11111111-1111-4111-8111-111111111111');
 

--- a/test/jest/__mock__/stripesSmartComponents.mock.js
+++ b/test/jest/__mock__/stripesSmartComponents.mock.js
@@ -36,7 +36,7 @@ jest.mock('@folio/stripes/smart-components', () => ({
     return <RealSearchAndSort {...props} />;
   }),
   withTags: Component => (props) => {
-    return <Component {...props} tagsEnabled={true} />;
+    return <Component {...props} tagsEnabled />;
   },
 }), { virtual: true });
 

--- a/test/jest/helpers/Harness.js
+++ b/test/jest/helpers/Harness.js
@@ -57,7 +57,7 @@ Harness.propTypes = {
   translations: PropTypes.arrayOf(
     PropTypes.shape({
       prefix: PropTypes.string,
-      translations: PropTypes.object,
+      translations: PropTypes.objectOf(PropTypes.string),
     })
   ),
 };


### PR DESCRIPTION
## Purpose
* Accessing an edit-URL with invalid URL parameters in the path shows an error message.

## Approach
* Check for valid holdings and instances UUIDs, if not valid - show default 404 Error page from stripes-core.
* Add unit tests.
* Fixed eslint errors.

## Refs
[UIIN-3604](https://folio-org.atlassian.net/browse/UIIN-3604)

## Screenshots
<img width="1918" height="1092" alt="image" src="https://github.com/user-attachments/assets/91ce3042-12c2-4528-9c8b-489c31d724a0" />
<img width="1913" height="1096" alt="image" src="https://github.com/user-attachments/assets/0afeebeb-aad5-4000-a0f0-349a2b12f2e2" />
<img width="1919" height="1096" alt="image" src="https://github.com/user-attachments/assets/1131ac99-74ab-4e5b-9dea-cca2af6106b5" />
