### PR TITLE
UIIN-3658: Fetch items when holding accordion is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Show error message when edit URLs are with invalid UUIDs. Fixes UIIN-3604.
 * ECS | Show child and parent of shared Instance when Instance from Member tenant. Fixes UIIN-3642.
 * Source not displaying in Inventory version history for circ actions taken in different tenant. Fixes UIIN-3617.
+* Fetch items when holding accordion is open. Fixes UIIN-3658.
 
 ## [14.0.1](https://github.com/folio-org/ui-inventory/tree/v14.0.1) (2026-05-06)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v14.0.0...v14.0.1)

--- a/src/Instance/HoldingsList/Holding/Holding.js
+++ b/src/Instance/HoldingsList/Holding/Holding.js
@@ -79,6 +79,7 @@ const Holding = ({
         tenantId={tenantId}
         isBarcodeAsHotlink={isBarcodeAsHotlink}
         isItemsMovement={isItemsMovement}
+        pathToAccordionsState={pathToAccordionsState}
       />
     </HoldingAccordion>
   );

--- a/src/Instance/HoldingsList/Holding/HoldingAccordion.js
+++ b/src/Instance/HoldingsList/Holding/HoldingAccordion.js
@@ -19,7 +19,7 @@ import { useLocationsQuery } from '@folio/stripes-inventory-components';
 import { HoldingButtonsGroup } from './HoldingButtonsGroup';
 import HoldingAccordionLabel from './HoldingAccordionLabel';
 
-import { useHoldingItemsQuery } from '../../../hooks';
+import { useHoldingItemsQuery, useHoldingsFromStorage } from '../../../hooks';
 
 const CustomAccordionHeader = ({
   withMoveHoldingCheckbox = false,
@@ -83,6 +83,7 @@ const HoldingAccordion = ({
   onViewHolding,
   onAddItem,
   tenantId,
+  instanceId,
   isHoldingSelected,
   onSelectHolding,
   showViewHoldingsButton,
@@ -100,8 +101,20 @@ const HoldingAccordion = ({
     offset: 0,
   };
 
+  const [accordionStatus] = useHoldingsFromStorage({ defaultValue: {} });
   const pathToAccordion = [...pathToAccordionsState, holding?.id];
-  const { totalRecords, isFetching } = useHoldingItemsQuery(holding?.id, { searchParams, key: 'itemCount', tenantId });
+  const memberTenantAccId = `${tenantId}.${instanceId}`;
+  const isMemberAccOpen = accordionStatus[memberTenantAccId];
+
+  const { totalRecords, isFetching } = useHoldingItemsQuery(
+    holding?.id,
+    {
+      searchParams,
+      key: 'itemCount',
+      tenantId,
+      enabled: isMemberAccOpen,
+    },
+  );
   const { locations } = useLocationsQuery({ tenantId });
 
   if (!locations) return null;
@@ -194,6 +207,7 @@ HoldingAccordion.propTypes = {
   onViewHolding: PropTypes.func.isRequired,
   onAddItem: PropTypes.func.isRequired,
   tenantId: PropTypes.string,
+  instanceId: PropTypes.string,
   isHoldingSelected: PropTypes.bool,
   onSelectHolding: PropTypes.func,
   showViewHoldingsButton: PropTypes.bool,

--- a/src/Instance/HoldingsList/consortium/LimitedHolding/LimitedHolding.js
+++ b/src/Instance/HoldingsList/consortium/LimitedHolding/LimitedHolding.js
@@ -18,7 +18,7 @@ import {
   AddItemButton,
   ItemsCountBadge,
 } from '../../Holding';
-import { useConsortiumItems } from '../../../../hooks';
+import { useConsortiumItems, useHoldingsFromStorage } from '../../../../hooks';
 
 import { hasMemberTenantPermission } from '../../../../utils';
 import {
@@ -43,10 +43,20 @@ const LimitedHolding = ({
   const pathToAccordion = [...pathToAccordionsState, holding?.id];
   const accId = pathToAccordion.join('.');
 
+  const [accordionStatus] = useHoldingsFromStorage({ defaultValue: {} });
+  const memberTenantAccId = `${tenantId}.${instanceId}`;
+  const isMemberAccOpen = accordionStatus[memberTenantAccId];
+  const isHoldingAccOpen = accordionStatus[accId];
+
   const canViewHoldingsAndItems = hasMemberTenantPermission('ui-inventory.instance.view', tenantId, userTenantPermissions);
   const canCreateItem = hasMemberTenantPermission('ui-inventory.item.create', tenantId, userTenantPermissions);
 
-  const { totalRecords: itemCount } = useConsortiumItems(instance.id, holding.id, tenantId, { searchParams: { limit: 0 } });
+  const { totalRecords: itemCount } = useConsortiumItems(
+    instance.id,
+    holding.id,
+    tenantId,
+    { enabled: isMemberAccOpen, searchParams: { limit: 0 } },
+  );
 
   const onViewHolding = useCallback(() => {
     navigateToHoldingsViewPage(history, location, instanceId, holding, tenantId, stripes.okapi.tenant);
@@ -98,6 +108,7 @@ const LimitedHolding = ({
         holding={holding}
         tenantId={tenantId}
         userTenantPermissions={userTenantPermissions}
+        enabled={isHoldingAccOpen && isMemberAccOpen}
       />
     </Accordion>
   );

--- a/src/Instance/ItemsList/ItemsList.js
+++ b/src/Instance/ItemsList/ItemsList.js
@@ -28,6 +28,7 @@ import {
 } from '../../dnd';
 import {
   useHoldingItemsQuery,
+  useHoldingsFromStorage,
   useOrderManagement,
 } from '../../hooks';
 import { OrderManagementContext } from '../../contexts';
@@ -55,6 +56,7 @@ const ItemsList = ({
   tenantId,
   isBarcodeAsHotlink,
   isItemsMovement = false,
+  pathToAccordionsState,
 }) => {
   const intl = useIntl();
 
@@ -67,6 +69,13 @@ const ItemsList = ({
     isItemsDragSelected: ifItemsSelected,
   } = useSelection();
 
+  const [accordionStatus] = useHoldingsFromStorage({ defaultValue: {} });
+  const pathToAccordion = [...pathToAccordionsState, holding?.id];
+  const accId = pathToAccordion.join('.');
+  const memberTenantAccId = `${tenantId}.${instanceId}`;
+  const isMemberAccOpen = accordionStatus[memberTenantAccId];
+  const isHoldingAccOpen = accordionStatus[accId];
+
   const [offset, setOffset] = useState(0);
   const [sortByQuery, setSortByQuery] = useState(DEFAULT_ITEM_TABLE_SORTBY_FIELD);
   const searchParams = useMemo(() => ({
@@ -75,8 +84,24 @@ const ItemsList = ({
     offset,
   }), [isItemsMovement, sortByQuery, offset]);
 
-  const { items, isFetching } = useHoldingItemsQuery(holding.id, { searchParams, key: 'items', tenantId });
-  const { totalRecords: total = 0 } = useHoldingItemsQuery(holding.id, { searchParams: { limit: 0 }, key: 'itemCount', tenantId });
+  const { items, isFetching } = useHoldingItemsQuery(
+    holding.id,
+    {
+      searchParams,
+      key: 'items',
+      tenantId,
+      enabled: isHoldingAccOpen && isMemberAccOpen,
+    },
+  );
+  const { totalRecords: total = 0 } = useHoldingItemsQuery(
+    holding.id,
+    {
+      searchParams: { limit: 0 },
+      key: 'itemCount',
+      tenantId,
+      enabled: isHoldingAccOpen && isMemberAccOpen,
+    },
+  );
   const { boundWithHoldings: holdings } = useBoundWithHoldings(items, tenantId);
   const { registerOrderManagement } = useContext(OrderManagementContext);
 
@@ -267,6 +292,7 @@ ItemsList.propTypes = {
   tenantId: PropTypes.string.isRequired,
   isBarcodeAsHotlink: PropTypes.bool,
   isItemsMovement: PropTypes.bool,
+  pathToAccordionsState: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default ItemsList;

--- a/src/Instance/ItemsList/consortium/LimitedItemsList/LimitedItemsList.js
+++ b/src/Instance/ItemsList/consortium/LimitedItemsList/LimitedItemsList.js
@@ -26,6 +26,7 @@ const LimitedItemsList = ({
   holding,
   tenantId,
   userTenantPermissions,
+  enabled,
 }) => {
   const intl = useIntl();
   const location = useLocation();
@@ -48,7 +49,12 @@ const LimitedItemsList = ({
     items,
     totalRecords,
     isFetching,
-  } = useConsortiumItems(instance.id, holding.id, tenantId, { searchParams });
+  } = useConsortiumItems(
+    instance.id,
+    holding.id,
+    tenantId,
+    { enabled, searchParams },
+  );
 
   const onNeedMoreData = (askAmount, _index, _firstIndex, direction) => {
     const amount = (direction === 'next') ? askAmount : -askAmount;
@@ -156,6 +162,7 @@ LimitedItemsList.propTypes = {
   holding: PropTypes.object.isRequired,
   tenantId: PropTypes.string.isRequired,
   userTenantPermissions: PropTypes.arrayOf(PropTypes.object).isRequired,
+  enabled: PropTypes.bool,
 };
 
 export default LimitedItemsList;

--- a/src/Instance/ItemsList/tests/ItemsList.test.js
+++ b/src/Instance/ItemsList/tests/ItemsList.test.js
@@ -86,6 +86,7 @@ const ItemsListSetup = ({ isItemsMovement }) => (
                 <ItemsList
                   holding={holdingsRecordsFixture[0]}
                   isItemsMovement={isItemsMovement}
+                  pathToAccordionsState={[]}
                 />
               </OrderManagementProvider>
             </SelectionProvider>

--- a/src/hooks/useConsortiumItems/useConsortiumItems.js
+++ b/src/hooks/useConsortiumItems/useConsortiumItems.js
@@ -6,7 +6,12 @@ import {
   useOkapiKy,
 } from '@folio/stripes/core';
 
-const useConsortiumItems = (instanceId, holdingsRecordId, tenant, { searchParams } = {}) => {
+const useConsortiumItems = (
+  instanceId,
+  holdingsRecordId,
+  tenant,
+  { searchParams, enabled = true } = {},
+) => {
   const stripes = useStripes();
   const consortium = stripes.user?.user?.consortium;
   const centralTenantId = consortium?.centralTenantId;
@@ -25,7 +30,7 @@ const useConsortiumItems = (instanceId, holdingsRecordId, tenant, { searchParams
           ...searchParams,
         },
       }).json(),
-    enabled: Boolean(centralTenantId && instanceId && holdingsRecordId && tenant),
+    enabled: Boolean(centralTenantId && instanceId && holdingsRecordId && tenant && enabled),
   });
 
   return {

--- a/src/hooks/useHoldingItemsQuery.js
+++ b/src/hooks/useHoldingItemsQuery.js
@@ -16,7 +16,12 @@ import { useTenantKy } from '../common';
 
 const useHoldingItemsQuery = (
   holdingsRecordId,
-  options = { searchParams: {}, key: 'items', tenantId: null },
+  options = {
+    searchParams: {},
+    key: 'items',
+    tenantId: null,
+    enabled: true,
+  },
 ) => {
   const [sortBy, setSortBy] = useState(`${DEFAULT_ITEM_TABLE_SORTBY_FIELD}/sort.ascending`);
   const ky = useTenantKy({ tenantId: options.tenantId }).extend({ timeout: false });


### PR DESCRIPTION
## Purpose
* This PR adds support for fetching item data when the holding accordion is open in ui-inventory.

## Approach
* This change addresses the issue where item data was not being loaded consistently when the user opened the holding accordion, improving UX and aligning item retrieval with accordion state.
- Ensures item fetch occurs only when the holding accordion panel is expanded
- Improves data loading behavior for inventory holdings
- Prevents unnecessary fetches when the accordion is collapsed

## Refs
[UIIN-3658](https://folio-org.atlassian.net/browse/UIIN-3658)

## Screenshots
https://github.com/user-attachments/assets/17fa023b-1027-49ae-8186-719ba9ca51d3



