### PR TITLE
UIIN-3684: Add more informative label to select/unselect all checkbox in results list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add number generator settings for Instance Identifier. Refs UIIN-3678.
 * Move menu item "Number generator options" to Section Settings > Inventory > Instances, Holdings, Items. Refs UIIN-3677.
 * Update `Instance status term` field when opening instance after updating. Fixes UIIN-3650.
+* Update Inventory results list's select/unselect all checkbox label. Refs UIIN-3684.
 
 ## [14.0.3](https://github.com/folio-org/ui-inventory/tree/v14.0.3) (2026-05-29)
 [Full Changelog](https://github.com/folio-org/ui-inventory/compare/v14.0.2...v14.0.3)

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -1024,7 +1024,7 @@ class InstancesList extends React.Component {
       return intl.formatMessage({ id: 'ui-inventory.instances.rows.unselectAll' }, { count: rowCount });
     }
 
-    return intl.formatMessage({ id: 'ui-inventory.instances.rows.selectAll' }, { count: unselectedRowCount })
+    return intl.formatMessage({ id: 'ui-inventory.instances.rows.selectAll' }, { count: unselectedRowCount });
   };
 
   toggleAllRows = () => {

--- a/src/components/InstancesList/InstancesList.js
+++ b/src/components/InstancesList/InstancesList.js
@@ -1013,6 +1013,20 @@ class InstancesList extends React.Component {
     return parentResources.records.records.every(({ id }) => Object.keys(selectedRows).includes(id));
   };
 
+  getCheckColumnLabel = () => {
+    const { intl, parentResources } = this.props;
+    const { selectedRows } = this.state;
+
+    const rowCount = parentResources.records.records.length;
+    const unselectedRowCount = rowCount - parentResources.records.records.filter(({ id }) => Object.keys(selectedRows).includes(id)).length;
+
+    if (this.getIsAllRowsSelected()) {
+      return intl.formatMessage({ id: 'ui-inventory.instances.rows.unselectAll' }, { count: rowCount });
+    }
+
+    return intl.formatMessage({ id: 'ui-inventory.instances.rows.selectAll' }, { count: unselectedRowCount })
+  };
+
   toggleAllRows = () => {
     const { parentResources } = this.props;
     const { selectedRows } = this.state;
@@ -1042,7 +1056,7 @@ class InstancesList extends React.Component {
       select: !this.state.isSelectedRecordsModalOpened && (
         <Checkbox
           checked={this.getIsAllRowsSelected()}
-          aria-label={intl.formatMessage({ id: 'ui-inventory.instances.rows.select' })}
+          aria-label={this.getCheckColumnLabel()}
           onChange={() => this.toggleAllRows()}
         />
       ),

--- a/src/components/InstancesList/InstancesList.test.js
+++ b/src/components/InstancesList/InstancesList.test.js
@@ -1240,4 +1240,26 @@ describe('InstancesList', () => {
       expect(checkboxes[4]).toHaveTextContent('Instance HRID');
     });
   });
+
+  describe('Select column header', () => {
+    it('is labelled correctly for "select all" state', async () => {
+      const { getAllByRole } = await act(async () => renderInstancesList());
+
+      const selectColumn = getAllByRole('columnheader')[0];
+      const selectColumnCheckbox = within(selectColumn).getByRole('checkbox');
+
+      expect(selectColumnCheckbox).toHaveAttribute('aria-label', 'Select 4 results');
+    });
+
+    it('is labelled correctly for "unselect all" state', async () => {
+      const { getAllByRole } = await act(async () => renderInstancesList());
+
+      const selectColumn = getAllByRole('columnheader')[0];
+      const selectColumnCheckbox = within(selectColumn).getByRole('checkbox');
+
+      fireEvent.click(selectColumnCheckbox);
+
+      expect(selectColumnCheckbox).toHaveAttribute('aria-label', 'Unselect 4 results');
+    });
+  });
 });

