### PR TITLE
UIIN-3675: Do not show item link, status and 'View holding' button for user without affiliation in Member tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-inventory
 
+## (13.0.18) IN PROGRESS
+* Do not show item link, status and "View holding" button for user without affiliation in Member tenant. Fixes UIIN-3675.
+
 ## [13.0.17](https://github.com/folio-org/ui-inventory/tree/v13.0.17) (2026-06-18)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v13.0.16...v13.0.17)
 * ECS - Render items under Holdings accordion in Inventory instance detail view. Fixes UIIN-3673.

--- a/src/Instance/HoldingsList/consortium/MemberTenantHoldings/MemberTenantHoldings.js
+++ b/src/Instance/HoldingsList/consortium/MemberTenantHoldings/MemberTenantHoldings.js
@@ -41,12 +41,14 @@ const MemberTenantHoldings = ({
   const [accordionStatus, updateAccordionStatus] = useHoldingsFromStorage({ defaultValue: {} });
   const isAccordionOpen = accordionStatus[accordionId] || false;
 
+  const isUserAffiliatedWithMemberTenant = stripes.user.user.tenants?.some(tenant => tenant.id === memberTenantId);
+
   const {
     userPermissions,
     isFetching: isUserTenantPermissionsLoading,
   } = useUserTenantPermissions(
     { tenantId: memberTenantId },
-    { enabled: !!memberTenantId && isAccordionOpen },
+    { enabled: !!memberTenantId && isAccordionOpen && isUserAffiliatedWithMemberTenant },
   );
 
   useEffect(() => {


### PR DESCRIPTION
# Reproducible only on Sunflower ECS Bugfest

## Purpose
* This users who don’t have affiliation in Member tenant are able to see item links and status. If they click on the item barcode or the “View holding” button, the page shows an error and crashes.

## Approach
* Check if user is affiliated with member tenant. If no - do not fetch tenent's permissions and render LimitedHoldingsList instead of  usual HoldingsList

## Refs
[UIIN-3675](https://folio-org.atlassian.net/browse/UIIN-3675)

## Screenshots
https://github.com/user-attachments/assets/2f035656-069a-4770-ad8a-d186e1441809

