### PR TITLE
Move UIIN-3631 change-log entry up into IN PROGRESS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 ## 14.1.0 IN PROGRESS
 
 * Source not displaying in Inventory version history for circ actions taken in different tenant. Fixes UIIN-3617.
+* "Add Bound with and analytics" button is not shown when creating a new item. Fixes UIIN-3631.
 
 ## [14.0.3](https://github.com/folio-org/ui-inventory/tree/v14.0.3) (2026-05-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v14.0.2...v14.0.3)
 
 * Fetch items when holding accordion is open. Fixes UIIN-3658.
-* "Add Bound with and analytics" button is not shown when creating a new item. Fixes UIIN-3631.
 
 ## [14.0.2](https://github.com/folio-org/ui-inventory/tree/v14.0.2) (2026-05-21)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v14.0.1...v14.0.2)


### PR DESCRIPTION
While I was doing the PR dance for UIIN-3631, v14.0.3 got released, so I merged the changes from master into my branch. What I didn't realise is that this resulted in the change-log entry for UIIN-3631 being wrongly listed as belonging to the just-released v14.0.3. This PR moved that entry up where it belongs.