--- a/src/routes/InstancesRoute.test.js
+++ b/src/routes/InstancesRoute.test.js
@@ -193,11 +193,11 @@ describe('InstancesRoute', () => {
       beforeEach(() => {
         selectRowCheckboxes = screen.getAllByRole('checkbox', { name: 'Select instance' });
 
-        fireEvent.click(selectRowCheckboxes[1]);
+        fireEvent.click(selectRowCheckboxes[0]);
       });
 
       it('should display checked select row checkbox', () => {
-        expect(selectRowCheckboxes[1]).toBeChecked();
+        expect(selectRowCheckboxes[0]).toBeChecked();
       });
 
       it('should display selected rows count message in the sub header', () => {
@@ -206,7 +206,7 @@ describe('InstancesRoute', () => {
 
       describe('selecting one more row and clicking on show selected records action button', () => {
         beforeEach(() => {
-          fireEvent.click(selectRowCheckboxes[2]);
+          fireEvent.click(selectRowCheckboxes[1]);
           fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
           fireEvent.click(screen.getByRole('button', { name: 'Show selected records' }));
         });
@@ -255,22 +255,22 @@ describe('InstancesRoute', () => {
             const cancelBt = await screen.findByText(/cancel/i);
             fireEvent.click(cancelBt);
 
+            expect(selectRowCheckboxes[0]).toBeChecked();
             expect(selectRowCheckboxes[1]).toBeChecked();
-            expect(selectRowCheckboxes[2]).toBeChecked();
           });
 
           it('should unselect corresponding rows in the results list after close of the modal upon click on save button', async () => {
             fireEvent.click(screen.getByRole('button', { name: 'Save & close' }));
 
+            expect(selectRowCheckboxes[0]).not.toBeChecked();
             expect(selectRowCheckboxes[1]).not.toBeChecked();
-            expect(selectRowCheckboxes[2]).not.toBeChecked();
           });
         });
       });
 
       describe('selecting more than one row', () => {
         beforeEach(() => {
-          fireEvent.click(selectRowCheckboxes[2]);
+          fireEvent.click(selectRowCheckboxes[1]);
         });
 
         it('should display selected rows count message (plural form) in the sub header', () => {
@@ -354,7 +354,7 @@ describe('InstancesRoute', () => {
           });
 
           it('should preserve the selected state for the previously selected row', () => {
-            expect(selectRowCheckboxes[1]).toBeChecked();
+            expect(selectRowCheckboxes[0]).toBeChecked();
           });
 
           it('should display selected rows count message in the sub header', () => {

--- a/translations/ui-inventory/en.json
+++ b/translations/ui-inventory/en.json
@@ -21,6 +21,8 @@
   "instances.columns.classificationNumber": "Classification",
   "instances.columns.instanceHRID": "Instance HRID",
   "instances.rows.select": "Select instance",
+  "instances.rows.selectAll": "Select {count} results",
+  "instances.rows.unselectAll": "Unselect {count} results",
   "instances.showSelectedRecords": "Show selected records",
   "instances.selectedRecords": "Selected records",
   "instances.rows.recordsSelected": "{count, number} {count, plural, one {record} other {records}} selected",


### PR DESCRIPTION
## Purpose

The aria-label for the select / unselect all column header checkbox was previously the same as the aria-label for each individual row's select / unselect checkbox, making it unclear to users using assistive technologies what would happen when this checkbox is toggled. Update the InstancesList component to provide a more useful state-sensitive label.

## Approach

Define a new method that checks for whether everything is selected. If not, provide a label specifying how many more rows to select to select all of them. If so, provide a label specifying how many rows to unselect (all of them).

## Refs

https://folio-org.atlassian.net/browse/UIIN-3684

## Screenshots

Select
<img width="1115" height="774" alt="Screenshot 2026-07-28 at 15 26 03" src="https://github.com/user-attachments/assets/f58aacaa-4bc6-47fc-98a4-a83becb191b7" />

Unselect
<img width="1115" height="774" alt="Screenshot 2026-07-28 at 15 26 32" src="https://github.com/user-attachments/assets/e9d0243f-f6e1-4104-b4b5-cb68af4ffdbc" />

