### PR TITLE
UIIN-3617: Source not displaying in Inventory version history for circ actions taken in different tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Show error message when edit URLs are with invalid UUIDs. Fixes UIIN-3604.
 * ECS | Show child and parent of shared Instance when Instance from Member tenant. Fixes UIIN-3642.
+* Source not displaying in Inventory version history for circ actions taken in different tenant. Fixes UIIN-3617.
 
 ## [14.0.1](https://github.com/folio-org/ui-inventory/tree/v14.0.1) (2026-05-06)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v14.0.0...v14.0.1)

--- a/src/Item/ViewItem/components/ItemVersionHistory/ItemVersionHistory.js
+++ b/src/Item/ViewItem/components/ItemVersionHistory/ItemVersionHistory.js
@@ -48,13 +48,15 @@ export const createFieldFormatter = (referenceData, circulationHistory) => ({
   staffMemberId: () => circulationHistory.source,
   dateTime: value => getDateWithTime(value),
   source: value => {
+    const unknownUser = <FormattedMessage id="stripes-components.metaSection.unknownUser" />;
+
     if (value.personal) {
       const { firstName, lastName = '' } = value.personal;
 
-      return firstName ? `${lastName}, ${firstName}` : lastName;
+      return firstName ? `${lastName}, ${firstName}` : (lastName || unknownUser);
     }
 
-    return <FormattedMessage id="stripes-components.metaSection.unknownUser" />;
+    return unknownUser;
   },
 });
 

--- a/src/Item/ViewItem/components/ItemVersionHistory/ItemVersionHistory.test.js
+++ b/src/Item/ViewItem/components/ItemVersionHistory/ItemVersionHistory.test.js
@@ -277,6 +277,12 @@ describe('createFieldFormatter', () => {
   it('should display only last name as source if no first name provided', () => {
     expect(fieldFormatter.source({ personal: { lastName: 'Doe' } })).toBe('Doe');
   });
+
+  it('should display Unknown user as source if no firstName and lastName provided', () => {
+    const result = fieldFormatter.source({ personal: { firstName: '', lastName: '' } });
+
+    expect(result.props.id).toBe('stripes-components.metaSection.unknownUser');
+  });
 });
 
 describe('createItemFormatter', () => {

--- a/src/hooks/useInventoryVersionHistory/useInventoryVersionHistory.js
+++ b/src/hooks/useInventoryVersionHistory/useInventoryVersionHistory.js
@@ -25,8 +25,9 @@ export const versionsFormatter = (usersMap, intl, canViewUser) => (diffArray) =>
 
   const getUserName = (userId) => {
     const user = usersMap[userId];
+    const { firstName, lastName = '' } = (user?.personal || {});
 
-    return user ? `${user.personal.lastName}, ${user.personal.firstName}` : null;
+    return firstName ? `${lastName}, ${firstName}` : (lastName || anonymousUserLabel);
   };
 
   const getSourceLink = (userId) => {
@@ -44,7 +45,7 @@ export const versionsFormatter = (usersMap, intl, canViewUser) => (diffArray) =>
       isOriginal: action === ACTIONS.CREATE,
       eventDate: formatDateTime(eventDate, intl),
       source: getSourceLink(userId),
-      userName: getUserName(userId) || anonymousUserLabel,
+      userName: getUserName(userId),
       fieldChanges: diff ? getChangedFieldsList(diff) : [],
       eventId,
       eventTs,


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
Source not displaying in Inventory version history for circ actions taken in different tenant.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Display unknownUser when neither firstName or lastName is missed.
  
## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->
https://folio-org.atlassian.net/browse/UIIN-3617

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
