### PR TITLE
UIIN-3665: Move number generator options capability to 'manage' column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Source not displaying in Inventory version history for circ actions taken in different tenant. Fixes UIIN-3617.
 * "Add Bound with and analytics" button is not shown when creating a new item. Fixes UIIN-3631.
 * Translate all status-action entries in `<ItemStatusMenu>`. Fixes UIIN-3666.
+* Place "Manage number generator options" capability checkbox in the `manage` column instead of `view`. Fixes UIIN-3665.
 
 ## [14.0.3](https://github.com/folio-org/ui-inventory/tree/v14.0.3) (2026-05-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v14.0.2...v14.0.3)

--- a/package.json
+++ b/package.json
@@ -595,8 +595,9 @@
         "visible": false
       },
       {
-        "permissionName": "ui-inventory.settings.manage-number-generator-options",
+        "permissionName": "ui-inventory.settings.number-generator-options.manage",
         "displayName": "Settings (Inventory): Manage number generator options",
+        "replaces": ["ui-inventory.settings.manage-number-generator-options"],
         "subPermissions": [
           "settings.inventory.enabled",
           "mod-settings.entries.collection.get",

--- a/src/settings/InventorySettings/InventorySettings.js
+++ b/src/settings/InventorySettings/InventorySettings.js
@@ -301,7 +301,7 @@ const InventorySettings = (props) => {
             component: NumberGeneratorSettings,
             label: <FormattedMessage id="ui-inventory.numberGenerator.options" />,
             route: 'numberGeneratorOptions',
-            perm: 'ui-inventory.settings.manage-number-generator-options',
+            perm: 'ui-inventory.settings.number-generator-options.manage',
           },
         ]
       },

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -791,7 +791,7 @@
   "permission.settings.single-record-import": "Settings (Inventory): Configure single-record import",
   "permission.settings.holdings-note-types": "Settings (Inventory): Create, edit, delete holdings note types",
   "permission.settings.item-note-types": "Settings (Inventory): Create, edit, delete item note types",
-  "permission.settings.manage-number-generator-options": "Settings (Inventory): Manage number generator options",
+  "permission.settings.number-generator-options.manage": "Settings (Inventory): Manage number generator options",
   "permission.settings.hrid-handling": "Settings (Inventory): Create, edit and delete HRID handling",
   "permission.instance.view": "Inventory: View instances, holdings, and items",
   "permission.instance.create": "Inventory: View, create instances",


### PR DESCRIPTION
[UIIN-3665](https://folio-org.atlassian.net/browse/UIIN-3665
)
## Purpose
In Settings > Authorization roles, the "Manage number generator options" capability/capability-set for app-inventory renders its checkbox in the view column instead of the manage column.  This misrepresents the permission: the resource lets users view and edit number generator options in Settings (Inventory), so it belongs under manage, not view.

The root cause is naming. `mod-roles-keycloak` derives a capability's action (which column the checkbox lands in) from the last dot-delimited segment of the permission name, and that segment must be a recognized verb (`view`/`edit`/`create`/`delete`/`manage`/`execute`). The existing permission was named `ui-inventory.settings.manage-number-generator-options`, so the generator fell back to the default `view` action and folded the whole string into the resource name.

## Approach
- Move the verb to the end of the permission name so the capability generator parses it correctly.
- Make sure `replaces` is set, references are renamed, and change log is updated

## Screenshots
Before with checkbox in view column on etesting:
<img width="1918" height="1093" alt="UIIN-3665-before-etesting" src="https://github.com/user-attachments/assets/af7cb1ff-fcfc-4da5-bc6b-5de8737fd0a1" />

With fix with checkbox in manage column on local test system:
<img width="1918" height="1093" alt="UIIN-3665-after-local" src="https://github.com/user-attachments/assets/7fdbd179-507c-4d14-9a29-e759550ad717" />
