### PR TITLE
UIIN-3668: Render items under Holdings accordion in Inventory instance detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory
 
+## 13.0.16 (IN PROGRESS)
+
+* Render items under Holdings accordion in Inventory instance detail view. Fixes UIIN-3668.
+
 ## [13.0.15](https://github.com/folio-org/ui-inventory/tree/v13.0.15) (2026-05-25)
 
 * Reduce the amount of calls when many holdings exist in several tenants. Fixes UIIN-3660.

--- a/src/Instance/ItemsList/ItemsListContainer.js
+++ b/src/Instance/ItemsList/ItemsListContainer.js
@@ -6,6 +6,8 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 
+import { useStripes } from '@folio/stripes/core';
+
 import DnDContext from '../DnDContext';
 import ItemsList from './ItemsList';
 
@@ -21,6 +23,7 @@ const ItemsListContainer = ({
   isBarcodeAsHotlink,
   pathToAccordionsState,
 }) => {
+  const stripes = useStripes();
   const {
     selectItemsForDrag,
     isItemsDragSelected,
@@ -42,9 +45,26 @@ const ItemsListContainer = ({
   const accId = pathToAccordion.join('.');
   const [accordionStatus] = useHoldingsFromStorage({ defaultValue: {} });
   const isHoldingAccOpen = accordionStatus[accId] || false;
+  const isConsortiumMode = stripes.hasInterface('consortia');
+  const enabled = isConsortiumMode ? isHoldingAccOpen : true;
 
-  const { isFetching, items } = useHoldingItemsQuery(holding.id, { searchParams, tenantId, enabled: isHoldingAccOpen });
-  const { totalRecords } = useHoldingItemsQuery(holding.id, { searchParams: { limit: 0 }, key: 'itemCount', tenantId });
+  const { isFetching, items } = useHoldingItemsQuery(
+    holding.id,
+    {
+      searchParams,
+      tenantId,
+      enabled,
+    },
+  );
+  const { totalRecords } = useHoldingItemsQuery(
+    holding.id,
+    {
+      searchParams: { limit: 0 },
+      key: 'itemCount',
+      tenantId,
+      enabled,
+    },
+  );
 
   useEffect(() => {
     setItemsToShow(items);


### PR DESCRIPTION
## PR Summary
* This change updates ui-inventory so item queries in `ItemsListContainer` are enabled conditionally based on consortium mode and accordion state.

### What changed
- In `src/Instance/ItemsList/ItemsListContainer.js`
  - Added `isConsortiumMode` based on `stripes.hasInterface('consortia')`
  - Added `enabled` condition:
    - `true` when not in consortium mode
    - `isHoldingAccOpen` when in consortium mode
  - Passed `enabled` into both `useHoldingItemsQuery` calls

### Why
- Ensures item fetching only happens for opened holding accordions in consortium mode
- Keeps normal behavior for non-consortium users by always enabling queries

### Notes
- No UI or prop changes were introduced beyond the query enablement logic
- This should prevent unnecessary item requests when a consortium user collapses a holding accordion

### Links
[UIIN-3668](https://folio-org.atlassian.net/browse/UIIN-3668)