### PR TITLE
[UIIN-3631] "Add Bound with and analytics" is disabled for new items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Source not displaying in Inventory version history for circ actions taken in different tenant. Fixes UIIN-3617.
 * Fetch items when holding accordion is open. Fixes UIIN-3658.
+* "Add Bound with and analytics" is disabled when creating a new item. Fixes UIIN-3631.
 
 ## [14.0.2](https://github.com/folio-org/ui-inventory/tree/v14.0.2) (2026-05-21)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v14.0.1...v14.0.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Source not displaying in Inventory version history for circ actions taken in different tenant. Fixes UIIN-3617.
 * Fetch items when holding accordion is open. Fixes UIIN-3658.
-* "Add Bound with and analytics" is disabled when creating a new item. Fixes UIIN-3631.
+* "Add Bound with and analytics" button is not shown when creating a new item. Fixes UIIN-3631.
 
 ## [14.0.2](https://github.com/folio-org/ui-inventory/tree/v14.0.2) (2026-05-21)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v14.0.1...v14.0.2)

--- a/src/edit/items/repeatableFields/BoundWithTitlesFields.js
+++ b/src/edit/items/repeatableFields/BoundWithTitlesFields.js
@@ -139,15 +139,16 @@ const BoundWithTitlesFields = ({
         canAdd={false}
         onRemove={false}
       />
-      <Button
-        data-testid="bound-with-add-button"
-        type="button"
-        align="end"
-        onClick={() => setBoundWithModalOpen(true)}
-        disabled={!item.id}
-      >
-        <FormattedMessage id="ui-inventory.boundWithTitles.add" />
-      </Button>
+      {item.id && (
+        <Button
+          data-testid="bound-with-add-button"
+          type="button"
+          align="end"
+          onClick={() => setBoundWithModalOpen(true)}
+        >
+          <FormattedMessage id="ui-inventory.boundWithTitles.add" />
+        </Button>
+      )}
       <BoundWithModal
         item={item}
         open={isBoundWithModalOpen}

--- a/src/edit/items/repeatableFields/BoundWithTitlesFields.js
+++ b/src/edit/items/repeatableFields/BoundWithTitlesFields.js
@@ -128,6 +128,8 @@ const BoundWithTitlesFields = ({
     </Row>
   );
 
+  if (!item.id) return null;
+
   return (
     <>
       <FieldArray
@@ -139,16 +141,14 @@ const BoundWithTitlesFields = ({
         canAdd={false}
         onRemove={false}
       />
-      {item.id && (
-        <Button
-          data-testid="bound-with-add-button"
-          type="button"
-          align="end"
-          onClick={() => setBoundWithModalOpen(true)}
-        >
-          <FormattedMessage id="ui-inventory.boundWithTitles.add" />
-        </Button>
-      )}
+      <Button
+        data-testid="bound-with-add-button"
+        type="button"
+        align="end"
+        onClick={() => setBoundWithModalOpen(true)}
+      >
+        <FormattedMessage id="ui-inventory.boundWithTitles.add" />
+      </Button>
       <BoundWithModal
         item={item}
         open={isBoundWithModalOpen}

--- a/src/edit/items/repeatableFields/BoundWithTitlesFields.js
+++ b/src/edit/items/repeatableFields/BoundWithTitlesFields.js
@@ -144,6 +144,7 @@ const BoundWithTitlesFields = ({
         type="button"
         align="end"
         onClick={() => setBoundWithModalOpen(true)}
+        disabled={!item.id}
       >
         <FormattedMessage id="ui-inventory.boundWithTitles.add" />
       </Button>

--- a/src/edit/items/repeatableFields/tests/BoundWithTitlesFields.test.js
+++ b/src/edit/items/repeatableFields/tests/BoundWithTitlesFields.test.js
@@ -58,7 +58,7 @@ const initialValues = {
 const renderBoundWithTitlesFields = (props = {}) => {
   const component = (
     <BoundWithTitlesFields
-      item={{}}
+      item={{ id: 123 }}
       addBoundWithTitles={addBoundWithTitlesProp}
       {...props}
     />

--- a/src/edit/items/repeatableFields/tests/BoundWithTitlesFields.test.js
+++ b/src/edit/items/repeatableFields/tests/BoundWithTitlesFields.test.js
@@ -144,7 +144,7 @@ describe('BoundWithTitlesFields', () => {
 
   describe("when item's holdingsRecordId is equal to added briefHoldingsRecord id", () => {
     it('trash icon for this field should be disabled', () => {
-      const { getByRole } = renderBoundWithTitlesFields({ item: { holdingsRecordId: 'holdingsId' } });
+      const { getByRole } = renderBoundWithTitlesFields({ item: { id: 123, holdingsRecordId: 'holdingsId' } });
 
       const deleteButton = getByRole('button', { name: /delete this item/i });
 
@@ -154,7 +154,7 @@ describe('BoundWithTitlesFields', () => {
 
   describe("when item's holdingsRecordId is not equal to added briefHoldingsRecord id", () => {
     it('trash icon for this field should be active', () => {
-      const { getByRole } = renderBoundWithTitlesFields({ item: { holdingsRecordId: 'holdingsId1' } });
+      const { getByRole } = renderBoundWithTitlesFields({ item: { id: 123, holdingsRecordId: 'holdingsId1' } });
 
       const deleteButton = getByRole('button', { name: /delete this item/i });
 


### PR DESCRIPTION
This button is enabled when editing an existing item, but not when creating a new one.