### PR TITLE
UIIN-3686: Show "Source" field in "Version history" for a user not having permissions in Central tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add number generator settings for Instance Identifier. Refs UIIN-3678.
 * Move menu item "Number generator options" to Section Settings > Inventory > Instances, Holdings, Items. Refs UIIN-3677.
 * Update `Instance status term` field when opening instance after updating. Fixes UIIN-3650.
+* Show "Source" field in "Version history" for a user not having permissions in Central tenant. Fixes UIIN-3686.
 
 ## [14.0.3](https://github.com/folio-org/ui-inventory/tree/v14.0.3) (2026-05-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v14.0.2...v14.0.3)

--- a/src/Holding/HoldingVersionHistory/HoldingVersionHistory.js
+++ b/src/Holding/HoldingVersionHistory/HoldingVersionHistory.js
@@ -56,7 +56,11 @@ export const getItemFormatter = (fieldLabelsMap, fieldFormatter) => (element, i)
   );
 };
 
-const HoldingVersionHistory = ({ onClose, holdingId }) => {
+const HoldingVersionHistory = ({
+  onClose,
+  holdingId,
+  isInstanceShared,
+}) => {
   const { formatMessage } = useIntl();
   const referenceData = useContext(DataContext);
 
@@ -72,7 +76,7 @@ const HoldingVersionHistory = ({ onClose, holdingId }) => {
   const {
     actionsMap,
     versions,
-  } = useInventoryVersionHistory(data);
+  } = useInventoryVersionHistory(data, isInstanceShared);
 
   const [totalVersions] = useTotalVersions(totalRecords);
 
@@ -157,6 +161,7 @@ const HoldingVersionHistory = ({ onClose, holdingId }) => {
 HoldingVersionHistory.propTypes = {
   holdingId: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
+  isInstanceShared: PropTypes.bool,
 };
 
 export default HoldingVersionHistory;

--- a/src/Instance/ViewInstance/InstanceVersionHistory/InstanceVersionHistory.js
+++ b/src/Instance/ViewInstance/InstanceVersionHistory/InstanceVersionHistory.js
@@ -49,6 +49,7 @@ const InstanceVersionHistory = ({
   onClose,
   tenantId,
   isSharedFromLocalRecord,
+  isInstanceShared,
 }) => {
   const intl = useIntl();
   const { formatMessage } = intl;
@@ -67,7 +68,7 @@ const InstanceVersionHistory = ({
   const {
     actionsMap,
     versions,
-  } = useInventoryVersionHistory(data);
+  } = useInventoryVersionHistory(data, isInstanceShared);
 
   const [totalVersions] = useTotalVersions(totalRecords);
 
@@ -136,6 +137,7 @@ InstanceVersionHistory.propTypes = {
   onClose: PropTypes.func,
   tenantId: PropTypes.string,
   isSharedFromLocalRecord: PropTypes.bool,
+  isInstanceShared: PropTypes.bool,
 };
 
 export default InstanceVersionHistory;

--- a/src/Instance/ViewInstance/ViewInstancePane/ViewInstancePane.js
+++ b/src/Instance/ViewInstance/ViewInstancePane/ViewInstancePane.js
@@ -78,10 +78,13 @@ const ViewInstancePane = ({
   const { sharedInstances } = useSharedInstancesQuery({ searchParams: { instanceIdentifier: instanceId } });
   const isUserInConsortium = isUserInConsortiumMode(stripes);
 
+  const isInstanceShared = useMemo(
+    () => Boolean(isShared || isInstanceShadowCopy(instance?.source)),
+    [isShared, instance?.source],
+  );
+
   const paneTitle = useMemo(
     () => {
-      const isInstanceShared = Boolean(isShared || isInstanceShadowCopy(instance?.source));
-
       return intl.formatMessage(
         { id: `ui-inventory.${isUserInConsortium ? 'consortia.' : ''}instanceRecordTitle` },
         {
@@ -91,7 +94,7 @@ const ViewInstancePane = ({
         }
       );
     },
-    [isShared, instance?.source, instance?.title, isUserInConsortium, intl],
+    [isInstanceShared, instance?.title, isUserInConsortium, intl],
   );
 
   const paneSubTitle = useMemo(
@@ -207,6 +210,7 @@ const ViewInstancePane = ({
           onClose={() => setIsVersionHistoryOpen(false)}
           tenantId={instance?.tenantId}
           isSharedFromLocalRecord={!!sharedInstances?.[0]}
+          isInstanceShared={isInstanceShared}
         />
       )}
       {helperApp && (

--- a/src/Item/ViewItem/ViewItem.js
+++ b/src/Item/ViewItem/ViewItem.js
@@ -331,6 +331,7 @@ const ViewItem = ({
             item={item}
             tenantId={tenantTo}
             onClose={() => setIsVersionHistoryOpen(false)}
+            isInstanceShared={isInstanceShared || isInstanceShadowCopy(instance.source)}
           />
         )}
       </Paneset>

--- a/src/Item/ViewItem/components/ItemVersionHistory/ItemVersionHistory.js
+++ b/src/Item/ViewItem/components/ItemVersionHistory/ItemVersionHistory.js
@@ -90,6 +90,7 @@ const ItemVersionHistory = ({
   item,
   onClose,
   tenantId,
+  isInstanceShared,
 }) => {
   const { formatMessage } = useIntl();
   const referenceData = useContext(DataContext);
@@ -106,7 +107,7 @@ const ItemVersionHistory = ({
   const {
     actionsMap,
     versions,
-  } = useInventoryVersionHistory(data);
+  } = useInventoryVersionHistory(data, isInstanceShared);
   const { servicePoints } = useItemServicePointsQuery(item.lastCheckIn?.servicePointId);
   const { staffMembers } = useStaffMembersQuery(item.lastCheckIn?.staffMemberId);
 
@@ -202,6 +203,7 @@ ItemVersionHistory.propTypes = {
   item: PropTypes.object.isRequired,
   onClose: PropTypes.func.isRequired,
   tenantId: PropTypes.string,
+  isInstanceShared: PropTypes.bool,
 };
 
 export default ItemVersionHistory;

--- a/src/ViewHoldingsRecord.js
+++ b/src/ViewHoldingsRecord.js
@@ -668,6 +668,7 @@ class ViewHoldingsRecord extends React.Component {
       goTo,
       stripes,
       isVersionHistoryEnabled,
+      isInstanceShared,
     } = this.props;
     const {
       instance,
@@ -1408,6 +1409,7 @@ class ViewHoldingsRecord extends React.Component {
                     <HoldingVersionHistory
                       holdingId={holdingsRecord.id}
                       onClose={() => this.setState({ isVersionHistoryOpen: false })}
+                      isInstanceShared={isInstanceShared || isInstanceShadowCopy(instance.source)}
                     />
                   )}
                 </Paneset>

--- a/src/hooks/useInventoryVersionHistory/useInventoryVersionHistory.js
+++ b/src/hooks/useInventoryVersionHistory/useInventoryVersionHistory.js
@@ -52,16 +52,18 @@ export const versionsFormatter = (usersMap, intl, canViewUser) => (diffArray) =>
     }));
 };
 
-const useInventoryVersionHistory = (data) => {
+const useInventoryVersionHistory = (data, isInstanceShared) => {
   const stripes = useStripes();
   const intl = useIntl();
 
   const [usersId, setUsersId] = useState([]);
   const [usersMap, setUsersMap] = useState({});
 
-  const centralTenantId = stripes.user.user.consortium?.centralTenantId;
+  const tenantId = isInstanceShared
+    ? stripes.user.user.consortium?.centralTenantId
+    : stripes.okapi.tenant;
 
-  const { users } = useUsersBatch(usersId, { tenantId: centralTenantId });
+  const { users } = useUsersBatch(usersId, { tenantId });
 
   const canViewUser = stripes.hasPerm('users.item.get');
 

--- a/src/hooks/useInventoryVersionHistory/useInventoryVersionHistory.test.js
+++ b/src/hooks/useInventoryVersionHistory/useInventoryVersionHistory.test.js
@@ -90,7 +90,7 @@ describe('useInventoryVersionHistory', () => {
       },
     }));
 
-    renderHook(() => useInventoryVersionHistory(data));
+    renderHook(() => useInventoryVersionHistory(data, true));
 
     expect(useUsersBatch).toHaveBeenLastCalledWith(usersId, { tenantId: centralTenantId });
   });


### PR DESCRIPTION
* If instance is shared - send central tenant's id (for Instances, Holdings and Items).
* If instance if local - send current member tenant's id (for Instances, Holdings and Items).

[UIIN-3686](https://folio-org.atlassian.net/browse/UIIN-3686)