### PR TITLE
UIIN-3679: Integrate number generator button for identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Remove button "Generate accession and call numbers" at call number field and add an info popover instead. Refs UIIN-3680.
 * Add number generator settings for Instance Identifier. Refs UIIN-3678.
 * Move menu item "Number generator options" to Section Settings > Inventory > Instances, Holdings, Items. Refs UIIN-3677.
+* Integrate Button "Generate identifier" in Inventory instance records. Refs UIIN-3679.
 
 ## [14.0.3](https://github.com/folio-org/ui-inventory/tree/v14.0.3) (2026-05-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v14.0.2...v14.0.3)

--- a/src/common/hooks/useNumberGeneratorOptions/useNumberGeneratorOptions.js
+++ b/src/common/hooks/useNumberGeneratorOptions/useNumberGeneratorOptions.js
@@ -28,13 +28,14 @@ export const useNumberGeneratorOptions = () => {
     queryKey: [namespace],
     queryFn: async () => {
       const response = await ky.get(MOD_SETTINGS_API, { searchParams }).json();
-      const settingValue = response?.items?.[0]?.value;
+      const settingValue = response?.items?.[0]?.value ?? {};
 
       return {
         accessionNumber: settingValue.accessionNumber || '',
         barcode: settingValue.barcode || '',
         callNumber: settingValue.callNumber || '',
         callNumberHoldings: settingValue.callNumberHoldings || '',
+        identifier: settingValue.identifier || '',
         useSharedNumber: settingValue.useSharedNumber ?? false,
       };
     },

--- a/src/common/hooks/useNumberGeneratorOptions/useNumberGeneratorOptions.test.js
+++ b/src/common/hooks/useNumberGeneratorOptions/useNumberGeneratorOptions.test.js
@@ -12,6 +12,7 @@ import { useOkapiKy } from '@folio/stripes/core';
 import {
   NUMBER_GENERATOR_OPTIONS_OFF,
   NUMBER_GENERATOR_OPTIONS_ON_EDITABLE,
+  NUMBER_GENERATOR_OPTIONS_ON_NOT_EDITABLE,
   NUMBER_GENERATOR_SETTINGS_KEY,
   NUMBER_GENERATOR_SETTINGS_SCOPE,
 } from '../../../settings/NumberGeneratorSettings/constants';
@@ -29,6 +30,7 @@ const NUMBER_GENERATOR = {
   accessionNumber: NUMBER_GENERATOR_OPTIONS_ON_EDITABLE,
   callNumber: NUMBER_GENERATOR_OPTIONS_ON_EDITABLE,
   callNumberHoldings: '',
+  identifier: NUMBER_GENERATOR_OPTIONS_ON_NOT_EDITABLE,
   useSharedNumber: false,
 };
 
@@ -41,6 +43,8 @@ const mockData = {
 
 describe('useNumberGeneratorOptions', () => {
   beforeEach(() => {
+    queryClient.clear();
+
     useOkapiKy
       .mockClear()
       .mockReturnValue({
@@ -59,5 +63,31 @@ describe('useNumberGeneratorOptions', () => {
       isLoading: false,
       data: NUMBER_GENERATOR,
     }));
+  });
+
+  describe('when no settings have been saved yet', () => {
+    it('should resolve with default empty values', async () => {
+      useOkapiKy.mockReturnValue({
+        get: () => ({
+          json: () => Promise.resolve({ items: [] }),
+        }),
+      });
+
+      const { result } = renderHook(() => useNumberGeneratorOptions(), { wrapper });
+
+      await waitFor(() => expect(result.current.isLoading).toBeFalsy());
+
+      expect(result.current).toEqual(expect.objectContaining({
+        isLoading: false,
+        data: {
+          accessionNumber: '',
+          barcode: '',
+          callNumber: '',
+          callNumberHoldings: '',
+          identifier: '',
+          useSharedNumber: false,
+        },
+      }));
+    });
   });
 });

--- a/src/edit/InstanceForm.js
+++ b/src/edit/InstanceForm.js
@@ -954,8 +954,8 @@ const InstanceFormContainer = (props) => {
 
   return (
     <ConnectedInstanceForm
-      numberGeneratorData={numberGeneratorData}
       {...props}
+      numberGeneratorData={numberGeneratorData}
     />
   );
 };

--- a/src/edit/InstanceForm.js
+++ b/src/edit/InstanceForm.js
@@ -76,6 +76,8 @@ import {
   validateDates,
 } from '../validation';
 
+import { useNumberGeneratorOptions } from '../common/hooks';
+
 import ParentInstanceFields from '../Instance/InstanceEdit/ParentInstanceFields';
 import ChildInstanceFields from '../Instance/InstanceEdit/ChildInstanceFields';
 import { getPublishingInfo } from '../Instance/ViewInstance/utils';
@@ -211,6 +213,7 @@ class InstanceForm extends React.Component {
     id: PropTypes.string,
     httpError: PropTypes.object,
     form: PropTypes.object.isRequired,
+    numberGeneratorData: PropTypes.object,
   };
 
   static defaultProps = {
@@ -397,6 +400,7 @@ class InstanceForm extends React.Component {
       history,
       httpError,
       id,
+      numberGeneratorData,
     } = this.props;
 
     const refLookup = (referenceTable, recordId) => {
@@ -752,6 +756,7 @@ class InstanceForm extends React.Component {
                             canAdd={!this.isFieldBlocked('identifiers')}
                             canEdit={!this.isFieldBlocked('identifiers')}
                             canDelete={!this.isFieldBlocked('identifiers')}
+                            numberGeneratorData={numberGeneratorData}
                           />
                         </Accordion>
                         <Accordion
@@ -939,7 +944,20 @@ class InstanceForm extends React.Component {
   }
 }
 
-export default withRouter(stripesFinalForm({
+const ConnectedInstanceForm = withRouter(stripesFinalForm({
   validate,
   navigationCheck: true,
 })(stripesConnect(InstanceForm)));
+
+const InstanceFormContainer = (props) => {
+  const { data: numberGeneratorData } = useNumberGeneratorOptions();
+
+  return (
+    <ConnectedInstanceForm
+      numberGeneratorData={numberGeneratorData}
+      {...props}
+    />
+  );
+};
+
+export default InstanceFormContainer;

--- a/src/edit/InstanceForm.js
+++ b/src/edit/InstanceForm.js
@@ -76,11 +76,10 @@ import {
   validateDates,
 } from '../validation';
 
-import { useNumberGeneratorOptions } from '../common/hooks';
-
 import ParentInstanceFields from '../Instance/InstanceEdit/ParentInstanceFields';
 import ChildInstanceFields from '../Instance/InstanceEdit/ChildInstanceFields';
 import { getPublishingInfo } from '../Instance/ViewInstance/utils';
+import { withNumberGeneratorOptions } from '../hocs';
 import DateFields from './dateFields';
 
 import styles from './InstanceForm.css';
@@ -949,15 +948,4 @@ const ConnectedInstanceForm = withRouter(stripesFinalForm({
   navigationCheck: true,
 })(stripesConnect(InstanceForm)));
 
-const InstanceFormContainer = (props) => {
-  const { data: numberGeneratorData } = useNumberGeneratorOptions();
-
-  return (
-    <ConnectedInstanceForm
-      {...props}
-      numberGeneratorData={numberGeneratorData}
-    />
-  );
-};
-
-export default InstanceFormContainer;
+export default withNumberGeneratorOptions(ConnectedInstanceForm);

--- a/src/edit/identifierFields.js
+++ b/src/edit/identifierFields.js
@@ -1,12 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FieldArray } from 'react-final-form-arrays';
-import { Field } from 'react-final-form';
+import {
+  Field,
+  useForm,
+} from 'react-final-form';
 import {
   FormattedMessage,
   useIntl,
 } from 'react-intl';
 
+
+import { NumberGeneratorModalButton } from '@folio/service-interaction';
 import {
   Row,
   Col,
@@ -16,13 +21,21 @@ import {
   TextField,
 } from '@folio/stripes/components';
 
+import {
+  IDENTIFIER_SETTING,
+  NUMBER_GENERATOR_OPTIONS_ON_EDITABLE,
+  NUMBER_GENERATOR_OPTIONS_ON_NOT_EDITABLE,
+} from '../settings/NumberGeneratorSettings/constants';
+
 const IdentifierFields = ({
   identifierTypes = [],
   canAdd = true,
   canEdit = true,
   canDelete = true,
+  numberGeneratorData,
 }) => {
   const { formatMessage } = useIntl();
+  const { change } = useForm();
 
   const identifierTypeOptions = identifierTypes.map(it => ({
     label: it.name,
@@ -31,6 +44,9 @@ const IdentifierFields = ({
 
   const typeLabel = formatMessage({ id: 'ui-inventory.type' });
   const identifierLabel = formatMessage({ id: 'ui-inventory.identifier' });
+  const isIdentifierDisabled = numberGeneratorData?.[IDENTIFIER_SETTING] === NUMBER_GENERATOR_OPTIONS_ON_NOT_EDITABLE;
+  const showNumberGeneratorForIdentifier = isIdentifierDisabled ||
+      numberGeneratorData?.[IDENTIFIER_SETTING] === NUMBER_GENERATOR_OPTIONS_ON_EDITABLE;
 
   const headLabels = (
     <Row>
@@ -47,7 +63,7 @@ const IdentifierFields = ({
     </Row>
   );
 
-  const renderField = field => (
+  const renderField = (field, index) => (
     <Row>
       <Col sm={6}>
         <Field
@@ -65,9 +81,21 @@ const IdentifierFields = ({
           ariaLabel={identifierLabel}
           name={`${field}.value`}
           component={TextField}
-          disabled={!canEdit}
+          disabled={!canEdit || isIdentifierDisabled}
           required
         />
+        {showNumberGeneratorForIdentifier &&
+          <NumberGeneratorModalButton
+            buttonLabel={<FormattedMessage id="ui-inventory.numberGenerator.generateIdentifier" />}
+            callback={(generated) => change(`${field}.value`, generated)}
+            id={`number_generator_identifier_${index}`}
+            generateButtonLabel={<FormattedMessage id="ui-inventory.numberGenerator.generateIdentifier" />}
+            generator="inventory_instanceIdentifier"
+            modalProps={{
+              label: <FormattedMessage id="ui-inventory.numberGenerator.generateIdentifier" />
+            }}
+          />
+        }
       </Col>
     </Row>
   );
@@ -92,6 +120,7 @@ IdentifierFields.propTypes = {
   canAdd: PropTypes.bool,
   canEdit: PropTypes.bool,
   canDelete: PropTypes.bool,
+  numberGeneratorData: PropTypes.object,
 };
 
 export default IdentifierFields;

--- a/src/edit/identifierFields.test.js
+++ b/src/edit/identifierFields.test.js
@@ -23,7 +23,7 @@ const props = {
   identifierTypes: [{ name: 'identifyName', id: '129459' }]
 };
 
-const Form = ({ handleSubmit, identifierFieldsProps }) => (
+const Form = ({ handleSubmit, identifierFieldsProps = {} }) => (
   <form onSubmit={handleSubmit}>
     <IdentifierFields {...props} {...identifierFieldsProps} />
   </form>
@@ -32,10 +32,6 @@ const Form = ({ handleSubmit, identifierFieldsProps }) => (
 Form.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
   identifierFieldsProps: PropTypes.object,
-};
-
-Form.defaultProps = {
-  identifierFieldsProps: {},
 };
 
 const WrappedForm = stripesFinalForm({

--- a/src/edit/identifierFields.test.js
+++ b/src/edit/identifierFields.test.js
@@ -7,6 +7,11 @@ import stripesFinalForm from '@folio/stripes/final-form';
 import renderWithRouter from '../../test/jest/helpers/renderWithRouter';
 import renderWithIntl from '../../test/jest/helpers/renderWithIntl';
 
+import {
+  NUMBER_GENERATOR_OPTIONS_OFF,
+  NUMBER_GENERATOR_OPTIONS_ON_EDITABLE,
+  NUMBER_GENERATOR_OPTIONS_ON_NOT_EDITABLE,
+} from '../settings/NumberGeneratorSettings/constants';
 import IdentifierFields from './identifierFields';
 import translationsProperties from '../../test/jest/helpers/translationsProperties';
 
@@ -18,14 +23,19 @@ const props = {
   identifierTypes: [{ name: 'identifyName', id: '129459' }]
 };
 
-const Form = ({ handleSubmit }) => (
+const Form = ({ handleSubmit, identifierFieldsProps }) => (
   <form onSubmit={handleSubmit}>
-    <IdentifierFields {...props} />
+    <IdentifierFields {...props} {...identifierFieldsProps} />
   </form>
 );
 
 Form.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
+  identifierFieldsProps: PropTypes.object,
+};
+
+Form.defaultProps = {
+  identifierFieldsProps: {},
 };
 
 const WrappedForm = stripesFinalForm({
@@ -34,8 +44,8 @@ const WrappedForm = stripesFinalForm({
   canDelete: true,
 })(Form);
 
-const renderIdentifierFields = () => renderWithIntl(
-  renderWithRouter(<WrappedForm onSubmit={onSubmit} />),
+const renderIdentifierFields = (identifierFieldsProps = {}) => renderWithIntl(
+  renderWithRouter(<WrappedForm onSubmit={onSubmit} identifierFieldsProps={identifierFieldsProps} />),
   translationsProperties,
 );
 
@@ -56,5 +66,45 @@ describe('IdentifierFields', () => {
     expect(myText).toHaveValue('');
     fireEvent.change(myText, { target: { value: 'Enter text' } });
     expect(myText).toHaveValue('Enter text');
+  });
+
+  describe('Number generator button', () => {
+    const addIdentifier = () => fireEvent.click(screen.getByText('Add identifier'));
+
+    describe('when number generator settings for identifier is "onNotEditable"', () => {
+      it('should render generate identifier button and disable identifier field', () => {
+        renderIdentifierFields({
+          numberGeneratorData: { identifier: NUMBER_GENERATOR_OPTIONS_ON_NOT_EDITABLE },
+        });
+        addIdentifier();
+
+        expect(screen.getByRole('button', { name: 'Generate identifier' })).toBeInTheDocument();
+        expect(screen.getByRole('textbox')).toBeDisabled();
+      });
+    });
+
+    describe('when number generator settings for identifier is "onEditable"', () => {
+      it('should render generate identifier button and enable identifier field', () => {
+        renderIdentifierFields({
+          numberGeneratorData: { identifier: NUMBER_GENERATOR_OPTIONS_ON_EDITABLE },
+        });
+        addIdentifier();
+
+        expect(screen.getByRole('button', { name: 'Generate identifier' })).toBeInTheDocument();
+        expect(screen.getByRole('textbox')).toBeEnabled();
+      });
+    });
+
+    describe('when number generator settings for identifier is "off"', () => {
+      it('should not render generate identifier button and enable identifier field', () => {
+        renderIdentifierFields({
+          numberGeneratorData: { identifier: NUMBER_GENERATOR_OPTIONS_OFF },
+        });
+        addIdentifier();
+
+        expect(screen.queryByRole('button', { name: 'Generate identifier' })).not.toBeInTheDocument();
+        expect(screen.getByRole('textbox')).toBeEnabled();
+      });
+    });
   });
 });

--- a/src/hocs/index.js
+++ b/src/hocs/index.js
@@ -2,3 +2,4 @@ export { default as withLastSearchTerms } from './withLastSearchTerms/withLastSe
 export { default as withLocation } from './withLocation/withLocation';
 export { withUseResourcesIds } from './withUseResourcesIds/withUseResourcesIds';
 export { default as withSingleRecordImport } from './withSingleRecordImport';
+export { default as withNumberGeneratorOptions } from './withNumberGeneratorOptions';

--- a/src/hocs/withNumberGeneratorOptions/index.js
+++ b/src/hocs/withNumberGeneratorOptions/index.js
@@ -1,0 +1,1 @@
+export { default } from './withNumberGeneratorOptions';

--- a/src/hocs/withNumberGeneratorOptions/withNumberGeneratorOptions.js
+++ b/src/hocs/withNumberGeneratorOptions/withNumberGeneratorOptions.js
@@ -1,0 +1,16 @@
+import { useNumberGeneratorOptions } from '../../common/hooks';
+
+const withNumberGeneratorOptions = (WrappedComponent) => {
+  return (props) => {
+    const { data: numberGeneratorData } = useNumberGeneratorOptions();
+
+    return (
+      <WrappedComponent
+        {...props}
+        numberGeneratorData={numberGeneratorData}
+      />
+    );
+  };
+};
+
+export default withNumberGeneratorOptions;

--- a/src/hocs/withNumberGeneratorOptions/withNumberGeneratorOptions.test.js
+++ b/src/hocs/withNumberGeneratorOptions/withNumberGeneratorOptions.test.js
@@ -1,0 +1,42 @@
+import {
+  render,
+  screen,
+} from '@folio/jest-config-stripes/testing-library/react';
+
+import { useNumberGeneratorOptions } from '../../common/hooks';
+import withNumberGeneratorOptions from './withNumberGeneratorOptions';
+
+jest.mock('../../common/hooks', () => ({
+  useNumberGeneratorOptions: jest.fn(),
+}));
+
+const numberGeneratorData = { identifier: 'identifierGenerator' };
+
+const TestComponent = (props) => (
+  <div>
+    <span>{props.numberGeneratorData?.identifier}</span>
+    <span>{props.otherProp}</span>
+  </div>
+);
+
+describe('withNumberGeneratorOptions', () => {
+  beforeEach(() => {
+    useNumberGeneratorOptions.mockClear().mockReturnValue({ data: numberGeneratorData });
+  });
+
+  it('should pass number generator options to the wrapped component', () => {
+    const WrappedComponent = withNumberGeneratorOptions(TestComponent);
+
+    render(<WrappedComponent />);
+
+    expect(screen.getByText('identifierGenerator')).toBeInTheDocument();
+  });
+
+  it('should pass through the original props', () => {
+    const WrappedComponent = withNumberGeneratorOptions(TestComponent);
+
+    render(<WrappedComponent otherProp="testProp" />);
+
+    expect(screen.getByText('testProp')).toBeInTheDocument();
+  });
+});

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+const mockForwardRef = React.forwardRef;
+
 jest.mock('@folio/stripes/components', () => ({
   ...jest.requireActual('@folio/stripes/components'),
   collapseAllSections: jest.fn(),
@@ -41,9 +43,10 @@ jest.mock('@folio/stripes/components', () => ({
   Loading: () => <div>Loading</div>,
   LoadingPane: () => <div>LoadingPane</div>,
   LoadingView: jest.fn(() => <div>LoadingView</div>),
-  Modal: jest.fn(({ children, open, label, footer, ...rest }) => {
+  Modal: mockForwardRef(({ children, open, label, footer, ...rest }, ref) => {
     return open && (
       <div
+        ref={ref}
         {...rest}
       >
         <h1>{label}</h1>

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -388,6 +388,7 @@
   "numberGenerator.generateAccessionAndCallNumberWarning": "Both accession number and call number will be filled from this action, using a sequence from the Inventory: Accession number generator.",
   "numberGenerator.generateBarcode": "Generate barcode",
   "numberGenerator.generateCallNumber": "Generate call number",
+  "numberGenerator.generateIdentifier": "Generate identifier",
   "numberGenerator.info": "Fields which are usually filled using a numeric sequence can use the number generator. When the generator is switched on the field can either be fixed to prevent manual update, or made fully editable. When switched off, the field must be filled manually.",
   "numberGenerator.infoAdditional": "Additional number generator settings are available under {serviceInteractionLink}. At {numberGeneratorSequencesLink} sequences can be defined by selecting the appropriate generator via the drop-down menu.",
   "numberGenerator.options": "Number generator options",


### PR DESCRIPTION
[UIIN-3679](https://folio-org.atlassian.net/browse/UIIN-3679)

## Purpose

**Description**
For the number generator functionality for Instance identifier a Button "Generate identifier" needs to be displayed underneath the identifier field.
Functionality is the same like other number generators (e.g. item barcode in Inventory item level)
Same capabilities / capability sets apply

**Scenario 1**
- in create/new screen + edit screen + duplicate screen underneath the field Identifier a Button "Generate identifier" is displayed according to the Settings > Inventory > Instance, Holdings, Items > Number generator options
- add identifier is a repeatable field via button "Add identifier" therefore underneath every identifier field in each row the Button "Generate identifier" is displayed (Similar to the buttons “Generate call number” in the additional item call numbers section on item level)

**Scenario 2**
- clicking this button the modal "Generate identifier" is displayed for selecting the Instance identifier sequence to then generate the next number 
- it is the same functionality like other number generators but the Instance identifier sequences are displayed for selection defined prior in Settings > Service interaction > Number generator sequences > Generator Inventory: Instance identifier (Number generator Name = Inventory: Instance identifier / Code = inventory_instanceIdentifier)

**Scenario 3**
- after selecting the sequence in the modal “Generate identifier” and clicking button "Generate identifier" the next number defined by the selected sequence is inserted in the identifier field
- the next value of the selected sequence is increased by one in Settings > Service interaction > Number generator sequences > Inventory: Instance identifier > selected sequence

**Scenario 4**
- clicking “Cancel” in the modal “Generate identifier” modal is closed and no number was generated.

## Approach
- **useNumberGeneratorOptions hook**: added the missing `identifier` field to the returned data. Also guarded against missing settings to avoid a crash when nothing has been saved yet.
- **IdentifierFields**: now accepts `numberGeneratorData` and renders a `NumberGeneratorModalButton` for the `identifier` field, same `onNotEditable/onEditable/off` logic as _barcode_.
- **InstanceForm.js**: since `InstanceForm` (used for edit/create/duplicate) is a class component that can't call hooks, it has been wrapped in a small functional `InstanceFormContainer` that calls the hook and passes `numberGeneratorData` down as a prop.
- **Tests**: updated/added for the hook and for `IdentifierFields`' generator button states.
- **Adapt Test mock**: `Modal` mock wrapped in `forwardRef` (was breaking on the ref `NumberGeneratorModal` forwards to it).

## Refs
- https://folio-org.atlassian.net/browse/UXPROD-5925
- https://folio-org.atlassian.net/browse/UIIN-3677
- https://folio-org.atlassian.net/browse/UIIN-3678
- https://folio-org.atlassian.net/browse/SI-171


## Screenshots

<img width="2751" height="340" alt="image" src="https://github.com/user-attachments/assets/9fec14cc-8a44-4bc3-abe7-7c58432be944" />
